### PR TITLE
feat: Open `.mpp` patch sources directly from file manager

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,16 +84,13 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
-            <!-- Open .mpp patch bundle files from file managers  -->
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="file" android:mimeType="*/*" />
-            </intent-filter>
+            <!-- Open .mpp patch bundle files from file managers -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="content" android:mimeType="*/*" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/vnd.ms-project" />
             </intent-filter>
 
             <!-- Deep link: App Links (https://morphe.software/add-source?github=...) -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -84,6 +84,18 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
+            <!-- Open .mpp patch bundle files from file managers  -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter tools:ignore="AppLinkUrlError">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" android:mimeType="*/*" />
+            </intent-filter>
+
             <!-- Deep link: App Links (https://morphe.software/add-source?github=...) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/app/morphe/manager/MainActivity.kt
+++ b/app/src/main/java/app/morphe/manager/MainActivity.kt
@@ -45,6 +45,7 @@ import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.MainViewModel
 import app.morphe.manager.ui.viewmodel.PatcherViewModel
 import app.morphe.manager.util.UpdateNotificationManager
+import app.morphe.manager.util.hasMppExtension
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -100,6 +101,16 @@ class MainActivity : AppCompatActivity() {
      */
     private fun handleDeepLinkIntent(intent: Intent?, vm: MainViewModel) {
         val data = intent?.data ?: return
+
+        // Handle .mpp file open from file manager
+        if (intent.action == Intent.ACTION_VIEW && data.scheme in listOf("file", "content")) {
+            if (data.hasMppExtension(contentResolver)) {
+                vm.pendingMppUri = data
+            }
+            // Not .mpp - don't process further regardless
+            return
+        }
+
         val isAddSource = data.scheme == "https" &&
                 data.host == "morphe.software" &&
                 data.path?.startsWith("/add-source") == true
@@ -204,6 +215,14 @@ private fun MorpheManager(vm: MainViewModel) {
                     vm.pendingDeepLinkSource?.let { bundle ->
                         homeViewModel.handleDeepLinkAddSource(bundle.url, bundle.name)
                         vm.pendingDeepLinkSource = null
+                    }
+                }
+
+                // Handle .mpp file opened from file manager
+                LaunchedEffect(vm.pendingMppUri) {
+                    vm.pendingMppUri?.let { uri ->
+                        homeViewModel.setPendingMpp(uri)
+                        vm.pendingMppUri = null
                     }
                 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -48,6 +48,7 @@ import app.morphe.manager.ui.viewmodel.BundledAppTarget
 import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.SavedApkInfo
 import app.morphe.manager.util.KnownApps
+import app.morphe.manager.util.MppManifest
 import app.morphe.manager.util.RemoteAvatar
 import app.morphe.manager.util.htmlAnnotatedString
 import app.morphe.manager.util.toast
@@ -413,6 +414,16 @@ fun HomeDialogs(
             name = bundle.name,
             onConfirm = { homeViewModel.confirmDeepLinkBundle() },
             onDismiss = { homeViewModel.dismissDeepLinkBundle() }
+        )
+    }
+
+    // .mpp file opened from file manager: Add bundle confirmation dialog
+    homeViewModel.pendingMppUri?.let {
+        MppImportDialog(
+            manifest = homeViewModel.pendingMppManifest,
+            fileName = homeViewModel.pendingMppFileName,
+            onConfirm = { homeViewModel.confirmMppImport() },
+            onDismiss = { homeViewModel.dismissMppImport() }
         )
     }
 
@@ -1690,6 +1701,166 @@ fun DeepLinkAddSourceDialog(
                         fontFamily = FontFamily.Monospace,
                         color = LocalDialogSecondaryTextColor.current
                     )
+                }
+            }
+
+            InfoBadge(
+                text = stringResource(R.string.deep_link_add_source_warning),
+                style = InfoBadgeStyle.Warning,
+                icon = Icons.Outlined.Warning,
+                isExpanded = true
+            )
+        }
+    }
+}
+
+/**
+ * Confirmation dialog shown when a .mpp file is opened from a file manager.
+ */
+@Composable
+fun MppImportDialog(
+    manifest: MppManifest?,
+    fileName: String?,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.deep_link_add_source_title),
+        compactPadding = true,
+        footer = {
+            MorpheDialogButtonRow(
+                primaryText = stringResource(R.string.add),
+                onPrimaryClick = onConfirm,
+                primaryIcon = Icons.Outlined.Extension,
+                secondaryText = stringResource(android.R.string.cancel),
+                onSecondaryClick = onDismiss
+            )
+        }
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            // Icon
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier.size(56.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Outlined.FolderZip,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(28.dp)
+                    )
+                }
+            }
+
+            // Message
+            Text(
+                text = stringResource(R.string.deep_link_add_source_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = LocalDialogSecondaryTextColor.current,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Bundle details card
+            Surface(
+                shape = RoundedCornerShape(12.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    // Name (bold title)
+                    val displayName = manifest?.name ?: fileName
+                    if (displayName != null) {
+                        Text(
+                            text = displayName,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = LocalDialogTextColor.current,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    // Description
+                    manifest?.description?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LocalDialogSecondaryTextColor.current,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    // Metadata row: version, author
+                    if (manifest?.version != null || manifest?.author != null) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            manifest.version?.let { version ->
+                                InfoBadge(
+                                    text = "v$version",
+                                    icon = Icons.Outlined.NewReleases,
+                                    style = InfoBadgeStyle.Primary,
+                                    isCompact = true
+                                )
+                            }
+                            manifest.author?.let { author ->
+                                InfoBadge(
+                                    text = author,
+                                    icon = Icons.Outlined.Person,
+                                    style = InfoBadgeStyle.Default,
+                                    isCompact = true
+                                )
+                            }
+                        }
+                    }
+
+                    // Source URL
+                    manifest?.source?.let { source ->
+                        Text(
+                            text = source,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            color = LocalDialogSecondaryTextColor.current,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    // Filename (always shown as secondary info)
+                    if (fileName != null && manifest?.name != null) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Description,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(12.dp)
+                            )
+                            Text(
+                                text = fileName,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontFamily = FontFamily.Monospace,
+                                color = LocalDialogSecondaryTextColor.current,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -197,6 +197,34 @@ class HomeViewModel(
 
     data class DeepLinkBundle(val url: String, val name: String?)
 
+    // .mpp file opened from file manager: pending confirmation dialog
+    var pendingMppUri by mutableStateOf<Uri?>(null)
+    var pendingMppFileName by mutableStateOf<String?>(null)
+    var pendingMppManifest by mutableStateOf<MppManifest?>(null)
+
+    fun setPendingMpp(uri: Uri) {
+        pendingMppUri = uri
+        pendingMppFileName = uri.displayName(contentResolver)
+        pendingMppManifest = null
+        viewModelScope.launch(Dispatchers.IO) {
+            pendingMppManifest = uri.readMppManifest(contentResolver)
+        }
+    }
+
+    fun confirmMppImport() {
+        val uri = pendingMppUri ?: return
+        pendingMppUri = null
+        pendingMppFileName = null
+        pendingMppManifest = null
+        createLocalSource(uri)
+    }
+
+    fun dismissMppImport() {
+        pendingMppUri = null
+        pendingMppFileName = null
+        pendingMppManifest = null
+    }
+
     // Expert mode state
     var showExpertModeDialog by mutableStateOf(false)
     var expertModeSelectedApp by mutableStateOf<SelectedApp?>(null)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/MainViewModel.kt
@@ -1,5 +1,6 @@
 package app.morphe.manager.ui.viewmodel
 
+import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -23,6 +24,13 @@ class MainViewModel(
      * shows a confirmation dialog, then resets the flag to null.
      */
     var pendingDeepLinkSource: DeepLinkSource? by mutableStateOf(null)
+
+    /**
+     * Set by [app.morphe.manager.MainActivity.handleDeepLinkIntent] when the app is opened
+     * by tapping a .mpp file in a file manager. HomeScreen observes this via LaunchedEffect,
+     * shows a confirmation dialog, then resets the flag to null.
+     */
+    var pendingMppUri: Uri? by mutableStateOf(null)
 
     data class DeepLinkSource(val url: String, val name: String?)
 }

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -41,7 +41,7 @@ object KnownApps {
     const val YOUTUBE       = "com.google.android.youtube"
     const val YOUTUBE_MUSIC = "com.google.android.apps.youtube.music"
     const val REDDIT        = "com.reddit.frontpage"
-    const val X_TWITTER     = "com.twitter.android"
+    // const val X_TWITTER     = "com.twitter.android"
 
     // Shared Morphe brand gradient tail
     val GRADIENT_MID = Color(0xFF1E5AA8)

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -124,6 +124,7 @@ object KnownApps {
 const val APK_MIMETYPE  = "application/vnd.android.package-archive"
 const val JSON_MIMETYPE = "application/json"
 const val BIN_MIMETYPE  = "application/octet-stream"
+const val MPP_MIMETYPE  = "application/vnd.ms-project"
 
 val APK_FILE_MIME_TYPES = arrayOf(
     BIN_MIMETYPE,

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -1,9 +1,16 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
 package app.morphe.manager.util
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -11,6 +18,16 @@ import androidx.compose.runtime.remember
 import app.morphe.manager.data.platform.Filesystem
 import org.koin.compose.koinInject
 import java.io.File
+
+/** Parsed metadata from a .mpp patch bundle's META-INF/MANIFEST.MF entry. */
+data class MppManifest(
+    val name: String?,
+    val version: String?,
+    val author: String?,
+    val description: String?,
+    val source: String?,
+    val timestamp: Long?,
+)
 
 /**
  * Convert content:// URI to file path
@@ -37,6 +54,67 @@ fun Uri.toFilePath(): String {
         else -> Uri.decode(this.toString())
     }
 }
+
+/**
+ * Resolves the display name of a URI using [ContentResolver].
+ * For content:// URIs queries the provider via [OpenableColumns.DISPLAY_NAME].
+ * Falls back to the last path segment for file:// URIs or if the provider does not expose a name.
+ */
+fun Uri.displayName(contentResolver: ContentResolver): String? =
+    runCatching {
+        contentResolver.query(this, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                val col = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (col != -1 && cursor.moveToFirst()) cursor.getString(col) else null
+            }
+    }.getOrNull() ?: lastPathSegment
+
+/**
+ * Returns true if the URI refers to a .mpp patch bundle file.
+ * Delegates entirely to [displayName] which already handles both file:// and content://
+ * with a lastPathSegment fallback.
+ */
+fun Uri.hasMppExtension(contentResolver: ContentResolver): Boolean =
+    displayName(contentResolver)?.endsWith(".mpp", ignoreCase = true) == true
+
+
+/**
+ * Reads and parses the META-INF/MANIFEST.MF entry from a .mpp patch bundle URI.
+ * Returns null if the entry is missing, the URI is unreadable, or any IO error occurs.
+ * Values equal to "na" (case-insensitive) are treated as absent.
+ */
+fun Uri.readMppManifest(contentResolver: ContentResolver): MppManifest? =
+    runCatching {
+        contentResolver.openInputStream(this)?.use { stream ->
+            java.util.zip.ZipInputStream(stream).use { zip ->
+                var manifest: MppManifest? = null
+                var entry = zip.nextEntry
+                while (entry != null && manifest == null) {
+                    if (entry.name == "META-INF/MANIFEST.MF") {
+                        val attrs = zip.bufferedReader().readText()
+                            .lineSequence()
+                            .filter { ":" in it }
+                            .associate { line ->
+                                val idx = line.indexOf(':')
+                                line.substring(0, idx).trim() to line.substring(idx + 1).trim()
+                            }
+                        fun attr(key: String) =
+                            attrs[key]?.takeUnless { it.isBlank() || it.equals("na", ignoreCase = true) }
+                        manifest = MppManifest(
+                            name = attr("Name"),
+                            version = attr("Version"),
+                            author = attr("Author"),
+                            description = attr("Description"),
+                            source = attr("Source") ?: attr("Website"),
+                            timestamp = attr("Timestamp")?.toLongOrNull(),
+                        )
+                    }
+                    entry = zip.nextEntry
+                }
+                manifest
+            }
+        }
+    }.getOrNull()
 
 /**
  * Returns true if the device has an activity that can handle ACTION_CREATE_DOCUMENT.


### PR DESCRIPTION
Implements native file association for `.mpp` patch bundle files.
Tapping a `.mpp` file in any file manager now opens Morphe with a confirmation dialog to import it as a local patch source.
___
![Screenshot_2026-04-26-00-58-15-164_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/9920c082-63f0-4abd-92d0-365b2a1091e7)

