### PR TITLE
feat: Add selectable download version in APK availability expert dialog

### DIFF
--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Immutable
 import app.morphe.patcher.patch.Patch
 import app.morphe.patcher.patch.ApkFileType
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toImmutableSet
 import kotlin.reflect.KType
 import app.morphe.patcher.patch.Option as PatchOption
@@ -37,7 +39,16 @@ data class PatchInfo(
                         .mapNotNull { it.version }
                         .toImmutableSet()
                         .takeIf { it.isNotEmpty() },
-                    signatures = compatibility.signatures?.toImmutableSet()
+                    signatures = compatibility.signatures?.toImmutableSet(),
+                    versionDescriptions = compatibility.targets
+                        .mapNotNull { target ->
+                            val v = target.version ?: return@mapNotNull null
+                            val d = target.description ?: return@mapNotNull null
+                            v to d
+                        }
+                        .toMap()
+                        .toImmutableMap()
+                        .takeIf { it.isNotEmpty() }
                 )
             }
             ?.toImmutableList()
@@ -117,6 +128,8 @@ data class CompatiblePackage(
     val experimentalVersions: ImmutableSet<String>? = null,
     /** Valid SHA-256 signing certificate fingerprints of the original app APK. Null means no verification. */
     val signatures: ImmutableSet<String>? = null,
+    /** Per-version user-facing descriptions. */
+    val versionDescriptions: ImmutableMap<String, String>? = null,
 )
 
 @Immutable

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -11,11 +11,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
@@ -33,6 +35,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
@@ -46,7 +49,10 @@ import app.morphe.manager.util.RemoteAvatar
 import app.morphe.manager.util.htmlAnnotatedString
 import app.morphe.manager.util.toast
 import app.morphe.patcher.patch.AppTarget
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.net.URI
 
 /**
@@ -72,6 +78,7 @@ fun HomeDialogs(
         val appName = homeViewModel.pendingAppName ?: return@AnimatedVisibility
         val recommendedVersion = homeViewModel.pendingRecommendedVersion
         val compatibleVersions = homeViewModel.pendingCompatibleVersions
+        val selectedDownloadVersion = homeViewModel.pendingSelectedDownloadVersion
         val usingMountInstall = homeViewModel.usingMountInstall
         val isExpertMode = homeViewModel.prefs.useExpertMode.getBlocking()
         val savedApkInfo = homeViewModel.pendingSavedApkInfo
@@ -80,6 +87,8 @@ fun HomeDialogs(
             appName = appName,
             recommendedVersion = recommendedVersion,
             compatibleVersions = compatibleVersions,
+            selectedDownloadVersion = selectedDownloadVersion,
+            onVersionSelect = { homeViewModel.pendingSelectedDownloadVersion = it },
             usingMountInstall = usingMountInstall,
             isExpertMode = isExpertMode,
             savedApkInfo = savedApkInfo,
@@ -183,6 +192,13 @@ fun HomeDialogs(
             version = dialogState.version,
             recommendedVersion = dialogState.recommendedVersion?.version,
             allCompatibleVersions = dialogState.allCompatibleVersions.map { it.version ?: "" }.filter { it.isNotEmpty() },
+            versionDescriptions = dialogState.allCompatibleVersions
+                .mapNotNull { target ->
+                    val v = target.version ?: return@mapNotNull null
+                    val d = target.description ?: return@mapNotNull null
+                    v to d
+                }
+                .toMap(),
             experimentalVersions = homeViewModel.getExperimentalVersionsForPackage(dialogState.packageName),
             isExperimental = dialogState.isExperimental,
             isExpertMode = isExpertMode,
@@ -416,12 +432,19 @@ fun HomeDialogs(
 
 /**
  * Dialog 1: Initial "Do you have the APK?" dialog.
+ *
+ * In expert mode the version list is selectable: the user can tap any version to set it as the
+ * download target. [selectedDownloadVersion] reflects the current selection (defaults to
+ * [recommendedVersion]); [onVersionSelect] propagates the change to the ViewModel.
+ * In simple mode there is only one version and no selection UI is shown.
  */
 @Composable
 private fun ApkAvailabilityDialog(
     appName: String,
     recommendedVersion: AppTarget?,
     compatibleVersions: List<AppTarget>,
+    selectedDownloadVersion: AppTarget?,
+    onVersionSelect: (AppTarget) -> Unit,
     usingMountInstall: Boolean,
     isExpertMode: Boolean,
     savedApkInfo: SavedApkInfo?,
@@ -472,9 +495,8 @@ private fun ApkAvailabilityDialog(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // Description text
             if (isExpertMode && compatibleVersions.isNotEmpty()) {
-                // Expert mode with versions: show list of versions
+                // Expert mode: selectable version list
                 Text(
                     text = htmlAnnotatedString(stringResource(
                         R.string.home_apk_availability_dialog_expert,
@@ -485,19 +507,28 @@ private fun ApkAvailabilityDialog(
                     textAlign = TextAlign.Center
                 )
 
-                // Unified version list card
-                VersionListCard(
-                    versions = compatibleVersions.map { it.version ?: anyString },
-                    experimentalVersions = compatibleVersions
-                        .filter { it.isExperimental }
-                        .mapNotNull { it.version }
-                        .toSet(),
-                    recommendedIndex = compatibleVersions
-                        .indexOfFirst { it.version == recommendedVersion?.version }
-                        .takeIf { it >= 0 } ?: 0
-                )
+                if (compatibleVersions.size > 1) {
+                    SelectableVersionListCard(
+                        versions = compatibleVersions,
+                        selectedVersion = selectedDownloadVersion,
+                        recommendedVersion = recommendedVersion,
+                        onVersionSelect = onVersionSelect,
+                        anyString = anyString
+                    )
+                } else {
+                    VersionListCard(
+                        versions = compatibleVersions.map { it.version ?: anyString },
+                        experimentalVersions = compatibleVersions
+                            .filter { it.isExperimental }
+                            .mapNotNull { it.version }
+                            .toSet(),
+                        descriptions = compatibleVersions
+                            .mapNotNull { t -> t.version?.let { v -> t.description?.let { d -> v to d } } }
+                            .toMap()
+                    )
+                }
             } else {
-                // Simple mode or single version: show card with unpatched badge
+                // Simple mode: single static version, no selection
                 Text(
                     text = htmlAnnotatedString(stringResource(
                         R.string.home_apk_availability_dialog_simple,
@@ -508,9 +539,8 @@ private fun ApkAvailabilityDialog(
                     textAlign = TextAlign.Center
                 )
 
-                val versionToShow = recommendedVersion?.version ?: anyString
                 VersionListCard(
-                    versions = listOf(versionToShow),
+                    versions = listOf(recommendedVersion?.version ?: anyString),
                     showUnpatchedBadge = true
                 )
             }
@@ -750,6 +780,7 @@ private fun UnsupportedVersionWarningDialog(
     version: String,
     recommendedVersion: String?,
     allCompatibleVersions: List<String>,
+    versionDescriptions: Map<String, String> = emptyMap(),
     experimentalVersions: Set<String> = emptySet(),
     isExperimental: Boolean = false,
     isExpertMode: Boolean,
@@ -860,7 +891,8 @@ private fun UnsupportedVersionWarningDialog(
                                 .indexOfFirst { it !in experimentalVersions }
                                 .takeIf { it >= 0 } ?: 0,
                             isCompatible = true,
-                            experimentalVersions = experimentalVersions
+                            experimentalVersions = experimentalVersions,
+                            descriptions = versionDescriptions
                         )
                     }
                 } else if (recommendedVersion != null) {
@@ -1123,8 +1155,123 @@ fun WrongPackageDialog(
 }
 
 /**
- * Unified version list card component.
+ * Version list card where each row is tappable.
+ * The selected version gets a checkmark; the recommended version is labelled when not selected.
+ * Experimental versions are always labelled regardless of selection state.
  */
+@Composable
+private fun SelectableVersionListCard(
+    versions: List<AppTarget>,
+    selectedVersion: AppTarget?,
+    recommendedVersion: AppTarget?,
+    onVersionSelect: (AppTarget) -> Unit,
+    anyString: String,
+    modifier: Modifier = Modifier
+) {
+    if (versions.isEmpty()) return
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+        tonalElevation = 1.dp
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            versions.forEachIndexed { index, target ->
+                val versionString = target.version ?: anyString
+                val isSelected = target.version != null &&
+                        target.version == selectedVersion?.version
+                val isRecommended = target.version != null &&
+                        target.version == recommendedVersion?.version
+
+                val badge: @Composable (() -> Unit)? = when {
+                    target.isExperimental -> ({
+                        InfoBadge(
+                            text = stringResource(R.string.home_dialog_unsupported_version_experimental_label),
+                            style = InfoBadgeStyle.Warning,
+                            isCompact = true
+                        )
+                    })
+                    isRecommended -> ({
+                        InfoBadge(
+                            text = stringResource(R.string.home_apk_availability_recommended_label),
+                            style = InfoBadgeStyle.Default,
+                            isCompact = true
+                        )
+                    })
+                    else -> null
+                }
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onVersionSelect(target) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Checkmark column - fixed width so text aligns across all rows
+                    Box(
+                        modifier = Modifier.size(18.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (isSelected) {
+                            Icon(
+                                imageVector = Icons.Filled.Check,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = versionString,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontFamily = FontFamily.Monospace,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                color = when {
+                                    isSelected -> MaterialTheme.colorScheme.primary
+                                    target.isExperimental -> MaterialTheme.colorScheme.tertiary
+                                    else -> LocalDialogTextColor.current
+                                },
+                                modifier = Modifier.weight(1f),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            badge?.invoke()
+                        }
+                        val description = target.description
+                        if (description != null) {
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = LocalDialogSecondaryTextColor.current
+                            )
+                        }
+                    }
+                }
+
+                if (index < versions.lastIndex) {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+
 @Composable
 private fun VersionListCard(
     versions: List<String>,
@@ -1132,6 +1279,7 @@ private fun VersionListCard(
     isCompatible: Boolean = false,
     showUnpatchedBadge: Boolean = false,
     experimentalVersions: Set<String> = emptySet(),
+    descriptions: Map<String, String> = emptyMap(),
     @SuppressLint("ModifierParameter")
     modifier: Modifier = Modifier
 ) {
@@ -1163,40 +1311,65 @@ private fun VersionListCard(
         ) {
             versions.forEachIndexed { index, version ->
                 val isExperimentalVersion = version in experimentalVersions
+                val versionDescription = descriptions[version]
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    // Version number
-                    Text(
-                        text = version,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontFamily = FontFamily.Monospace,
-                        fontWeight = if (index == recommendedIndex) FontWeight.Bold else FontWeight.Normal,
-                        color = if (isExperimentalVersion)
-                            MaterialTheme.colorScheme.tertiary
-                        else
-                            textColor
-                    )
-
-                    // Badges
-                    when {
-                        isExperimentalVersion -> InfoBadge(
+                // Resolve badge once - drives both the badge composable and version text color
+                val badge: @Composable (() -> Unit)? = when {
+                    isExperimentalVersion -> ({
+                        InfoBadge(
                             text = stringResource(R.string.home_dialog_unsupported_version_experimental_label),
                             style = InfoBadgeStyle.Warning,
                             isCompact = true
                         )
-                        index == recommendedIndex && !showUnpatchedBadge -> InfoBadge(
+                    })
+                    index == recommendedIndex && !showUnpatchedBadge -> ({
+                        InfoBadge(
                             text = stringResource(R.string.home_apk_availability_recommended_label),
                             style = InfoBadgeStyle.Primary,
                             isCompact = true
                         )
-                        showUnpatchedBadge && versions.size == 1 -> InfoBadge(
+                    })
+                    showUnpatchedBadge && versions.size == 1 -> ({
+                        InfoBadge(
                             text = stringResource(R.string.home_apk_availability_unpatched_label),
                             style = InfoBadgeStyle.Warning,
                             isCompact = true
+                        )
+                    })
+                    else -> null
+                }
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(3.dp)
+                ) {
+                    // Version + optional badge inline
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = version,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontFamily = FontFamily.Monospace,
+                            fontWeight = if (index == recommendedIndex) FontWeight.Bold else FontWeight.Normal,
+                            color = if (isExperimentalVersion)
+                                MaterialTheme.colorScheme.tertiary
+                            else
+                                textColor,
+                            modifier = Modifier.weight(1f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        badge?.invoke()
+                    }
+
+                    // Optional per-version description
+                    if (versionDescription != null) {
+                        Text(
+                            text = versionDescription,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LocalDialogSecondaryTextColor.current
                         )
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -201,6 +201,8 @@ class HomeViewModel(
     var pendingAppName by mutableStateOf<String?>(null)
     var pendingRecommendedVersion by mutableStateOf<AppTarget?>(null)
     var pendingCompatibleVersions by mutableStateOf<List<AppTarget>>(emptyList())
+    // Version selected by the user in Dialog 1 for the APK search query. Defaults to pendingRecommendedVersion
+    var pendingSelectedDownloadVersion by mutableStateOf<AppTarget?>(null)
     var pendingSelectedApp by mutableStateOf<SelectedApp?>(null)
     var resolvedDownloadUrl by mutableStateOf<String?>(null)
     var pendingSavedApkInfo by mutableStateOf<SavedApkInfo?>(null)
@@ -1128,6 +1130,7 @@ class HomeViewModel(
         pendingAppName = KnownApps.getAppName(packageName)
         pendingRecommendedVersion = recommendedVersions[packageName]
         pendingCompatibleVersions = compatibleVersions[packageName] ?: emptyList()
+        pendingSelectedDownloadVersion = pendingRecommendedVersion
 
         // Guard: if there is a pending bundle update on metered data, show the outdated-patches
         // dialog before proceeding with the actual APK selection flow.
@@ -1644,6 +1647,7 @@ class HomeViewModel(
         pendingAppName = null
         pendingRecommendedVersion = null
         pendingCompatibleVersions = emptyList()
+        pendingSelectedDownloadVersion = null
         resolvedDownloadUrl = null
         showDownloadInstructionsDialog = false
         showFilePickerPromptDialog = false
@@ -1705,8 +1709,9 @@ class HomeViewModel(
             }
         }
 
-        // Handle null pendingRecommendedVersion
-        val escapedVersion = pendingRecommendedVersion?.let { encode(it.version, "UTF-8") } ?: "any"
+        // Use the version selected by the user in Dialog 1; fall back to recommended
+        val versionForSearch = pendingSelectedDownloadVersion ?: pendingRecommendedVersion
+        val escapedVersion = versionForSearch?.let { encode(it.version, "UTF-8") } ?: "any"
         val searchQuery = "$pendingPackageName~$escapedVersion~${Build.SUPPORTED_ABIS.first()}".encodeURLPath()
         val searchUrl = "$MORPHE_API_URL/v2/web-search/$searchQuery"
         Log.d(tag, "Using search url: $searchUrl")
@@ -1734,8 +1739,9 @@ class HomeViewModel(
             "nodpi"
         }
 
-        // Handle null pendingRecommendedVersion
-        val versionPart = pendingRecommendedVersion?.version?.let { "\"$it\"" } ?: ""
+        // Use the version selected by the user in Dialog 1; fall back to recommended
+        val versionForSearch = pendingSelectedDownloadVersion ?: pendingRecommendedVersion
+        val versionPart = versionForSearch?.version?.let { "\"$it\"" } ?: ""
         val searchQuery = "\"$pendingPackageName\" $versionPart $architecture site:APKMirror.com"
         val searchUrl = "https://google.com/search?q=${encode(searchQuery, "UTF-8")}"
         Log.d(tag, "Using search query: $searchQuery")
@@ -1767,6 +1773,7 @@ class HomeViewModel(
         pendingAppName = null
         pendingRecommendedVersion = null
         pendingCompatibleVersions = emptyList()
+        pendingSelectedDownloadVersion = null
         resolvedDownloadUrl = null
         pendingSavedApkInfo = null
         if (!keepSelectedApp) {


### PR DESCRIPTION
In expert mode with multiple compatible versions, the APK availability dialog now shows a selectable version list.

The user can tap any version to set it as the download target  a checkmark appears to the left of the selected row while badges (`Recommended`/ `Experimental`) remain on the right.

Single-version expert mode and simple mode are unchanged.
___
![Screenshot_2026-04-02-16-28-09-058_app.morphe.manager-edit.jpg](https://github.com/user-attachments/assets/ea17e703-c805-485a-b84e-8328f223bb2f)

