### PR TITLE
fix: Manager does not show updates if available

### DIFF
--- a/app/src/main/java/app/morphe/manager/MainActivity.kt
+++ b/app/src/main/java/app/morphe/manager/MainActivity.kt
@@ -3,6 +3,8 @@ package app.morphe.manager
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -19,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -108,7 +111,11 @@ private fun MorpheManager(vm: MainViewModel) {
     val prefs: PreferencesManager = koinInject()
     val backgroundType by prefs.backgroundType.getAsState()
     val enableParallax by prefs.enableBackgroundParallax.getAsState()
-    val homeViewModel = koinViewModel<HomeViewModel>()
+
+    // HomeViewModel must be scoped to the Activity, not to a NavBackStackEntry
+    val homeViewModel: HomeViewModel = koinViewModel(
+        viewModelStoreOwner = LocalActivity.current as ComponentActivity
+    )
 
     // Box with background at the highest level
     Box(

--- a/app/src/main/java/app/morphe/manager/network/api/MorpheAPI.kt
+++ b/app/src/main/java/app/morphe/manager/network/api/MorpheAPI.kt
@@ -240,7 +240,7 @@ class MorpheAPI(
             is APIResponse.Success -> {
                 val mapped = runCatching {
                     mapManagerJsonToAsset(managerConfig, response.data).also { asset ->
-                        Log.d(tag, "Manager from CDN ($branch): version=${asset.version}, url=${asset.downloadUrl}")
+                        Log.d(tag, "Manager from JSON ($branch): version=${asset.version}, url=${asset.downloadUrl}")
                     }
                 }
 
@@ -260,26 +260,25 @@ class MorpheAPI(
     /**
      * Get app update - returns the newest available version if it is strictly newer
      * than the currently installed one.
+     * The dev channel always contains the latest version.
      *
-     * Uses jsDelivr CDN which is cache-cleared after each release, so the JSON file
-     * is only visible once the release is fully available.
-     * The branch is determined by [PreferencesManager.useManagerPrereleases].
+     * Matches the FCM subscription matrix in [app.morphe.manager.util.syncFcmTopics].
      */
     suspend fun getAppUpdate(): MorpheAsset? {
         val usePrereleases = prefs.useManagerPrereleases.get()
-        val branch = if (usePrereleases) "dev" else "main"
         val currentWeight = versionWeight(BuildConfig.VERSION_NAME.removePrefix("v"))
+        val branch = if (usePrereleases || isDevBuild) "dev" else "main"
 
         val candidate = if (USE_MANAGER_DIRECT_JSON) {
             getManagerFromJson(branch).fallbackTo {
-                Log.w(tag, "Manager CDN unavailable, falling back to GitHub API")
+                Log.w(tag, "Manager JSON unavailable, falling back to GitHub API")
                 getManagerFromGitHub()
             }.getOrNull()
         } else {
             getManagerFromGitHub().getOrNull()
-        } ?: return null
+        }
 
-        return candidate.takeIf {
+        return candidate?.takeIf {
             versionWeight(it.version.removePrefix("v")) > currentWeight
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/AdvancedTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/AdvancedTabContent.kt
@@ -97,8 +97,8 @@ fun AdvancedTabContent(
                 val newValue = !usePrereleases.value
                 scope.launch {
                     prefs.useManagerPrereleases.update(newValue)
-                    homeViewModel.checkForManagerUpdates()
                 }
+                homeViewModel.triggerUpdateCheck()
             },
             prefs = prefs
         )

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -49,6 +49,8 @@ import app.morphe.manager.util.PatchSelectionUtils.validatePatchOptions
 import app.morphe.manager.util.PatchSelectionUtils.validatePatchSelection
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import java.io.File
 import java.io.FileNotFoundException
 import java.net.HttpURLConnection
@@ -57,6 +59,7 @@ import java.net.URL
 import java.net.URLEncoder.encode
 import java.util.zip.ZipInputStream
 import javax.net.ssl.SSLException
+import kotlin.time.Clock
 
 /**
  * Bundle update status for snackbar display.
@@ -257,9 +260,7 @@ class HomeViewModel(
     var onStartQuickPatch: ((QuickPatchParams) -> Unit)? = null
 
     init {
-        viewModelScope.launch {
-            checkForManagerUpdates()
-        }
+        triggerUpdateCheck()
     }
 
     /**
@@ -318,9 +319,36 @@ class HomeViewModel(
         pendingPatchAction = null
     }
 
+    /**
+     * Checks for a manager update and defers showing the banner until the APK
+     * is likely fully uploaded. If the release is newer than [MANAGER_UPDATE_SHOW_DELAY_SECONDS],
+     * the banner is shown immediately; otherwise we wait out the remaining time.
+     */
+    @OptIn(kotlin.time.ExperimentalTime::class)
     suspend fun checkForManagerUpdates() {
         uiSafe(app, R.string.failed_to_check_updates, "Failed to check for updates") {
-            updatedManagerVersion = morpheAPI.getAppUpdate()?.version
+            val update = morpheAPI.getAppUpdate() ?: return@uiSafe
+
+            val releaseAgeSeconds = (Clock.System.now().toEpochMilliseconds() -
+                    update.createdAt.toInstant(TimeZone.UTC).toEpochMilliseconds()) / 1_000L
+
+            if (releaseAgeSeconds < MANAGER_UPDATE_SHOW_DELAY_SECONDS) {
+                val remainingMs = (MANAGER_UPDATE_SHOW_DELAY_SECONDS - releaseAgeSeconds) * 1_000L
+                Log.d(tag, "Manager update ${update.version} is ${releaseAgeSeconds}s old, waiting ${remainingMs / 1000}s before showing banner")
+                delay(remainingMs)
+            }
+
+            updatedManagerVersion = update.version
+        }
+    }
+
+    /**
+     * Launches [checkForManagerUpdates] on [viewModelScope] so it survives composition changes.
+     * Safe to call from UI without a coroutine scope.
+     */
+    fun triggerUpdateCheck() {
+        viewModelScope.launch {
+            checkForManagerUpdates()
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -11,11 +11,22 @@ const val MANAGER_REPO_URL = "https://github.com/MorpheApp/morphe-manager"
 const val SOURCE_REPO_URL = "https://github.com/MorpheApp/morphe-patches"
 const val MORPHE_API_URL = "https://api.morphe.software"
 
-/** jsDelivr CDN URL for the stable manager release JSON (main branch) */
-const val MANAGER_RELEASE_JSON_URL = "https://cdn.jsdelivr.net/gh/MorpheApp/morphe-manager@main/app/app-release.json"
+///** jsDelivr CDN URL for the stable manager release JSON (main branch) */
+//const val MANAGER_RELEASE_JSON_URL = "https://cdn.jsdelivr.net/gh/MorpheApp/morphe-manager@main/app/app-release.json"
+///** jsDelivr CDN URL for the pre-release manager release JSON (dev branch) */
+//const val MANAGER_PRERELEASE_JSON_URL = "https://cdn.jsdelivr.net/gh/MorpheApp/morphe-manager@dev/app/app-release.json"
 
-/** jsDelivr CDN URL for the pre-release manager release JSON (dev branch) */
-const val MANAGER_PRERELEASE_JSON_URL = "https://cdn.jsdelivr.net/gh/MorpheApp/morphe-manager@dev/app/app-release.json"
+/**
+ * Delay before showing a manager update notification to the user.
+ * Gives time for the APK to be fully uploaded after app-release.json is published.
+ */
+const val MANAGER_UPDATE_SHOW_DELAY_SECONDS = 300L
+
+/** Raw GitHub URL for the stable manager release JSON (main branch) */
+const val MANAGER_RELEASE_JSON_URL = "https://raw.githubusercontent.com/MorpheApp/morphe-manager/refs/heads/main/app/app-release.json"
+
+/** Raw GitHub URL for the pre-release manager release JSON (dev branch) */
+const val MANAGER_PRERELEASE_JSON_URL = "https://raw.githubusercontent.com/MorpheApp/morphe-manager/refs/heads/dev/app/app-release.json"
 
 /** Controls whether manager updates are fetched directly from JSON files in the repository instead of using the GitHub API */
 const val USE_MANAGER_DIRECT_JSON = true


### PR DESCRIPTION
### Changes in this PR:

- Changed direct JSON links to Github
- Add 5-minute delay after release creation before showing update banner, giving time for the APK to finish uploading to GitHub