### PR TITLE
chore: clarify APK file picker tip in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The website will guide you to the latest release for your device. No account nee
 3. **Choose your mode:**
   - **Simple mode** - designed for a one-tap experience. Just tap Patch and Morphe handles the rest with sensible defaults. No configuration needed.
   - **Expert mode** - gives you full control. Choose exactly which of the 100+ patches to apply, configure per-patch options (colors, toggles, and more), and fine-tune everything before patching.
-4. **Provide the APK** - Morphe guides you through obtaining the original app file via step-by-step dialogs. The patching itself happens entirely on your device.
+4. **Provide the APK** - Morphe guides you through obtaining the original app file via step-by-step dialogs. The patching itself happens entirely on your device (If you can't select the apk file, move the apk file to the root directory not in the Download folder after downloaded).
 5. **Install and enjoy** - once patching is complete, install the result like any normal APK.
 
 Everything happens locally. Morphe never uploads your APKs or personal data anywhere.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The website will guide you to the latest release for your device. No account nee
 3. **Choose your mode:**
   - **Simple mode** - designed for a one-tap experience. Just tap Patch and Morphe handles the rest with sensible defaults. No configuration needed.
   - **Expert mode** - gives you full control. Choose exactly which of the 100+ patches to apply, configure per-patch options (colors, toggles, and more), and fine-tune everything before patching.
-4. **Provide the APK** - Morphe guides you through obtaining the original app file via step-by-step dialogs. The patching itself happens entirely on your device (If you can't select the apk file, move the apk file to the root directory not in the Download folder after downloaded).
+4. **Provide the APK** - Morphe guides you through obtaining the original app file via step-by-step dialogs. The patching itself happens entirely on your device. *(If you can't select the APK file, try moving it out of the Downloads folder to the root of your internal storage.)*
 5. **Install and enjoy** - once patching is complete, install the result like any normal APK.
 
 Everything happens locally. Morphe never uploads your APKs or personal data anywhere.


### PR DESCRIPTION
Clarified instructions for providing the APK file by adding a note about moving the APK to the root directory if it cannot be selected.