### PR TITLE
feat: Group compatible versions by bundle in APK availability dialog

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -47,6 +47,7 @@ import app.morphe.manager.R
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.ui.viewmodel.BundledAppTarget
 import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.SavedApkInfo
 import app.morphe.manager.util.KnownApps
@@ -83,6 +84,7 @@ fun HomeDialogs(
         val appName = homeViewModel.pendingAppName ?: return@AnimatedVisibility
         val recommendedVersion = homeViewModel.pendingRecommendedVersion
         val compatibleVersions = homeViewModel.pendingCompatibleVersions
+        val recommendedBundleVersions = homeViewModel.pendingRecommendedBundleVersions
         val selectedDownloadVersion = homeViewModel.pendingSelectedDownloadVersion
         val usingMountInstall = homeViewModel.usingMountInstall
         val isExpertMode = homeViewModel.prefs.useExpertMode.getBlocking()
@@ -92,6 +94,7 @@ fun HomeDialogs(
             appName = appName,
             recommendedVersion = recommendedVersion,
             compatibleVersions = compatibleVersions,
+            recommendedBundleVersions = recommendedBundleVersions,
             selectedDownloadVersion = selectedDownloadVersion,
             onVersionSelect = { homeViewModel.pendingSelectedDownloadVersion = it },
             usingMountInstall = usingMountInstall,
@@ -449,7 +452,8 @@ fun HomeDialogs(
 private fun ApkAvailabilityDialog(
     appName: String,
     recommendedVersion: AppTarget?,
-    compatibleVersions: List<AppTarget>,
+    compatibleVersions: List<BundledAppTarget>,
+    recommendedBundleVersions: Map<Int, AppTarget>,
     selectedDownloadVersion: AppTarget?,
     onVersionSelect: (AppTarget) -> Unit,
     usingMountInstall: Boolean,
@@ -463,6 +467,7 @@ private fun ApkAvailabilityDialog(
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.home_apk_availability_dialog_title),
+        compactPadding = true,
         footer = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -518,19 +523,20 @@ private fun ApkAvailabilityDialog(
                     SelectableVersionListCard(
                         versions = compatibleVersions,
                         selectedVersion = selectedDownloadVersion,
-                        recommendedVersion = recommendedVersion,
+                        recommendedBundleVersions = recommendedBundleVersions,
                         onVersionSelect = onVersionSelect,
-                        anyString = anyString
+                        anyString = anyString,
+                        hasMultipleBundles = compatibleVersions.map { it.bundleUid }.distinct().size > 1
                     )
                 } else {
                     VersionListCard(
-                        versions = compatibleVersions.map { it.version ?: anyString },
+                        versions = compatibleVersions.map { it.target.version ?: anyString },
                         experimentalVersions = compatibleVersions
-                            .filter { it.isExperimental }
-                            .mapNotNull { it.version }
+                            .filter { it.target.isExperimental }
+                            .mapNotNull { it.target.version }
                             .toSet(),
                         descriptions = compatibleVersions
-                            .mapNotNull { t -> t.version?.let { v -> t.description?.let { d -> v to d } } }
+                            .mapNotNull { b -> b.target.version?.let { v -> b.target.description?.let { d -> v to d } } }
                             .toMap()
                     )
                 }
@@ -797,6 +803,7 @@ private fun UnsupportedVersionWarningDialog(
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.home_dialog_unsupported_version_dialog_title),
+        compactPadding = true,
         footer = {
             MorpheDialogButtonRow(
                 primaryText = stringResource(R.string.home_dialog_unsupported_version_dialog_proceed),
@@ -1081,6 +1088,7 @@ fun WrongPackageDialog(
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.home_dialog_wrong_package_title),
+        compactPadding = true,
         footer = {
             MorpheDialogButton(
                 text = stringResource(android.R.string.ok),
@@ -1168,11 +1176,12 @@ fun WrongPackageDialog(
  */
 @Composable
 private fun SelectableVersionListCard(
-    versions: List<AppTarget>,
+    versions: List<BundledAppTarget>,
     selectedVersion: AppTarget?,
-    recommendedVersion: AppTarget?,
+    recommendedBundleVersions: Map<Int, AppTarget>,
     onVersionSelect: (AppTarget) -> Unit,
     anyString: String,
+    hasMultipleBundles: Boolean,
     modifier: Modifier = Modifier
 ) {
     if (versions.isEmpty()) return
@@ -1184,13 +1193,49 @@ private fun SelectableVersionListCard(
         tonalElevation = 1.dp
     ) {
         Column(modifier = Modifier.fillMaxWidth().selectableGroup()) {
-            versions.forEachIndexed { index, target ->
+            var lastBundleUid = -1
+
+            versions.forEachIndexed { index, bundled ->
+                val target = bundled.target
                 val versionString = target.version ?: anyString
                 val isSelected = target.version != null && target.version == selectedVersion?.version
-                val isRecommended = target.version != null && target.version == recommendedVersion?.version
+                val isRecommended = target.version != null &&
+                        target.version == recommendedBundleVersions[bundled.bundleUid]?.version
                 val recommendedLabel = stringResource(R.string.home_apk_availability_recommended_label)
                 val experimentalLabel = stringResource(R.string.home_dialog_unsupported_version_experimental_label)
                 val selectedLabel = stringResource(R.string.home_selected_version)
+
+                // Bundle section header - only when multiple bundles are present and uid changes
+                if (hasMultipleBundles && bundled.bundleUid != lastBundleUid) {
+                    if (lastBundleUid != -1) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 7.dp),
+                        horizontalArrangement = Arrangement.spacedBy(5.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Extension,
+                            contentDescription = null,
+                            modifier = Modifier.size(12.dp),
+                            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.65f)
+                        )
+                        Text(
+                            text = bundled.bundleName,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.65f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    lastBundleUid = bundled.bundleUid
+                }
 
                 val badge: @Composable (() -> Unit)? = when {
                     target.isExperimental -> ({
@@ -1218,6 +1263,7 @@ private fun SelectableVersionListCard(
                     }
                     if (isSelected) append(", $selectedLabel")
                     target.description?.let { append(", $it") }
+                    if (hasMultipleBundles) append(", ${bundled.bundleName}")
                 }
 
                 Row(
@@ -1283,7 +1329,10 @@ private fun SelectableVersionListCard(
                     }
                 }
 
-                if (index < versions.lastIndex) {
+                // Row divider - skip after last row in a bundle group (section divider handles it)
+                val isLastInBundle = index == versions.lastIndex ||
+                        (hasMultipleBundles && versions[index + 1].bundleUid != bundled.bundleUid)
+                if (index < versions.lastIndex && !isLastInBundle) {
                     HorizontalDivider(
                         modifier = Modifier.padding(horizontal = 16.dp),
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
@@ -1293,6 +1342,7 @@ private fun SelectableVersionListCard(
         }
     }
 }
+
 
 
 @Composable
@@ -1539,6 +1589,7 @@ fun DeepLinkAddSourceDialog(
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.deep_link_add_source_title),
+        compactPadding = true,
         footer = {
             MorpheDialogButtonRow(
                 primaryText = stringResource(R.string.add),

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -85,6 +85,16 @@ data class UnsupportedVersionDialogState(
     val isExperimental: Boolean = false
 )
 
+/**
+ * An [AppTarget] annotated with the bundle it originates from.
+ * Used to group versions by bundle in the APK availability dialog.
+ */
+data class BundledAppTarget(
+    val target: AppTarget,
+    val bundleUid: Int,
+    val bundleName: String
+)
+
 /** Dialog state for wrong package warning. */
 data class WrongPackageDialogState(
     val expectedPackage: String,
@@ -205,7 +215,9 @@ class HomeViewModel(
     var pendingPackageName by mutableStateOf<String?>(null)
     var pendingAppName by mutableStateOf<String?>(null)
     var pendingRecommendedVersion by mutableStateOf<AppTarget?>(null)
-    var pendingCompatibleVersions by mutableStateOf<List<AppTarget>>(emptyList())
+    var pendingCompatibleVersions by mutableStateOf<List<BundledAppTarget>>(emptyList())
+    // Per-bundle recommended versions for multi-bundle display in ApkAvailabilityDialog
+    var pendingRecommendedBundleVersions by mutableStateOf<Map<Int, AppTarget>>(emptyMap())
     // Version selected by the user in Dialog 1 for the APK search query. Defaults to pendingRecommendedVersion
     var pendingSelectedDownloadVersion by mutableStateOf<AppTarget?>(null)
     var pendingSelectedApp by mutableStateOf<SelectedApp?>(null)
@@ -234,11 +246,13 @@ class HomeViewModel(
     var installedAppsLoading by mutableStateOf(true)
 
     // Bundle data - reactive StateFlows derived directly from bundleInfoFlow
-    val compatibleVersionsFlow: StateFlow<Map<String, List<AppTarget>>> =
+    val compatibleVersionsFlow: StateFlow<Map<String, List<BundledAppTarget>>> =
         patchBundleRepository.bundleInfoFlow
             .combine(patchBundleRepository.sources) { bundleInfo, sources ->
-                val enabledUids = sources.filter { it.enabled }.map { it.uid }.toSet()
-                extractCompatibleVersions(bundleInfo, enabledUids)
+                val enabledSources = sources.filter { it.enabled }
+                val enabledUids = enabledSources.map { it.uid }.toSet()
+                val bundleNames = enabledSources.associate { it.uid to it.displayTitle }
+                extractCompatibleVersions(bundleInfo, bundleNames, enabledUids)
             }
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
@@ -259,7 +273,8 @@ class HomeViewModel(
                 .mapNotNull { it.packageName }
                 .toSet()
 
-            versionData.mapValues { (packageName, targets) ->
+            versionData.mapValues { (packageName, bundledTargets) ->
+                val targets = bundledTargets.map { it.target }
                 if (packageName in experimentalEnabledPackages) {
                     // Experimental mode: prefer the highest experimental version, fallback to first
                     targets.firstOrNull { it.isExperimental } ?: targets.first()
@@ -273,7 +288,50 @@ class HomeViewModel(
 
     // Convenience accessors - read current value synchronously for non-reactive call sites
     val recommendedVersions: Map<String, AppTarget> get() = recommendedVersionsFlow.value
-    val compatibleVersions: Map<String, List<AppTarget>> get() = compatibleVersionsFlow.value
+    val compatibleVersions: Map<String, List<BundledAppTarget>> get() = compatibleVersionsFlow.value
+
+    /**
+     * Per-bundle recommended version for each package.
+     * Returns Map<PackageName, Map<BundleUid, AppTarget>> so the APK availability dialog
+     * can show the correct "Recommended" badge independently for each bundle section.
+     */
+    val recommendedBundleVersionsFlow: StateFlow<Map<String, Map<Int, AppTarget>>> =
+        combine(
+            compatibleVersionsFlow,
+            prefs.bundleExperimentalVersionsEnabled.flow,
+            patchBundleRepository.bundleInfoFlow,
+            patchBundleRepository.sources
+        ) { versionData, experimentalEnabledUids, bundleInfo, sources ->
+            val enabledUids = sources.filter { it.enabled }.map { it.uid }.toSet()
+            // Per-bundle set of packages that have experimental mode enabled.
+            // Key: bundleUid, Value: set of packageNames with experimental toggle on for that bundle
+            val experimentalPackagesByBundle: Map<Int, Set<String>> = bundleInfo
+                .filterKeys { it in enabledUids && it.toString() in experimentalEnabledUids }
+                .mapValues { (_, info) ->
+                    info.patches
+                        .flatMap { it.compatiblePackages.orEmpty() }
+                        .mapNotNull { it.packageName }
+                        .toSet()
+                }
+
+            versionData.mapValues { (packageName, bundledTargets) ->
+                bundledTargets
+                    .groupBy { it.bundleUid }
+                    .mapValues { (bundleUid, targets) ->
+                        val appTargets = targets.map { it.target }
+                        val preferExperimental = experimentalPackagesByBundle[bundleUid]
+                            ?.contains(packageName) == true
+                        if (preferExperimental) {
+                            appTargets.firstOrNull { it.isExperimental } ?: appTargets.first()
+                        } else {
+                            appTargets.firstOrNull { !it.isExperimental } ?: appTargets.first()
+                        }
+                    }
+            }
+        }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+
+    val recommendedBundleVersions: Map<String, Map<Int, AppTarget>> get() = recommendedBundleVersionsFlow.value
 
     // Track available updates for installed apps
     private val _appUpdatesAvailable = MutableStateFlow<Map<String, Boolean>>(emptyMap())
@@ -1052,8 +1110,8 @@ class HomeViewModel(
      */
     fun getExperimentalVersionsForPackage(packageName: String): Set<String> =
         compatibleVersions[packageName]
-            ?.filter { it.isExperimental }
-            ?.mapNotNull { it.version }
+            ?.filter { it.target.isExperimental }
+            ?.mapNotNull { it.target.version }
             ?.toSet()
             ?: emptySet()
 
@@ -1150,6 +1208,7 @@ class HomeViewModel(
             ?: KnownApps.getAppName(packageName)
         pendingRecommendedVersion = recommendedVersions[packageName]
         pendingCompatibleVersions = compatibleVersions[packageName] ?: emptyList()
+        pendingRecommendedBundleVersions = recommendedBundleVersions[packageName] ?: emptyMap()
         pendingSelectedDownloadVersion = pendingRecommendedVersion
 
         // Guard: if there is a pending bundle update on metered data, show the outdated-patches
@@ -1412,7 +1471,7 @@ class HomeViewModel(
 
         if (versionMismatch && !allowIncompatible) {
             val recommendedVersion = recommendedVersions[selectedApp.packageName]
-            val allVersions = compatibleVersions[selectedApp.packageName] ?: emptyList()
+            val allVersions = compatibleVersions[selectedApp.packageName]?.map { it.target } ?: emptyList()
             pendingSelectedApp = selectedApp
             showUnsupportedVersionDialog = UnsupportedVersionDialogState(
                 packageName = selectedApp.packageName,
@@ -1430,7 +1489,7 @@ class HomeViewModel(
         // - Experimental mode OFF → UnsupportedVersionWarningDialog
         if (isVersionExperimental && !allowIncompatible) {
             val recommendedVersion = recommendedVersions[selectedApp.packageName]
-            val allVersions = compatibleVersions[selectedApp.packageName] ?: emptyList()
+            val allVersions = compatibleVersions[selectedApp.packageName]?.map { it.target } ?: emptyList()
             pendingSelectedApp = selectedApp
             val state = UnsupportedVersionDialogState(
                 packageName = selectedApp.packageName,
@@ -1718,6 +1777,7 @@ class HomeViewModel(
         pendingAppName = null
         pendingRecommendedVersion = null
         pendingCompatibleVersions = emptyList()
+        pendingRecommendedBundleVersions = emptyMap()
         pendingSelectedDownloadVersion = null
         resolvedDownloadUrl = null
         showDownloadInstructionsDialog = false
@@ -2097,6 +2157,7 @@ class HomeViewModel(
         pendingAppName = null
         pendingRecommendedVersion = null
         pendingCompatibleVersions = emptyList()
+        pendingRecommendedBundleVersions = emptyMap()
         pendingSelectedDownloadVersion = null
         resolvedDownloadUrl = null
         pendingSavedApkInfo = null
@@ -2114,15 +2175,17 @@ class HomeViewModel(
 
     /**
      * Extract compatible versions for each package from bundle info.
-     * Returns a map of package name to sorted list of AppTargets - newest first regardless
-     * of experimental status. The [AppTarget.isExperimental] flag is preserved for badge display.
-     * Single pass per bundle - O(patches) instead of O(packages × patches).
+     * Returns a map of package name to a list of [BundledAppTarget] - versions are grouped by
+     * bundle (ordered by bundle display name) and sorted newest→oldest within each bundle.
+     * Versions are NOT deduplicated across bundles so the UI can show per-bundle sections.
      */
     private fun extractCompatibleVersions(
         bundleInfo: Map<Int, PatchBundleInfo>,
+        bundleNames: Map<Int, String>,
         enabledBundleUids: Set<Int> = emptySet()
-    ): Map<String, List<AppTarget>> {
-        val targetsByPackage = mutableMapOf<String, MutableMap<String, AppTarget>>()
+    ): Map<String, List<BundledAppTarget>> {
+        // packageName → bundleUid → version → AppTarget
+        val targetsByPackage = mutableMapOf<String, MutableMap<Int, MutableMap<String, AppTarget>>>()
 
         bundleInfo.forEach { (bundleUid, info) ->
             if (enabledBundleUids.isNotEmpty() && bundleUid !in enabledBundleUids) return@forEach
@@ -2130,23 +2193,43 @@ class HomeViewModel(
             info.patches.forEach { patch ->
                 patch.compatiblePackages?.forEach { pkg ->
                     val packageName = pkg.packageName ?: return@forEach
-                    val map = targetsByPackage.getOrPut(packageName) { mutableMapOf() }
+                    val bundleMap = targetsByPackage
+                        .getOrPut(packageName) { mutableMapOf() }
+                        .getOrPut(bundleUid) { mutableMapOf() }
 
                     pkg.versions?.forEach { version ->
                         val isExperimental = pkg.experimentalVersions?.contains(version) == true
-                        // If a version appears in multiple patches, prefer stable over experimental
-                        if (version !in map || isExperimental.not()) {
+                        // If a version appears in multiple patches of the same bundle, prefer stable
+                        if (version !in bundleMap || !isExperimental) {
                             val description = pkg.versionDescriptions?.get(version)
-                            map[version] = AppTarget(version = version, isExperimental = isExperimental, description = description)
+                            bundleMap[version] = AppTarget(
+                                version = version,
+                                isExperimental = isExperimental,
+                                description = description
+                            )
                         }
                     }
                 }
             }
         }
 
-        // Sort all versions together newest→oldest regardless of experimental flag
+        // Flatten: bundles ordered by display name, versions newest→oldest within each bundle
         return targetsByPackage
-            .mapValues { (_, map) -> map.values.sortedDescending() }
+            .mapValues { (_, byBundle) ->
+                byBundle.entries
+                    .sortedBy { (uid, _) -> bundleNames[uid] ?: "" }
+                    .flatMap { (uid, versionMap) ->
+                        versionMap.values
+                            .sortedDescending()
+                            .map { target ->
+                                BundledAppTarget(
+                                    target = target,
+                                    bundleUid = uid,
+                                    bundleName = bundleNames[uid] ?: "Bundle $uid"
+                                )
+                            }
+                    }
+            }
             .filterValues { it.isNotEmpty() }
     }
 


### PR DESCRIPTION
When multiple bundles support the same package, versions are now grouped by bundle with a labeled section header per bundle instead of a flat merged list.

Each bundle independently shows its own `Recommended` badge based on its own experimental mode setting.
___
![Screenshot_2026-04-15-17-28-12-832_app.morphe.manager-edit.jpg](https://github.com/user-attachments/assets/52db1d32-bfbe-4839-a20f-cd858df174f9)

