### PR TITLE
fix: Change "help me find apk" dialog "yes" button to open web search

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -361,10 +361,10 @@ private fun ApkAvailabilityDialog(
             ) {
                 // Main action buttons
                 MorpheDialogButtonRow(
-                    primaryText = stringResource(R.string.home_apk_availability_no),
+                    primaryText = stringResource(R.string.home_apk_availability_yes),
                     onPrimaryClick = onNeedApk,
                     primaryIcon = Icons.Outlined.Download,
-                    secondaryText = stringResource(R.string.home_apk_availability_yes),
+                    secondaryText = stringResource(R.string.home_apk_availability_no),
                     onSecondaryClick = onHaveApk,
                     secondaryIcon = Icons.Outlined.Check,
                     layout = DialogButtonLayout.Vertical

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,13 +83,13 @@
     <string name="sources_download_fail">Failed to download sources: %s</string>
 
     <!-- Home Screen - Dialog 1: APK Availability -->
-    <string name="home_apk_availability_dialog_title">Do you have the original APK?</string>
-    <string name="home_apk_availability_dialog_simple">To patch &lt;b&gt;%1$s&lt;/b&gt;, you need an unpatched APK file with version:</string>
-    <string name="home_apk_availability_dialog_expert">Compatible versions for &lt;b&gt;%1$s&lt;/b&gt;:</string>
+    <string name="home_apk_availability_dialog_title">Need help finding an original unpatched APK?</string>
+    <string name="home_apk_availability_dialog_simple">To patch &lt;b&gt;%s&lt;/b&gt;, you need the unpatched APK version:</string>
+    <string name="home_apk_availability_dialog_expert">To patch &lt;b&gt;%s&lt;/b&gt;, you need an unpatched APK of versions:</string>
     <string name="home_apk_availability_recommended_label">Recommended</string>
     <string name="home_apk_availability_unpatched_label">Unpatched</string>
-    <string name="home_apk_availability_yes">Yes, I have it</string>
-    <string name="home_apk_availability_no">No, help me find it</string>
+    <string name="home_apk_availability_yes">Yes, help me find an APK</string>
+    <string name="home_apk_availability_no">No, I already have an APK</string>
     <string name="home_apk_use_saved_with_version">Use saved APK (v%s)</string>
     <string name="home_app_info_no_saved_apk">No saved APK. Patching will require selecting the APK file again</string>
 


### PR DESCRIPTION
Inverts the 'yes' and 'no' buttons so 'yes' opens web search.

"Yes help me find it" is the default for 99% of use cases, and is more intuitive pressing 'yes' to continue with the process.


<details>

<summary>Simple patching</summary>
<img width="1080" height="2204" alt="simple" src="https://github.com/user-attachments/assets/fbec5d01-3605-4ba0-9a60-390c6f1deda0" />
</details>

<details>

<summary>Expert patching</summary>
<img width="1080" height="2204" alt="expert" src="https://github.com/user-attachments/assets/b11c987b-514a-4293-be46-ff8b5a99df65" />
</details>