### PR TITLE
fix: Allow disabling built-in bundle

### DIFF
--- a/app/src/main/java/app/revanced/manager/ui/component/bundle/BundleItem.kt
+++ b/app/src/main/java/app/revanced/manager/ui/component/bundle/BundleItem.kt
@@ -386,7 +386,6 @@ fun BundleItem(
                     }
                 }
 
-                // Morphe: For now, don't allow removing the built in patches bundles
                 val toggleIcon = if (src.enabled) Icons.Outlined.Block else Icons.Outlined.CheckCircle
                 val toggleLabel = if (src.enabled) R.string.disable else R.string.enable
                 Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {


### PR DESCRIPTION
There has always been redundant delete/disable buttons when navigating into the expert mode bundle, but this change restores the disable button shown in the patch bundle list.
