### PR TITLE
chore: Add GitHub issue/feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: 🐞 Bug report
+description: Report a bug or an issue.
+title: 'bug: '
+labels: ['Bug report']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Morphe (Manager) bug report
+
+        Before creating a new bug report, please keep the following in mind:
+
+        - **Do not submit a duplicate bug report**: Search for existing bug reports [here](https://github.com/MorpheApp/morphe-manager/issues?q=label%3A%22Bug+report%22).
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: |
+        - Describe the bug in detail
+        - Add steps to reproduce
+        - Include images and videos if possible
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Version of Morphe (Manager) and the app you are patching
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Morphe logs
+      description: Export logs `Expert mode > Advanced > Export debug logs` (attach file if log is very large)
+      render: shell
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your bug report will be closed if you don't follow the checklist below.
+      options:
+        - label: I have checked all open and closed bug reports and this is not a duplicate.
+          required: true
+        - label: I have chosen an appropriate title.
+          required: true
+        - label: All requested information has been provided properly.
+          required: true
+        - label: The bug only affects using Morphe (Manager)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: ⭐ Feature request
+description: Create a detailed request for a new feature.
+title: 'feat: '
+labels: ['Feature request']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Morphe (Manager) feature request
+
+        Before creating a new feature request, please keep the following in mind:
+
+        - **Do not submit a duplicate feature request**: Search for existing feature requests [here](https://github.com/MorpheApp/morphe-manager/issues?q=label%3A%22Feature+request%22).
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: |
+        - Describe your feature in detail
+        - Add images, videos, links, examples, references, etc. if possible
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: |
+        A strong motivation is necessary for a feature request to be considered.
+
+        - Why should this feature be implemented? 
+        - What is the explicit use case?
+        - What are the benefits?
+        - What makes this feature important?
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your feature request will be closed if you don't follow the checklist below.
+      options:
+        - label:  I have checked all open and closed feature requests and this is not a duplicate.
+          required: true
+        - label: I have chosen an appropriate title.
+          required: true
+        - label: The feature request is only related to Morphe (Manager).
+          required: true


### PR DESCRIPTION
Because [URV](https://github.com/Jman-Github/Universal-ReVanced-Manager) doesn't have any templates, using modified templates from https://github.com/ReVanced/revanced-manager/blob/main/.github/ISSUE_TEMPLATE