### PR TITLE
feat: Improve patch visibility in bundle and app patch dialogs

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -51,10 +51,6 @@ fun HomeScreen(
     val view = LocalView.current
 
     // Dialog states
-    val showInstalledAppDialog = remember { mutableStateOf<String?>(null) }
-    // Increments on every open - ensures key(packageName, openToken) forces fresh
-    // composition even when the same package is opened twice in a row
-    val installedAppDialogToken = remember { mutableIntStateOf(0) }
     val showUpdateDetailsDialog = remember { mutableStateOf(false) }
 
     // Patches dialog state (swipe-right on app card)
@@ -166,21 +162,6 @@ fun HomeScreen(
         )
     }
 
-    // Installed App Info Dialog
-    showInstalledAppDialog.value?.let { packageName ->
-        key(packageName, installedAppDialogToken.intValue) {
-            InstalledAppInfoDialog(
-                packageName = packageName,
-                onDismiss = { showInstalledAppDialog.value = null },
-                onTriggerPatchFlow = { originalPackageName ->
-                    showInstalledAppDialog.value = null
-                    homeViewModel.showPatchDialog(originalPackageName)
-                },
-                homeViewModel = homeViewModel
-            )
-        }
-    }
-
     // All dialogs
     HomeDialogs(
         homeViewModel = homeViewModel,
@@ -233,8 +214,7 @@ fun HomeScreen(
                         installedApp = item.installedApp
                     )
                     item.installedApp?.let {
-                        showInstalledAppDialog.value = it.currentPackageName
-                        installedAppDialogToken.intValue++
+                        homeViewModel.openInstalledAppInfo(it.currentPackageName)
                     }
                 },
                 onHideApp = { packageName -> homeViewModel.hideApp(packageName) },

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -52,6 +52,9 @@ fun HomeScreen(
 
     // Dialog states
     val showInstalledAppDialog = remember { mutableStateOf<String?>(null) }
+    // Increments on every open - ensures key(packageName, openToken) forces fresh
+    // composition even when the same package is opened twice in a row
+    val installedAppDialogToken = remember { mutableIntStateOf(0) }
     val showUpdateDetailsDialog = remember { mutableStateOf(false) }
 
     // Patches dialog state (swipe-right on app card)
@@ -165,7 +168,7 @@ fun HomeScreen(
 
     // Installed App Info Dialog
     showInstalledAppDialog.value?.let { packageName ->
-        key(packageName) {
+        key(packageName, installedAppDialogToken.intValue) {
             InstalledAppInfoDialog(
                 packageName = packageName,
                 onDismiss = { showInstalledAppDialog.value = null },
@@ -229,7 +232,10 @@ fun HomeScreen(
                         android11BugActive = homeViewModel.android11BugActive,
                         installedApp = item.installedApp
                     )
-                    item.installedApp?.let { showInstalledAppDialog.value = it.currentPackageName }
+                    item.installedApp?.let {
+                        showInstalledAppDialog.value = it.currentPackageName
+                        installedAppDialogToken.intValue++
+                    }
                 },
                 onHideApp = { packageName -> homeViewModel.hideApp(packageName) },
                 onHideMultiple = { packageNames -> packageNames.forEach { homeViewModel.hideApp(it) } },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -287,6 +287,21 @@ fun HomeDialogs(
         )
     }
 
+    // Installed App Info Dialog
+    homeViewModel.showInstalledAppInfoDialog?.let { packageName ->
+        key(packageName, homeViewModel.installedAppDialogToken) {
+            InstalledAppInfoDialog(
+                packageName = packageName,
+                onDismiss = homeViewModel::dismissInstalledAppInfo,
+                onTriggerPatchFlow = { originalPackageName ->
+                    homeViewModel.dismissInstalledAppInfo()
+                    homeViewModel.showPatchDialog(originalPackageName)
+                },
+                homeViewModel = homeViewModel
+            )
+        }
+    }
+
     // Expert Mode Dialog
     if (homeViewModel.showExpertModeDialog) {
         ExpertModeDialog(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -264,7 +264,7 @@ fun InstalledAppInfoDialog(
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 // Hero header
                 item(contentType = "hero") {
@@ -531,7 +531,7 @@ private fun AppHeroHeader(
             modifier = Modifier
                 .fillMaxWidth()
                 .statusBarsPadding()
-                .padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 24.dp)
+                .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 16.dp)
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -766,7 +766,7 @@ private fun InfoRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp),
+            .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -805,7 +805,7 @@ private fun InfoRowWithAction(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp),
+            .padding(vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -1122,13 +1122,13 @@ private fun TileActionButton(
     Surface(
         onClick = action.onClick,
         enabled = action.enabled && !action.isLoading,
-        modifier = modifier.height(64.dp),
+        modifier = modifier.height(56.dp),
         shape = RoundedCornerShape(16.dp),
         color = containerColor,
         contentColor = contentColor
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(vertical = 8.dp, horizontal = 8.dp),
+            modifier = Modifier.fillMaxSize().padding(vertical = 6.dp, horizontal = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -276,10 +276,16 @@ fun InstalledAppInfoDialog(
                     )
                 }
 
+                // Stagger index counter: hero header is index 0 (animated independently),
+                // each subsequent visible item increments so the delay chain is always correct
+                // regardless of which optional banners are shown.
+                var staggerIndex = 1
+
                 // Deleted app warning banner
                 if (viewModel.isAppDeleted) {
+                    val idx = staggerIndex++
                     item {
-                        StaggeredItem(entered = entered.value, index = 1) {
+                        StaggeredItem(entered = entered.value, index = idx) {
                             WarningBanner(
                                 icon = Icons.Outlined.Warning,
                                 title = stringResource(R.string.home_app_info_app_deleted_warning),
@@ -299,8 +305,9 @@ fun InstalledAppInfoDialog(
 
                 // Update available banner
                 if (hasUpdate && !viewModel.isAppDeleted) {
+                    val idx = staggerIndex++
                     item {
-                        StaggeredItem(entered = entered.value, index = 1) {
+                        StaggeredItem(entered = entered.value, index = idx) {
                             WarningBanner(
                                 icon = Icons.Outlined.Update,
                                 title = stringResource(R.string.home_app_info_patch_update_available),
@@ -319,8 +326,9 @@ fun InstalledAppInfoDialog(
                 }
 
                 // Info Section
+                val infoIdx = staggerIndex++
                 item {
-                    StaggeredItem(entered = entered.value, index = 2) {
+                    StaggeredItem(entered = entered.value, index = infoIdx) {
                         InfoSection(
                             installedApp = installedApp,
                             appliedPatches = appliedPatches,
@@ -331,8 +339,9 @@ fun InstalledAppInfoDialog(
                 }
 
                 // Actions Section
+                val actionsIdx = staggerIndex++
                 item {
-                    StaggeredItem(entered = entered.value, index = 3) {
+                    StaggeredItem(entered = entered.value, index = actionsIdx) {
                         ActionsSection(
                             viewModel = viewModel,
                             installViewModel = installViewModel,
@@ -357,8 +366,9 @@ fun InstalledAppInfoDialog(
 
                 // Info about saved APK availability
                 if (!viewModel.hasOriginalApk) {
+                    val idx = staggerIndex++
                     item {
-                        StaggeredItem(entered = entered.value, index = 4) {
+                        StaggeredItem(entered = entered.value, index = idx) {
                             InfoBadge(
                                 text = stringResource(R.string.home_app_info_no_saved_apk),
                                 style = InfoBadgeStyle.Warning,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -979,6 +979,20 @@ private data class ActionItem(
     val isLoading: Boolean = false
 )
 
+/** Shared loading/icon content used by action buttons. */
+@Composable
+private fun LoadingOrIcon(isLoading: Boolean, action: ActionItem, tint: Color) {
+    if (isLoading) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(22.dp),
+            strokeWidth = 2.dp,
+            color = tint
+        )
+    } else {
+        Icon(action.icon, null, modifier = Modifier.size(22.dp))
+    }
+}
+
 /** Full-width primary button. */
 @Composable
 private fun PrimaryActionButton(
@@ -1000,15 +1014,7 @@ private fun PrimaryActionButton(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (action.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(22.dp),
-                    strokeWidth = 2.dp,
-                    color = onAccent
-                )
-            } else {
-                Icon(action.icon, null, modifier = Modifier.size(22.dp))
-            }
+            LoadingOrIcon(action.isLoading, action, onAccent)
             Spacer(Modifier.width(10.dp))
             Text(
                 text = action.text,
@@ -1051,15 +1057,7 @@ private fun TileActionButton(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            if (action.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(22.dp),
-                    strokeWidth = 2.dp,
-                    color = contentColor
-                )
-            } else {
-                Icon(action.icon, null, modifier = Modifier.size(22.dp))
-            }
+            LoadingOrIcon(action.isLoading, action, contentColor)
             Spacer(Modifier.height(5.dp))
             Text(
                 text = action.text,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -9,10 +9,12 @@ import android.annotation.SuppressLint
 import android.content.pm.PackageInfo
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
-import androidx.compose.animation.*
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Launch
@@ -27,6 +29,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -35,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.data.room.apps.installed.InstallType
@@ -42,13 +49,13 @@ import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.ui.screen.settings.system.InstallerUnavailableDialog
 import app.morphe.manager.ui.screen.shared.*
-import app.morphe.manager.ui.screen.shared.MorpheDefaults
 import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.InstallViewModel
 import app.morphe.manager.ui.viewmodel.InstalledAppInfoViewModel
 import app.morphe.manager.util.*
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
+import java.io.File
 
 data class AppliedPatchBundleUi(
     val uid: Int,
@@ -90,12 +97,27 @@ fun InstalledAppInfoDialog(
     val appUpdates by homeViewModel.appUpdatesAvailable.collectAsStateWithLifecycle()
     val hasUpdate = appUpdates[packageName] == true
 
+    // Accent color from bundle metadata (appIconColor) → KnownApps.brandColor → default.
+    // originalPackageName needed because metadata is keyed by original pkg, not patched.
+    val bundleAppMetadata by homeViewModel.bundleAppMetadataFlow.collectAsStateWithLifecycle()
+    val appAccentColor: Color by remember(packageName) {
+        derivedStateOf {
+            val orig = viewModel.installedApp?.originalPackageName ?: packageName
+            bundleAppMetadata[orig]?.downloadColor
+                ?: KnownApps.fromPackage(orig)?.brandColor
+                ?: KnownApps.DEFAULT_DOWNLOAD_COLOR
+        }
+    }
+
     // Dialog states
     val showUninstallConfirm = remember { mutableStateOf(false) }
     val showDeleteDialog = remember { mutableStateOf(false) }
     val showAppliedPatchesDialog = remember { mutableStateOf(false) }
     val showMountWarningDialog = remember { mutableStateOf(false) }
     val pendingMountWarningAction = remember { mutableStateOf<(() -> Unit)?>(null) }
+
+    // Content entrance animation
+    val entered = remember { mutableStateOf(false) }
 
     // Bundle data
     val appliedBundles by viewModel.appliedBundles.collectAsStateWithLifecycle()
@@ -228,107 +250,131 @@ fun InstalledAppInfoDialog(
         onDismissRequest = onDismiss,
         title = null,
         dismissOnClickOutside = true,
-        compactPadding = true,
-        footer = null
+        noPadding = true,
+        footer = null,
+        onEntered = { entered.value = true }
     ) {
         if (isLoading || installedApp == null) {
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp),
+                modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
                 LoadingIndicator()
             }
         } else {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                // App Header Card
-                AppHeaderCard(
-                    appInfo = appInfo,
-                    packageName = packageName,
-                    installedApp = installedApp
-                )
+                // Hero header
+                item(contentType = "hero") {
+                    AppHeroHeader(
+                        appInfo = appInfo,
+                        packageName = packageName,
+                        installedApp = installedApp,
+                        accentColor = appAccentColor,
+                    )
+                }
 
                 // Deleted app warning banner
-                AnimatedVisibility(
-                    visible = viewModel.isAppDeleted,
-                    enter = fadeIn(tween(MorpheDefaults.ANIMATION_DURATION)) + expandVertically(tween(MorpheDefaults.ANIMATION_DURATION)),
-                    exit = fadeOut(tween(MorpheDefaults.ANIMATION_DURATION)) + shrinkVertically(tween(MorpheDefaults.ANIMATION_DURATION))
-                ) {
-                    WarningBanner(
-                        icon = Icons.Outlined.Warning,
-                        title = stringResource(R.string.home_app_info_app_deleted_warning),
-                        description = stringResource(R.string.home_app_info_app_deleted_description),
-                        buttonText = stringResource(R.string.patch),
-                        buttonIcon = Icons.Outlined.AutoFixHigh,
-                        onClick = {
-                            onDismiss()
-                            onTriggerPatchFlow(installedApp.originalPackageName)
-                        },
-                        isError = true
-                    )
+                if (viewModel.isAppDeleted) {
+                    item {
+                        StaggeredItem(entered = entered.value, index = 1) {
+                            WarningBanner(
+                                icon = Icons.Outlined.Warning,
+                                title = stringResource(R.string.home_app_info_app_deleted_warning),
+                                description = stringResource(R.string.home_app_info_app_deleted_description),
+                                buttonText = stringResource(R.string.patch),
+                                buttonIcon = Icons.Outlined.AutoFixHigh,
+                                onClick = {
+                                    onDismiss()
+                                    onTriggerPatchFlow(installedApp.originalPackageName)
+                                },
+                                isError = true,
+                                modifier = Modifier.padding(horizontal = 20.dp)
+                            )
+                        }
+                    }
                 }
 
                 // Update available banner
-                AnimatedVisibility(
-                    visible = hasUpdate && !viewModel.isAppDeleted,
-                    enter = fadeIn(tween(MorpheDefaults.ANIMATION_DURATION)) + expandVertically(tween(MorpheDefaults.ANIMATION_DURATION)),
-                    exit = fadeOut(tween(MorpheDefaults.ANIMATION_DURATION)) + shrinkVertically(tween(MorpheDefaults.ANIMATION_DURATION))
-                ) {
-                    WarningBanner(
-                        icon = Icons.Outlined.Update,
-                        title = stringResource(R.string.home_app_info_patch_update_available),
-                        description = stringResource(R.string.home_app_info_patch_update_available_description),
-                        buttonText = stringResource(R.string.patch),
-                        buttonIcon = Icons.Outlined.AutoFixHigh,
-                        onClick = {
-                            onDismiss()
-                            onTriggerPatchFlow(installedApp.originalPackageName)
-                        },
-                        isError = false
-                    )
+                if (hasUpdate && !viewModel.isAppDeleted) {
+                    item {
+                        StaggeredItem(entered = entered.value, index = 1) {
+                            WarningBanner(
+                                icon = Icons.Outlined.Update,
+                                title = stringResource(R.string.home_app_info_patch_update_available),
+                                description = stringResource(R.string.home_app_info_patch_update_available_description),
+                                buttonText = stringResource(R.string.patch),
+                                buttonIcon = Icons.Outlined.AutoFixHigh,
+                                onClick = {
+                                    onDismiss()
+                                    onTriggerPatchFlow(installedApp.originalPackageName)
+                                },
+                                isError = false,
+                                modifier = Modifier.padding(horizontal = 20.dp)
+                            )
+                        }
+                    }
                 }
 
                 // Info Section
-                InfoSection(
-                    installedApp = installedApp,
-                    appliedPatches = appliedPatches,
-                    bundlesUsedSummary = bundlesUsedSummary,
-                    onShowPatches = { showAppliedPatchesDialog.value = true }
-                )
+                item {
+                    StaggeredItem(entered = entered.value, index = 2) {
+                        InfoSection(
+                            installedApp = installedApp,
+                            appliedPatches = appliedPatches,
+                            bundlesUsedSummary = bundlesUsedSummary,
+                            onShowPatches = { showAppliedPatchesDialog.value = true },
+                        )
+                    }
+                }
 
                 // Actions Section
-                ActionsSection(
-                    viewModel = viewModel,
-                    installViewModel = installViewModel,
-                    installedApp = installedApp,
-                    availablePatches = availablePatches,
-                    isInstalling = isInstalling,
-                    mountOperation = mountOperation,
-                    hasUpdate = hasUpdate,
-                    onPatchClick = { handlePatchClick() },
-                    onUninstall = { showUninstallConfirm.value = true },
-                    onDelete = { showDeleteDialog.value = true },
-                    onExport = { exportSavedLauncher.launch(exportFileName) },
-                    onShowMountWarning = { action ->
-                        pendingMountWarningAction.value = action
-                        showMountWarningDialog.value = true
+                item {
+                    StaggeredItem(entered = entered.value, index = 3) {
+                        ActionsSection(
+                            viewModel = viewModel,
+                            installViewModel = installViewModel,
+                            installedApp = installedApp,
+                            availablePatches = availablePatches,
+                            isInstalling = isInstalling,
+                            mountOperation = mountOperation,
+                            hasUpdate = hasUpdate,
+                            accentColor = appAccentColor,
+                            onPatchClick = { handlePatchClick() },
+                            onUninstall = { showUninstallConfirm.value = true },
+                            onDelete = { showDeleteDialog.value = true },
+                            onExport = { exportSavedLauncher.launch(exportFileName) },
+                            onShowMountWarning = { action ->
+                                pendingMountWarningAction.value = action
+                                showMountWarningDialog.value = true
+                            },
+                            modifier = Modifier.padding(horizontal = 20.dp)
+                        )
                     }
-                )
+                }
 
                 // Info about saved APK availability
                 if (!viewModel.hasOriginalApk) {
-                    InfoBadge(
-                        text = stringResource(R.string.home_app_info_no_saved_apk),
-                        style = InfoBadgeStyle.Warning,
-                        icon = Icons.Outlined.Info,
-                        isExpanded = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    item {
+                        StaggeredItem(entered = entered.value, index = 4) {
+                            InfoBadge(
+                                text = stringResource(R.string.home_app_info_no_saved_apk),
+                                style = InfoBadgeStyle.Warning,
+                                icon = Icons.Outlined.Info,
+                                isExpanded = true,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp)
+                            )
+                        }
+                    }
                 }
+
+                // Bottom nav bar padding
+                item { Spacer(Modifier.navigationBarsPadding()) }
             }
         }
     }
@@ -345,6 +391,7 @@ private fun WarningBanner(
     buttonText: String,
     buttonIcon: ImageVector,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
     isError: Boolean = false
 ) {
     val containerColor = if (isError) {
@@ -359,102 +406,207 @@ private fun WarningBanner(
         MaterialTheme.colorScheme.onPrimaryContainer
     }
 
-    MorpheCard(
-        cornerRadius = 12.dp,
-        elevation = 2.dp
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(containerColor)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Header with icon
+        Row(
+            modifier = Modifier.wrapContentWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(20.dp)
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        // Description
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = contentColor.copy(alpha = 0.9f),
+            textAlign = TextAlign.Center
+        )
+
+        // Action button
+        PrimaryActionButton(
+            action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
+            accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+/**
+ * Hero header for the app info dialog.
+ */
+@Composable
+private fun AppHeroHeader(
+    appInfo: PackageInfo?,
+    packageName: String,
+    installedApp: InstalledApp,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    val onHero = MaterialTheme.colorScheme.onBackground
+    val chipBg = accentColor.copy(alpha = 0.18f)
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        // Simple tinted background
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .matchParentSize()
+                .background(accentColor.copy(alpha = 0.12f))
+        )
+        // Radial glow from center-top for depth
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .matchParentSize()
+                .background(
+                    Brush.radialGradient(
+                        colors = listOf(
+                            accentColor.copy(alpha = 0.18f),
+                            Color.Transparent
+                        ),
+                        radius = 700f
+                    )
+                )
+        )
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(containerColor)
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .statusBarsPadding()
+                .padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 24.dp)
         ) {
-            // Header with icon
             Row(
-                modifier = Modifier.wrapContentWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
             ) {
-                Icon(
-                    imageVector = icon,
+                AppIcon(
+                    packageInfo = appInfo,
                     contentDescription = null,
-                    tint = contentColor,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier
+                        .size(88.dp)
+                        .clip(RoundedCornerShape(22.dp))
                 )
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = contentColor,
-                    textAlign = TextAlign.Center
-                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    AppLabel(
+                        packageInfo = appInfo,
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 22.sp,
+                            color = onHero
+                        ),
+                        defaultText = packageName
+                    )
+                    Text(
+                        text = appInfo?.versionName?.let { "v$it" } ?: installedApp.version,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = onHero.copy(alpha = 0.50f)
+                    )
+                }
             }
 
-            // Description
-            Text(
-                text = description,
-                style = MaterialTheme.typography.bodySmall,
-                color = contentColor.copy(alpha = 0.9f),
-                textAlign = TextAlign.Center
-            )
+            Spacer(Modifier.height(14.dp))
 
-            // Action button
-            ActionButton(
-                text = buttonText,
-                icon = buttonIcon,
-                onClick = onClick,
-                isPrimary = true,
-                isHighlighted = true,
-                modifier = Modifier.fillMaxWidth()
-            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                val (chipIcon, chipLabel) = when (installedApp.installType) {
+                    InstallType.MOUNT   -> Icons.Outlined.Link to R.string.mount
+                    InstallType.SHIZUKU -> Icons.Outlined.Terminal to R.string.home_app_info_install_type_shizuku
+                    InstallType.CUSTOM  -> Icons.Outlined.Build to R.string.home_app_info_install_type_custom_installer
+                    InstallType.SAVED   -> Icons.Outlined.Save to R.string.saved
+                    InstallType.DEFAULT -> Icons.Outlined.InstallMobile to R.string.home_app_info_install_type_system_installer
+                }
+                InfoChip(icon = chipIcon, text = stringResource(chipLabel), bg = chipBg, fg = onHero)
+                installedApp.patchedAt?.let { ts ->
+                    InfoChip(
+                        icon = Icons.Outlined.Schedule,
+                        text = getRelativeTimeString(ts),
+                        bg = chipBg,
+                        fg = onHero
+                    )
+                }
+            }
         }
     }
 }
 
+/**
+ * Wraps content with a staggered fade+slide entrance animation.
+ * Each item appears [index] * 60ms after [entered] becomes true.
+ */
 @Composable
-private fun AppHeaderCard(
-    appInfo: PackageInfo?,
-    packageName: String,
-    installedApp: InstalledApp,
+private fun StaggeredItem(
+    entered: Boolean,
+    index: Int,
+    content: @Composable () -> Unit
 ) {
-    MorpheCard(
-        cornerRadius = 16.dp,
-        elevation = 2.dp
+    val alpha by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = tween(
+            durationMillis = 200,
+            delayMillis = index * 60,
+            easing = FastOutSlowInEasing
+        ),
+        label = "itemAlpha$index"
+    )
+    val offsetY by animateFloatAsState(
+        targetValue = if (entered) 0f else 28f,
+        animationSpec = tween(
+            durationMillis = 200,
+            delayMillis = index * 60,
+            easing = FastOutSlowInEasing
+        ),
+        label = "itemOffsetY$index"
+    )
+    Box(modifier = Modifier.graphicsLayer { this.alpha = alpha; translationY = offsetY }) {
+        content()
+    }
+}
+
+@Composable
+private fun InfoChip(icon: ImageVector, text: String, bg: Color, fg: Color) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(bg)
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // App icon
-            AppIcon(
-                packageInfo = appInfo,
-                contentDescription = null,
-                modifier = Modifier.size(64.dp)
-            )
-
-            // App details
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(6.dp)
-            ) {
-                AppLabel(
-                    packageInfo = appInfo,
-                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    defaultText = packageName
-                )
-
-                Text(
-                    text = appInfo?.versionName?.let { "v$it" } ?: installedApp.version,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = LocalDialogSecondaryTextColor.current
-                )
-            }
-        }
+        Icon(icon, null, tint = fg, modifier = Modifier.size(13.dp))
+        Text(
+            text,
+            style = MaterialTheme.typography.labelSmall,
+            color = fg,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1
+        )
     }
 }
 
@@ -463,96 +615,152 @@ private fun InfoSection(
     installedApp: InstalledApp,
     appliedPatches: Map<Int, Set<String>>?,
     bundlesUsedSummary: String,
-    onShowPatches: () -> Unit
+    onShowPatches: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val totalPatches = appliedPatches?.values?.sumOf { it.size } ?: 0
+    val context = LocalContext.current
 
-    MorpheCard(
-        cornerRadius = 16.dp,
-        elevation = 2.dp
+    // APK size from sourceDir
+    val apkSize = remember(installedApp.currentPackageName) {
+        try {
+            val pm = context.packageManager
+            val info = pm.getPackageInfo(installedApp.currentPackageName, 0)
+
+            val bytes = File(
+                info.applicationInfo?.sourceDir ?: return@remember null
+            ).length()
+
+            formatBytes(bytes)
+        } catch (_: Exception) { null }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            // Package name
+        InfoRow(
+            icon = Icons.Outlined.Inventory2,
+            label = stringResource(R.string.package_name),
+            value = installedApp.currentPackageName
+        )
+
+        if (installedApp.originalPackageName != installedApp.currentPackageName) {
             InfoRow(
-                label = stringResource(R.string.package_name),
-                value = installedApp.currentPackageName
+                icon = Icons.Outlined.Category,
+                label = stringResource(R.string.home_app_info_original_package_name),
+                value = installedApp.originalPackageName
             )
-
-            // Original package (if different)
-            if (installedApp.originalPackageName != installedApp.currentPackageName) {
-                MorpheSettingsDivider(fullWidth = true)
-                InfoRow(
-                    label = stringResource(R.string.home_app_info_original_package_name),
-                    value = installedApp.originalPackageName
-                )
-            }
-
-            MorpheSettingsDivider(fullWidth = true)
-
-            // Install type
-            InfoRow(
-                label = stringResource(R.string.home_app_info_install_type),
-                value = stringResource(installedApp.installType.stringResource)
-            )
-
-            // Patched date (if available)
-            installedApp.patchedAt?.let { timestamp ->
-                MorpheSettingsDivider(fullWidth = true)
-                InfoRow(
-                    label = stringResource(R.string.home_app_info_patched_at),
-                    value = getRelativeTimeString(timestamp)
-                )
-            }
-
-            // Applied patches with icon button
-            if (totalPatches > 0) {
-                MorpheSettingsDivider(fullWidth = true)
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.home_app_info_applied_patches),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Text(
-                            text = pluralStringResource(
-                                R.plurals.patch_count,
-                                totalPatches,
-                                totalPatches
-                            ),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                        )
-                    }
-                    ActionPillButton(
-                        onClick = onShowPatches,
-                        icon = Icons.AutoMirrored.Outlined.List,
-                        contentDescription = stringResource(R.string.view)
-                    )
-                }
-            }
-
-            // Bundles used
-            if (bundlesUsedSummary.isNotBlank()) {
-                MorpheSettingsDivider(fullWidth = true)
-                InfoRow(
-                    label = stringResource(R.string.home_app_info_patch_source_used),
-                    value = bundlesUsedSummary
-                )
-            }
         }
+
+        if (apkSize != null) {
+            InfoRow(
+                icon = Icons.Outlined.SdCard,
+                label = stringResource(R.string.home_app_info_apk_size),
+                value = apkSize
+            )
+        }
+
+        if (totalPatches > 0) {
+            InfoRowWithAction(
+                icon = Icons.Outlined.DoneAll,
+                label = stringResource(R.string.home_app_info_applied_patches),
+                value = pluralStringResource(R.plurals.patch_count, totalPatches, totalPatches),
+                onAction = onShowPatches
+            )
+        }
+
+        if (bundlesUsedSummary.isNotBlank()) {
+            InfoRow(
+                icon = Icons.Outlined.Source,
+                label = stringResource(R.string.home_app_info_patch_source_used),
+                value = bundlesUsedSummary
+            )
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(
+    icon: ImageVector,
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(1.dp)
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun InfoRowWithAction(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    onAction: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(1.dp)
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        ActionPillButton(
+            onClick = onAction,
+            icon = Icons.AutoMirrored.Outlined.List,
+            contentDescription = stringResource(R.string.view)
+        )
     }
 }
 
@@ -565,11 +773,13 @@ private fun ActionsSection(
     isInstalling: Boolean,
     mountOperation: InstallViewModel.MountOperation?,
     hasUpdate: Boolean,
+    accentColor: Color,
     onPatchClick: () -> Unit,
     onUninstall: () -> Unit,
     onDelete: () -> Unit,
     onExport: () -> Unit,
-    onShowMountWarning: (action: () -> Unit) -> Unit
+    onShowMountWarning: (action: () -> Unit) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     // Collect all available actions
     val primaryActions = mutableListOf<ActionItem>()
@@ -610,8 +820,8 @@ private fun ActionsSection(
         )
     }
 
-    when {
-        installedApp.installType == InstallType.SAVED && viewModel.hasSavedCopy -> {
+    when (installedApp.installType) {
+        InstallType.SAVED -> if (viewModel.hasSavedCopy) {
             val installText = if (viewModel.isInstalledOnDevice) {
                 stringResource(R.string.reinstall)
             } else {
@@ -653,7 +863,7 @@ private fun ActionsSection(
                 )
             )
         }
-        installedApp.installType == InstallType.MOUNT -> {
+        InstallType.MOUNT -> {
             val isMountLoading = mountOperation != null
             if (viewModel.isMounted) {
                 // Remount button
@@ -700,6 +910,7 @@ private fun ActionsSection(
                 )
             }
         }
+        else -> Unit
     }
 
     // Destructive actions
@@ -725,20 +936,36 @@ private fun ActionsSection(
         )
     }
 
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
         // Primary actions row
         if (primaryActions.isNotEmpty()) {
-            ActionButtonsRow(actions = primaryActions, isPrimary = true)
+            primaryActions.forEach { action ->
+                PrimaryActionButton(
+                    action = action,
+                    accentColor = accentColor,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
 
-        // Secondary actions row
-        if (secondaryActions.isNotEmpty()) {
-            ActionButtonsRow(actions = secondaryActions, isPrimary = false)
-        }
-
-        // Destructive actions row
-        if (destructiveActions.isNotEmpty()) {
-            ActionButtonsRow(actions = destructiveActions, isPrimary = false)
+        // Secondary + destructive - compact tile grid (2 per row)
+        val tileActions = secondaryActions + destructiveActions
+        if (tileActions.isNotEmpty()) {
+            tileActions.chunked(2).forEach { rowActions ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    rowActions.forEach { action ->
+                        TileActionButton(
+                            action = action,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    // Fill empty slot if odd count
+                    if (rowActions.size == 1) Spacer(Modifier.weight(1f))
+                }
+            }
         }
     }
 }
@@ -752,92 +979,91 @@ private data class ActionItem(
     val isLoading: Boolean = false
 )
 
+/** Full-width primary button. */
 @Composable
-private fun ActionButtonsRow(
-    actions: List<ActionItem>,
-    isPrimary: Boolean
+private fun PrimaryActionButton(
+    action: ActionItem,
+    accentColor: Color,
+    modifier: Modifier = Modifier
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        actions.chunked(2).forEach { rowActions ->
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                rowActions.forEach { action ->
-                    ActionButton(
-                        text = action.text,
-                        icon = action.icon,
-                        onClick = action.onClick,
-                        enabled = action.enabled,
-                        isDestructive = action.isDestructive,
-                        isPrimary = isPrimary && !action.isDestructive,
-                        isLoading = action.isLoading,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
+    val onAccent = if (accentColor.luminance() > 0.35f) Color(0xFF1A1A1A) else Color.White
+    Surface(
+        onClick = action.onClick,
+        enabled = action.enabled && !action.isLoading,
+        modifier = modifier.height(56.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = accentColor,
+        contentColor = onAccent
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (action.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(22.dp),
+                    strokeWidth = 2.dp,
+                    color = onAccent
+                )
+            } else {
+                Icon(action.icon, null, modifier = Modifier.size(22.dp))
             }
+            Spacer(Modifier.width(10.dp))
+            Text(
+                text = action.text,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }
 
+/** Square-ish tile button - icon on top, label below. Used for secondary/destructive actions. */
 @Composable
-private fun ActionButton(
-    text: String,
-    icon: ImageVector,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    isDestructive: Boolean = false,
-    isPrimary: Boolean = false,
-    isLoading: Boolean = false,
-    isHighlighted: Boolean = false
+private fun TileActionButton(
+    action: ActionItem,
+    modifier: Modifier = Modifier
 ) {
     val containerColor = when {
-        isHighlighted -> MaterialTheme.colorScheme.primary
-        isDestructive -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
-        isPrimary -> MaterialTheme.colorScheme.primaryContainer
-        !enabled -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-        else -> MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.7f)
+        action.isDestructive -> MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.45f)
+        !action.enabled -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+        else -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
     }
-
     val contentColor = when {
-        isHighlighted -> MaterialTheme.colorScheme.onPrimary
-        isDestructive -> MaterialTheme.colorScheme.error
-        isPrimary -> MaterialTheme.colorScheme.onPrimaryContainer
-        !enabled -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
-        else -> MaterialTheme.colorScheme.onSecondaryContainer
+        action.isDestructive -> MaterialTheme.colorScheme.error
+        !action.enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
+        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
     }
 
     Surface(
-        onClick = onClick,
-        enabled = enabled && !isLoading,
-        modifier = modifier.height(52.dp),
-        shape = RoundedCornerShape(14.dp),
+        onClick = action.onClick,
+        enabled = action.enabled && !action.isLoading,
+        modifier = modifier.height(72.dp),
+        shape = RoundedCornerShape(16.dp),
         color = containerColor,
         contentColor = contentColor
     ) {
-        Row(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = Modifier.fillMaxSize().padding(vertical = 12.dp, horizontal = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            if (isLoading) {
+            if (action.isLoading) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(22.dp),
                     strokeWidth = 2.dp,
                     color = contentColor
                 )
             } else {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
-                )
+                Icon(action.icon, null, modifier = Modifier.size(22.dp))
             }
-            Spacer(modifier = Modifier.width(6.dp))
+            Spacer(Modifier.height(5.dp))
             Text(
-                text = text,
-                style = MaterialTheme.typography.labelLarge,
+                text = action.text,
+                style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -569,7 +569,7 @@ private fun StaggeredItem(
     val alpha by animateFloatAsState(
         targetValue = if (entered) 1f else 0f,
         animationSpec = tween(
-            durationMillis = 100,
+            durationMillis = 60,
             delayMillis = index * 60,
             easing = FastOutSlowInEasing
         ),
@@ -578,7 +578,7 @@ private fun StaggeredItem(
     val offsetY by animateFloatAsState(
         targetValue = if (entered) 0f else 28f,
         animationSpec = tween(
-            durationMillis = 100,
+            durationMillis = 60,
             delayMillis = index * 60,
             easing = FastOutSlowInEasing
         ),
@@ -1041,13 +1041,13 @@ private fun TileActionButton(
     Surface(
         onClick = action.onClick,
         enabled = action.enabled && !action.isLoading,
-        modifier = modifier.height(72.dp),
+        modifier = modifier.height(64.dp),
         shape = RoundedCornerShape(16.dp),
         color = containerColor,
         contentColor = contentColor
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(vertical = 12.dp, horizontal = 8.dp),
+            modifier = Modifier.fillMaxSize().padding(vertical = 8.dp, horizontal = 8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -9,9 +9,7 @@ import android.annotation.SuppressLint
 import android.content.pm.PackageInfo
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -42,6 +40,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.lerp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.data.room.apps.installed.InstallType
@@ -97,7 +96,7 @@ fun InstalledAppInfoDialog(
     val appUpdates by homeViewModel.appUpdatesAvailable.collectAsStateWithLifecycle()
     val hasUpdate = appUpdates[packageName] == true
 
-    // Accent color from bundle metadata (appIconColor) → KnownApps.brandColor → default.
+    // Accent color resolution order: bundle metadata (appIconColor) -> KnownApps.brandColor -> default.
     // originalPackageName needed because metadata is keyed by original pkg, not patched.
     val bundleAppMetadata by homeViewModel.bundleAppMetadataFlow.collectAsStateWithLifecycle()
     val appAccentColor: Color by remember(packageName) {
@@ -467,6 +466,33 @@ private fun AppHeroHeader(
     val onHero = MaterialTheme.colorScheme.onBackground
     val chipBg = accentColor.copy(alpha = 0.18f)
 
+    // Entrance animations (progress-based: 0f -> 1f).
+    // One Float per visual group; alpha, offset and scale are derived via lerp
+    // to avoid redundant Recomposition subscribers.
+    var entered by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { entered = true }
+
+    // Icon: spring with overshoot (first thing the eye sees, no delay needed).
+    val iconProgress by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = spring(dampingRatio = 0.55f, stiffness = 320f),
+        label = "heroIconProgress"
+    )
+
+    // Name + version share one clock; stagger handled inside graphicsLayer via lerp
+    val textProgress by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = tween(durationMillis = 260, delayMillis = 60, easing = EaseOutCubic),
+        label = "heroTextProgress"
+    )
+
+    // Both chips share one clock; chip 2 uses a clamped sub-range for its offset
+    val chipsProgress by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = tween(durationMillis = 240, delayMillis = 160, easing = EaseOutBack),
+        label = "heroChipsProgress"
+    )
+
     Box(modifier = modifier.fillMaxWidth()) {
         // Simple tinted background
         Box(
@@ -502,30 +528,51 @@ private fun AppHeroHeader(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
+                // Animated app icon
                 AppIcon(
                     packageInfo = appInfo,
                     contentDescription = null,
                     modifier = Modifier
                         .size(88.dp)
                         .clip(RoundedCornerShape(22.dp))
+                        .graphicsLayer {
+                            val s = lerp(0.6f, 1f, iconProgress)
+                            scaleX = s
+                            scaleY = s
+                            alpha = iconProgress.coerceIn(0f, 1f)
+                        }
                 )
                 Column(
                     modifier = Modifier.weight(1f),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    AppLabel(
-                        packageInfo = appInfo,
-                        style = MaterialTheme.typography.headlineSmall.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 22.sp,
-                            color = onHero
-                        ),
-                        defaultText = packageName
-                    )
+                    // Animated app name (leads textProgress)
+                    Box(
+                        modifier = Modifier.graphicsLayer {
+                            translationX = lerp(40f, 0f, textProgress)
+                            alpha = textProgress.coerceIn(0f, 1f)
+                        }
+                    ) {
+                        AppLabel(
+                            packageInfo = appInfo,
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 22.sp,
+                                color = onHero
+                            ),
+                            defaultText = packageName
+                        )
+                    }
+                    // Animated version (slightly behind name via sub-range)
                     Text(
                         text = appInfo?.versionName?.let { "v$it" } ?: installedApp.version,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = onHero.copy(alpha = 0.50f)
+                        color = onHero.copy(alpha = 0.50f),
+                        modifier = Modifier.graphicsLayer {
+                            val p = ((textProgress - 0.15f) / 0.85f).coerceIn(0f, 1f)
+                            translationX = lerp(40f, 0f, p)
+                            alpha = p
+                        }
                     )
                 }
             }
@@ -542,14 +589,31 @@ private fun AppHeroHeader(
                     InstallType.SAVED   -> Icons.Outlined.Save to R.string.saved
                     InstallType.DEFAULT -> Icons.Outlined.InstallMobile to R.string.home_app_info_install_type_system_installer
                 }
-                InfoChip(icon = chipIcon, text = stringResource(chipLabel), bg = chipBg, fg = onHero)
+                // Animated chip 1
+                Box(
+                    modifier = Modifier.graphicsLayer {
+                        translationY = lerp(20f, 0f, chipsProgress)
+                        alpha = chipsProgress.coerceIn(0f, 1f)
+                    }
+                ) {
+                    InfoChip(icon = chipIcon, text = stringResource(chipLabel), bg = chipBg, fg = onHero)
+                }
+                // Animated chip 2 (sub-range: starts when chip1 is 30% done)
                 installedApp.patchedAt?.let { ts ->
-                    InfoChip(
-                        icon = Icons.Outlined.Schedule,
-                        text = getRelativeTimeString(ts),
-                        bg = chipBg,
-                        fg = onHero
-                    )
+                    Box(
+                        modifier = Modifier.graphicsLayer {
+                            val p = ((chipsProgress - 0.3f) / 0.7f).coerceIn(0f, 1f)
+                            translationY = lerp(20f, 0f, p)
+                            alpha = p
+                        }
+                    ) {
+                        InfoChip(
+                            icon = Icons.Outlined.Schedule,
+                            text = getRelativeTimeString(ts),
+                            bg = chipBg,
+                            fg = onHero
+                        )
+                    }
                 }
             }
         }
@@ -557,7 +621,9 @@ private fun AppHeroHeader(
 }
 
 /**
- * Wraps content with a staggered fade+slide entrance animation.
+ * Wraps content with a staggered entrance animation.
+ * Uses a single progress float (0 to 1); alpha, offsetY and scale are
+ * derived via lerp - one Recomposition subscriber instead of three.
  * Each item appears [index] * 60ms after [entered] becomes true.
  */
 @Composable
@@ -566,25 +632,24 @@ private fun StaggeredItem(
     index: Int,
     content: @Composable () -> Unit
 ) {
-    val alpha by animateFloatAsState(
+    val progress by animateFloatAsState(
         targetValue = if (entered) 1f else 0f,
         animationSpec = tween(
-            durationMillis = 60,
+            durationMillis = 280,
             delayMillis = index * 60,
-            easing = FastOutSlowInEasing
+            easing = EaseOutCubic
         ),
-        label = "itemAlpha$index"
+        label = "itemProgress$index"
     )
-    val offsetY by animateFloatAsState(
-        targetValue = if (entered) 0f else 28f,
-        animationSpec = tween(
-            durationMillis = 60,
-            delayMillis = index * 60,
-            easing = FastOutSlowInEasing
-        ),
-        label = "itemOffsetY$index"
-    )
-    Box(modifier = Modifier.graphicsLayer { this.alpha = alpha; translationY = offsetY }) {
+    Box(
+        modifier = Modifier.graphicsLayer {
+            alpha = progress
+            translationY = lerp(28f, 0f, progress)
+            val s = lerp(0.97f, 1f, progress)
+            scaleX = s
+            scaleY = s
+        }
+    ) {
         content()
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -569,7 +569,7 @@ private fun StaggeredItem(
     val alpha by animateFloatAsState(
         targetValue = if (entered) 1f else 0f,
         animationSpec = tween(
-            durationMillis = 200,
+            durationMillis = 100,
             delayMillis = index * 60,
             easing = FastOutSlowInEasing
         ),
@@ -578,7 +578,7 @@ private fun StaggeredItem(
     val offsetY by animateFloatAsState(
         targetValue = if (entered) 0f else 28f,
         animationSpec = tween(
-            durationMillis = 200,
+            durationMillis = 100,
             delayMillis = index * 60,
             easing = FastOutSlowInEasing
         ),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1646,6 +1646,26 @@ fun AppPatchesDialog(
     val isFiltering = searchQuery.isNotBlank() || selectedBundle != null
     val totalCount = allPatches.size
 
+    // Pre-compute per-bundle markers once so items{} can do O(1) lookups instead of O(n) scans
+    val firstPatchPerBundle: Map<Int, PatchInfo> = remember(filteredPatches) {
+        buildMap {
+            filteredPatches.forEach { (uid, patch) -> putIfAbsent(uid, patch) }
+        }
+    }
+    val firstUniversalPerBundle: Map<Int, PatchInfo> = remember(filteredPatches) {
+        buildMap {
+            filteredPatches.forEach { (uid, patch) ->
+                if (patch.compatiblePackages == null) putIfAbsent(uid, patch)
+            }
+        }
+    }
+    val bundlesWithSpecificPatches: Set<Int> = remember(filteredPatches) {
+        filteredPatches
+            .filter { (_, patch) -> patch.compatiblePackages != null }
+            .map { it.first }
+            .toSet()
+    }
+
     MorpheDialog(
         onDismissRequest = onDismiss,
         dismissOnClickOutside = true,
@@ -1875,9 +1895,7 @@ fun AppPatchesDialog(
                 ) {
                     // Bundle section label - only for multi-bundle, at first patch of each bundle
                     if (isMultiBundle) {
-                        val isFirstOfBundle = remember(filteredPatches, uid, patch) {
-                            filteredPatches.firstOrNull { it.first == uid }?.second == patch
-                        }
+                        val isFirstOfBundle = firstPatchPerBundle[uid] == patch
                         if (isFirstOfBundle) {
                             InfoBadge(
                                 text = bundleNames[uid] ?: uid.toString(),
@@ -1890,14 +1908,9 @@ fun AppPatchesDialog(
                     }
 
                     // Universal patches divider - shown before the first universal patch of each bundle
-                    val isFirstUniversalOfBundle = remember(filteredPatches, uid, patch) {
-                        if (!isUniversal) return@remember false
-                        filteredPatches.firstOrNull { it.first == uid && it.second.compatiblePackages == null }?.second == patch
-                    }
+                    val isFirstUniversalOfBundle = isUniversal && firstUniversalPerBundle[uid] == patch
                     if (isFirstUniversalOfBundle) {
-                        val hasSpecificAbove = remember(filteredPatches, uid) {
-                            filteredPatches.any { it.first == uid && it.second.compatiblePackages != null }
-                        }
+                        val hasSpecificAbove = uid in bundlesWithSpecificPatches
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1597,9 +1597,9 @@ fun AppPatchesDialog(
     onDismiss: () -> Unit
 ) {
     // Flatten to a list of (bundleUid, patch).
-    // Bundle ordering: bundles with at least one specific patch come first (alphabetically),
-    // then bundles with only universal patches.
-    // Within each bundle: specific patches first, universal patches last.
+    // Bundle ordering: bundles with at least one specific patch come first (by name),
+    // then bundles with only universal patches (by name).
+    // Within each bundle: specific patches first (alphabetically), universal patches last (alphabetically).
     val allPatches = remember(patchesByBundle, bundleNames) {
         patchesByBundle.entries
             .sortedWith(
@@ -1616,6 +1616,18 @@ fun AppPatchesDialog(
     }
 
     val isMultiBundle = patchesByBundle.size > 1
+
+    // Per-bundle accent color for multi-bundle mode only.
+    // Generated deterministically from uid via multiplicative hash → HSL,
+    // so the same uid always produces the same color.
+    // Returns null for single-bundle (no coloring needed).
+    val bundleAccentColors: Map<Int, Color> = remember(patchesByBundle, isMultiBundle) {
+        if (!isMultiBundle) return@remember emptyMap()
+        patchesByBundle.keys.associateWith { uid ->
+            val hue = ((uid.hashCode() * 2654435761L) and 0xFFFFFFFFL).toFloat() % 360f
+            Color.hsl(hue = hue, saturation = 0.55f, lightness = 0.60f)
+        }
+    }
     var searchQuery by remember { mutableStateOf("") }
     var selectedBundle by remember { mutableStateOf<Int?>(null) }
     val showFilterSheet = remember { mutableStateOf(false) }
@@ -1850,7 +1862,9 @@ fun AppPatchesDialog(
                 key = { (uid, patch) ->
                     "$uid:${patch.name}:${patch.compatiblePackages?.joinToString { it.packageName.orEmpty() }.orEmpty()}"
                 }
-            ) { (uid, patch) ->
+            ) { entry ->
+                val uid: Int = entry.first
+                val patch: PatchInfo = entry.second
                 val isUniversal = patch.compatiblePackages == null
                 Column {
                     // Bundle section label - only for multi-bundle, at first patch of each bundle
@@ -1859,11 +1873,11 @@ fun AppPatchesDialog(
                             filteredPatches.firstOrNull { it.first == uid }?.second == patch
                         }
                         if (isFirstOfBundle) {
-                            Text(
+                            InfoBadge(
                                 text = bundleNames[uid] ?: uid.toString(),
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary,
+                                style = InfoBadgeStyle.Primary,
+                                icon = Icons.Outlined.Layers,
+                                isExpanded = true,
                                 modifier = Modifier.padding(bottom = 6.dp, top = 8.dp)
                             )
                         }
@@ -1872,11 +1886,11 @@ fun AppPatchesDialog(
                     // Universal patches divider - shown before the first universal patch of each bundle
                     val isFirstUniversalOfBundle = remember(filteredPatches, uid, patch) {
                         if (!isUniversal) return@remember false
-                        filteredPatches.firstOrNull { (u, p) -> u == uid && p.compatiblePackages == null }?.second == patch
+                        filteredPatches.firstOrNull { it.first == uid && it.second.compatiblePackages == null }?.second == patch
                     }
                     if (isFirstUniversalOfBundle) {
                         val hasSpecificAbove = remember(filteredPatches, uid) {
-                            filteredPatches.any { (u, p) -> u == uid && p.compatiblePackages != null }
+                            filteredPatches.any { it.first == uid && it.second.compatiblePackages != null }
                         }
                         Row(
                             modifier = Modifier
@@ -1907,6 +1921,7 @@ fun AppPatchesDialog(
                     PatchItemCard(
                         patch = patch,
                         saveStateKey = "app_patches_${item.packageName}_$uid",
+                        accentColor = bundleAccentColors[uid],
                         modifier = Modifier.animateItem(
                             fadeInSpec = tween(220),
                             fadeOutSpec = tween(180),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1866,7 +1866,13 @@ fun AppPatchesDialog(
                 val uid: Int = entry.first
                 val patch: PatchInfo = entry.second
                 val isUniversal = patch.compatiblePackages == null
-                Column {
+                Column(
+                    modifier = Modifier.animateItem(
+                        fadeInSpec = tween(220),
+                        fadeOutSpec = tween(180),
+                        placementSpec = spring(stiffness = 400f, dampingRatio = 0.8f)
+                    )
+                ) {
                     // Bundle section label - only for multi-bundle, at first patch of each bundle
                     if (isMultiBundle) {
                         val isFirstOfBundle = remember(filteredPatches, uid, patch) {
@@ -1922,11 +1928,6 @@ fun AppPatchesDialog(
                         patch = patch,
                         saveStateKey = "app_patches_${item.packageName}_$uid",
                         accentColor = bundleAccentColors[uid],
-                        modifier = Modifier.animateItem(
-                            fadeInSpec = tween(220),
-                            fadeOutSpec = tween(180),
-                            placementSpec = spring(stiffness = 400f, dampingRatio = 0.8f)
-                        )
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -395,6 +395,16 @@ fun BundlePatchesDialog(
             .sortedBy { it.name }
     }
 
+    // Per-patch accent color: first non-null appIconColor across all compatible packages,
+    // converted from 0xRRGGBB to a full-opacity Compose Color. Null falls back to surfaceVariant.
+    val patchAccentColors: Map<String, Color> = remember(patches) {
+        patches.associate { patch ->
+            val rgb = patch.compatiblePackages
+                ?.firstNotNullOfOrNull { it.appIconColor }
+            patch.name to if (rgb != null) Color(rgb or (0xFF shl 24)) else Color.Unspecified
+        }
+    }
+
     val isFiltering = searchQuery.isNotBlank() || selectedPackages.isNotEmpty()
 
     MorpheDialog(
@@ -628,12 +638,15 @@ fun BundlePatchesDialog(
                     }
                 ) { patch ->
                     val context = LocalContext.current
+                    val accentColor = patchAccentColors[patch.name]
+                        ?.takeIf { it != Color.Unspecified }
                     PatchItemCard(
                         patch = patch,
                         saveStateKey = "bundle_${src.uid}",
                         onExpertBadgeClick = if (!patch.include) {
                             { context.toast(context.getString(R.string.sources_patch_expert_badge_tooltip)) }
                         } else null,
+                        accentColor = accentColor,
                         modifier = Modifier.animateItem(
                             fadeInSpec = tween(220),
                             fadeOutSpec = tween(180),
@@ -715,7 +728,8 @@ fun PatchItemCard(
     modifier: Modifier = Modifier,
     patch: PatchInfo,
     saveStateKey: String,
-    onExpertBadgeClick: (() -> Unit)? = null
+    onExpertBadgeClick: (() -> Unit)? = null,
+    accentColor: Color? = null
 ) {
     val textColor = LocalDialogTextColor.current
     val secondaryColor = LocalDialogSecondaryTextColor.current
@@ -743,7 +757,7 @@ fun PatchItemCard(
                 } else Modifier
             ),
         shape = RoundedCornerShape(14.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        color = accentColor?.copy(alpha = 0.13f) ?: MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
     ) {
         Column(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -757,7 +758,15 @@ fun PatchItemCard(
                 } else Modifier
             ),
         shape = RoundedCornerShape(14.dp),
-        color = accentColor?.copy(alpha = 0.13f) ?: MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        color = if (accentColor != null) {
+            lerp(
+                start = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                stop = accentColor.copy(alpha = 0.3f),
+                fraction = 0.25f
+            )
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
+        }
     ) {
         Column(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -6,6 +6,8 @@
 package app.morphe.manager.ui.screen.home
 
 import android.annotation.SuppressLint
+import android.graphics.Color.argb
+import android.graphics.Color.colorToHSV
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -28,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -758,12 +759,19 @@ fun PatchItemCard(
                 } else Modifier
             ),
         shape = RoundedCornerShape(14.dp),
+        // Extract hue from accentColor, rebuild with fixed saturation/lightness
+        // so all cards share the same base tone but are distinguishable by hue only
         color = if (accentColor != null) {
-            lerp(
-                start = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                stop = accentColor.copy(alpha = 0.3f),
-                fraction = 0.25f
+            val hsv = FloatArray(3)
+            colorToHSV(
+                argb(255,
+                    (accentColor.red * 255).toInt(),
+                    (accentColor.green * 255).toInt(),
+                    (accentColor.blue * 255).toInt()
+                ),
+                hsv
             )
+            Color.hsl(hue = hsv[0], saturation = 0.35f, lightness = 0.55f, alpha = 0.2f)
         } else {
             MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -749,6 +749,23 @@ fun PatchItemCard(
         label = "expand_rotation"
     )
 
+    // Cache the card background color: colorToHSV is a native call that allocates a FloatArray
+    val cardColor = remember(accentColor) {
+        if (accentColor != null) {
+            val hsv = FloatArray(3)
+            colorToHSV(
+                argb(
+                    255,
+                    (accentColor.red * 255).toInt(),
+                    (accentColor.green * 255).toInt(),
+                    (accentColor.blue * 255).toInt()
+                ),
+                hsv
+            )
+            Color.hsl(hue = hsv[0], saturation = 0.35f, lightness = 0.55f, alpha = 0.2f)
+        } else null
+    }
+
     Surface(
         modifier = modifier
             .fillMaxWidth()
@@ -759,22 +776,7 @@ fun PatchItemCard(
                 } else Modifier
             ),
         shape = RoundedCornerShape(14.dp),
-        // Extract hue from accentColor, rebuild with fixed saturation/lightness
-        // so all cards share the same base tone but are distinguishable by hue only
-        color = if (accentColor != null) {
-            val hsv = FloatArray(3)
-            colorToHSV(
-                argb(255,
-                    (accentColor.red * 255).toInt(),
-                    (accentColor.green * 255).toInt(),
-                    (accentColor.blue * 255).toInt()
-                ),
-                hsv
-            )
-            Color.hsl(hue = hsv[0], saturation = 0.35f, lightness = 0.55f, alpha = 0.2f)
-        } else {
-            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
-        }
+        color = cardColor ?: MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
     ) {
         Column(
             modifier = Modifier.padding(16.dp),

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppLabel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppLabel.kt
@@ -23,10 +23,10 @@ import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
 /**
- * Universal app label component
+ * Universal app label component.
  *
  * Automatically resolves label from available sources:
- * installed app → original APK → patched APK → constants → package name fallback
+ * installed app → original APK → patched APK → constants → package name fallback.
  */
 @Composable
 fun AppLabel(
@@ -77,7 +77,7 @@ fun AppLabel(
 }
 
 /**
- * Simple label display when PackageInfo is already available
+ * Simple label display when PackageInfo is already available.
  */
 @Composable
 private fun SimpleAppLabel(
@@ -89,10 +89,11 @@ private fun SimpleAppLabel(
     overflow: TextOverflow = TextOverflow.Clip
 ) {
     val context = LocalContext.current
-    var label: String? by rememberSaveable { mutableStateOf(null) }
 
-    LaunchedEffect(packageInfo) {
-        label = withContext(Dispatchers.IO) {
+    // Attempt a cheap synchronous resolution first so we never show a shimmer
+    // when the label is already available in memory
+    val initialLabel = remember(packageInfo.packageName) {
+        runCatching {
             packageInfo.applicationInfo?.loadLabel(context.packageManager)
                 ?.toString()
                 ?.let { raw ->
@@ -101,12 +102,32 @@ private fun SimpleAppLabel(
                 }
                 ?: packageInfo.applicationInfo?.nonLocalizedLabel?.toString()
                     ?.takeIf { it.isNotBlank() }
-                ?: defaultText
+        }.getOrNull()
+    }
+
+    var label: String? by rememberSaveable(packageInfo.packageName) {
+        mutableStateOf(initialLabel)
+    }
+
+    // Only dispatch to IO when the synchronous attempt didn't produce a result
+    if (label == null) {
+        LaunchedEffect(packageInfo.packageName) {
+            label = withContext(Dispatchers.IO) {
+                packageInfo.applicationInfo?.loadLabel(context.packageManager)
+                    ?.toString()
+                    ?.let { raw ->
+                        val cleaned = cleanWeirdLabel(raw, packageInfo.packageName)
+                        cleaned.takeIf { it.isNotBlank() && cleaned != packageInfo.packageName }
+                    }
+                    ?: packageInfo.applicationInfo?.nonLocalizedLabel?.toString()
+                        ?.takeIf { it.isNotBlank() }
+                    ?: defaultText
+            }
         }
     }
 
     Text(
-        label ?: stringResource(R.string.loading),
+        label ?: defaultText ?: stringResource(R.string.loading),
         modifier = Modifier
             .placeholder(
                 visible = label == null,
@@ -121,7 +142,7 @@ private fun SimpleAppLabel(
 }
 
 /**
- * Resolved label from any available source when only package name is known
+ * Resolved label from any available source when only package name is known.
  */
 @Composable
 private fun ResolvedAppLabel(
@@ -171,7 +192,7 @@ private fun ResolvedAppLabel(
 }
 
 /**
- * Clean weird labels that contain package name or other artifacts
+ * Clean weird labels that contain package name or other artifacts.
  */
 private fun cleanWeirdLabel(raw: String, packageName: String?): String {
     val trimmed = raw.trim()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
@@ -45,6 +45,7 @@ val LocalDialogSecondaryTextColor = compositionLocalOf { Color.White.copy(alpha 
  * @param dismissOnClickOutside Whether clicking outside dismisses the dialog
  * @param scrollable Whether to wrap content in verticalScroll. Set to false for LazyColumn. Default is true.
  * @param compactPadding Whether to use compact padding. Default is false.
+ * @param noPadding Whether to remove all padding and system bar insets. Default is false.
  * @param content Dialog content
  */
 @Composable
@@ -56,6 +57,8 @@ fun MorpheDialog(
     dismissOnClickOutside: Boolean = false,
     scrollable: Boolean = true,
     compactPadding: Boolean = false,
+    noPadding: Boolean = false,
+    onEntered: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val isDarkTheme = MaterialTheme.colorScheme.background.isDarkBackground()
@@ -63,6 +66,11 @@ fun MorpheDialog(
 
     LaunchedEffect(Unit) {
         visible = true
+        // Notify caller once the enter animation has completed
+        if (onEntered != null) {
+            kotlinx.coroutines.delay(MorpheDefaults.ANIMATION_DURATION.toLong())
+            onEntered()
+        }
     }
 
     Dialog(
@@ -118,6 +126,7 @@ fun MorpheDialog(
                         isDarkTheme = isDarkTheme,
                         scrollable = scrollable,
                         compactPadding = compactPadding,
+                        noPadding = noPadding,
                         content = content
                     )
                 }
@@ -137,6 +146,7 @@ private fun DialogContent(
     isDarkTheme: Boolean,
     scrollable: Boolean,
     compactPadding: Boolean,
+    noPadding: Boolean,
     content: @Composable ColumnScope.() -> Unit
 ) {
     val isLandscape = isLandscape()
@@ -145,6 +155,23 @@ private fun DialogContent(
     val textColor = if (isDarkTheme) Color.White else Color.Black
     val secondaryTextColor =
         if (isDarkTheme) Color.White.copy(alpha = 0.7f) else Color.Black.copy(alpha = 0.7f)
+
+    // noPadding mode: fill entire screen, no insets, caller handles layout
+    if (noPadding) {
+        CompositionLocalProvider(
+            LocalDialogTextColor provides textColor,
+            LocalDialogSecondaryTextColor provides secondaryTextColor
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) { detectTapGestures { /* Consume clicks */ } }
+            ) {
+                content()
+            }
+        }
+        return
+    }
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -20,6 +20,7 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -178,6 +179,21 @@ class HomeViewModel(
     var showAddSourceDialog by mutableStateOf(false)
     var bundleToRename by mutableStateOf<PatchBundleSource?>(null)
     var showRenameBundleDialog by mutableStateOf(false)
+
+    // Installed App Info dialog state
+    var showInstalledAppInfoDialog: String? by mutableStateOf(null)
+        private set
+    var installedAppDialogToken by mutableIntStateOf(0)
+        private set
+
+    fun openInstalledAppInfo(packageName: String) {
+        showInstalledAppInfoDialog = packageName
+        installedAppDialogToken++
+    }
+
+    fun dismissInstalledAppInfo() {
+        showInstalledAppInfoDialog = null
+    }
 
     // Deep link: pending bundle to add via confirmation dialog
     var deepLinkPendingBundle by mutableStateOf<DeepLinkBundle?>(null)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
     <string name="home_app_info_patch_update_available_description">A newer version of patches is available. Repatch your app to get the latest improvements and fixes</string>
     <string name="home_app_info_app_deleted_warning">App was uninstalled</string>
     <string name="home_app_info_app_deleted_description">This app was uninstalled outside the Morphe. Repatch it to restore functionality</string>
+    <string name="home_app_info_apk_size">APK size</string>
 
     <!-- Home Screen - Root Mode -->
     <string name="root_install_apk_required">Root mode requires the original APK to be installed on your device before patching</string>


### PR DESCRIPTION
Bundle names are displayed as styled pill badges.
- In `AppPatchesDialog` (multi-bundle): patch cards are tinted per bundle via deterministic HSL color, making it easy to visually distinguish which bundle a patch belongs to.
- In `BundlePatchesDialog`: patch cards are tinted using the app's `appIconColor` declared in the bundle, falling back to the default surface color when not available.
___
![Screenshot_2026-04-20-11-35-21-756_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/a15fdebe-04e9-43f7-a08b-0bb683ed5b88)

![Screenshot_2026-04-20-11-36-01-822_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/422ad08e-6458-481d-ba5a-fc0392f85d13)

