### PR TITLE
ci: Move to github changelog fork

### DIFF
--- a/api/.releaserc
+++ b/api/.releaserc
@@ -16,7 +16,13 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
+    [
+      "@MorpheApp/changelog", {
+        "releaseJson": {
+          "enabled": false
+        }
+      }
+    ],
     "gradle-semantic-release-plugin",
     [
       "@semantic-release/git",

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^1.1.10",
     "@saithodev/semantic-release-backmerge": "^4.0.1",
-    "@semantic-release/changelog": "^6.0.3",
+    "@MorpheApp/changelog": "git+https://github.com/MorpheApp/changelog.git#bundle",
     "@semantic-release/git": "^10.0.1",
     "gradle-semantic-release-plugin": "^1.10.1"
   }

--- a/app/.releaserc
+++ b/app/.releaserc
@@ -16,13 +16,22 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
+    [
+      "@MorpheApp/changelog", {
+        "releaseJson": {
+          "path": "app-release.json",
+          "downloadUrlTemplate": "https://github.com/${owner}/${repo}/releases/download/v${version}/morphe-manager-${version}.apk",
+          "signatureUrlTemplate": "https://github.com/${owner}/${repo}/releases/download/v${version}/morphe-manager-${version}.apk.asc"
+        }
+      }
+    ],
     "gradle-semantic-release-plugin",
     [
       "@semantic-release/git",
       {
         "assets": [
           "CHANGELOG.md",
+          "app-release.json",
           "gradle.properties"
         ],
         "message": "chore: Release v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^1.1.10",
     "@saithodev/semantic-release-backmerge": "^4.0.1",
-    "@semantic-release/changelog": "^6.0.3",
+    "@MorpheApp/changelog": "git+https://github.com/MorpheApp/changelog.git#bundle",
     "@semantic-release/git": "^10.0.1",
     "gradle-semantic-release-plugin": "^1.10.1"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
     "api": {
       "devDependencies": {
         "@anolilab/multi-semantic-release": "^1.1.10",
+        "@MorpheApp/changelog": "git+https://github.com/MorpheApp/changelog.git#bundle",
         "@saithodev/semantic-release-backmerge": "^4.0.1",
-        "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "gradle-semantic-release-plugin": "^1.10.1"
       }
@@ -62,8 +62,8 @@
     "app": {
       "devDependencies": {
         "@anolilab/multi-semantic-release": "^1.1.10",
+        "@MorpheApp/changelog": "git+https://github.com/MorpheApp/changelog.git#bundle",
         "@saithodev/semantic-release-backmerge": "^4.0.1",
-        "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "gradle-semantic-release-plugin": "^1.10.1"
       }
@@ -304,6 +304,68 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@MorpheApp/changelog": {
+      "version": "0.0.1",
+      "resolved": "git+ssh://git@github.com/MorpheApp/changelog.git#d45c829282d57d4902c57d7a2d602af74f13b8d5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "fs-extra": "^11.0.0",
+        "lodash": "^4.17.4"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@MorpheApp/changelog/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@MorpheApp/changelog/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@MorpheApp/changelog/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@MorpheApp/changelog/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1928,69 +1990,6 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/changelog/node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/changelog/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/changelog/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/changelog/node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.1",


### PR DESCRIPTION
Just as [patches-bundle.json](https://github.com/MorpheApp/morphe-patches/blob/dev/patches-bundle.json) is updated in the patches repo, the `app-release.json` in the manager repo is also updated when the release action completes.

Once this PR is merged, we can avoid using the GitHub releases API.

See also: https://github.com/MorpheApp/morphe-patches/pull/15.