### PR TITLE
fix: File picker and export for Android TV

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -8,7 +8,6 @@ package app.morphe.manager.ui.screen
 import android.annotation.SuppressLint
 import android.view.HapticFeedbackConstants
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -18,6 +17,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.manager.PreferencesManager
@@ -109,17 +109,14 @@ fun HomeScreen(
         homeViewModel.onStartQuickPatch = onStartQuickPatch
     }
 
-    // Initialize launchers
-    // GetContent is used instead of OpenDocument so that third-party file managers
-    // appear as available options in Android's picker
-    val openApkPicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
-    ) { uri ->
-        uri?.let { homeViewModel.handleApkSelection(it) }
-    }
+    val openApkPicker = rememberAdaptiveFilePicker(
+        mimeTypes = APK_FILE_MIME_TYPES,
+        chooserTitle = stringResource(R.string.home_select_apk_title)
+    ) { uri -> uri?.let { homeViewModel.handleApkSelection(it) } }
 
-    val openBundlePicker = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
+    val openBundlePicker = rememberAdaptiveFilePicker(
+        mimeTypes = MPP_FILE_MIME_TYPES,
+        chooserTitle = stringResource(R.string.sources_dialog_local_file)
     ) { uri ->
         uri?.let {
             homeViewModel.selectedBundleUri = it
@@ -162,8 +159,8 @@ fun HomeScreen(
     // All dialogs
     HomeDialogs(
         homeViewModel = homeViewModel,
-        storagePickerLauncher = { openApkPicker.launch("*/*") },
-        openBundlePicker = { openBundlePicker.launch("*/*") },
+        storagePickerLauncher = { openApkPicker() },
+        openBundlePicker = { openBundlePicker() },
         patchesItem = patchesSheetItem
     )
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
@@ -47,7 +47,6 @@ import app.morphe.manager.ui.viewmodel.PatcherViewModel
 import app.morphe.manager.ui.viewmodel.SettingsViewModel.Companion.ensureValidEntries
 import app.morphe.manager.util.APK_MIMETYPE
 import app.morphe.manager.util.EventEffect
-import app.morphe.manager.util.canHandleCreateDocument
 import app.morphe.manager.util.tag
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
@@ -458,10 +457,7 @@ fun PatcherScreen(
                         onHomeClick = onBackClick,
                         onSaveClick = {
                             if (!isSaving) {
-                                if (context.canHandleCreateDocument())
-                                    exportApkLauncher.launch(patcherViewModel.exportFileName)
-                                else
-                                    patcherViewModel.exportToDownloads()
+                                exportApkLauncher.launch(patcherViewModel.exportFileName)
                             }
                         },
                         isSaving = isSaving

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -47,9 +47,7 @@ import app.morphe.manager.ui.screen.settings.system.InstallerSelectionDialogCont
 import app.morphe.manager.ui.screen.settings.system.KeystoreCredentialsDialog
 import app.morphe.manager.ui.screen.shared.MorpheDefaults
 import app.morphe.manager.ui.viewmodel.*
-import app.morphe.manager.util.JSON_MIMETYPE
-import app.morphe.manager.util.canHandleCreateDocument
-import app.morphe.manager.util.toast
+import app.morphe.manager.util.*
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -81,6 +79,7 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
+    val isTV = remember { context.isAndroidTv() }
 
     // Pager state for swipeable tabs
     val pagerState = rememberPagerState(
@@ -100,13 +99,15 @@ fun SettingsScreen(
     val showInstallerDialog = remember { mutableStateOf(false) }
     val showChangelogDialog = remember { mutableStateOf(false) }
 
-    // Import launchers
-    val importKeystoreLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
+    // Import pickers - GetContentWithChooser on phones, OpenDocument on Android TV
+    val importKeystoreLauncher = rememberAdaptiveFilePicker(
+        mimeTypes = arrayOf("*/*"),
+        chooserTitle = stringResource(R.string.settings_system_import_keystore)
     ) { uri -> uri?.let { importExportViewModel.startKeystoreImport(it) } }
 
-    val importSettingsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.GetContent()
+    val importSettingsLauncher = rememberAdaptiveFilePicker(
+        mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
+        chooserTitle = stringResource(R.string.settings_system_import_manager_settings)
     ) { uri -> uri?.let { importExportViewModel.importManagerSettings(it) } }
 
     // Export launchers
@@ -119,7 +120,7 @@ fun SettingsScreen(
     ) { uri -> uri?.let { importExportViewModel.exportManagerSettings(it) } }
 
     val exportDebugLogsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("text/plain")
+        contract = ActivityResultContracts.CreateDocument(TEXT_MIMETYPE)
     ) { uri -> uri?.let { importExportViewModel.exportDebugLogs(it) } }
 
     // Show about dialog
@@ -192,19 +193,19 @@ fun SettingsScreen(
                     settingsViewModel = settingsViewModel,
                     onShowInstallerDialog = { showInstallerDialog.value = true },
                     importExportViewModel = importExportViewModel,
-                    onImportKeystore = { importKeystoreLauncher.launch("*/*") },
+                    onImportKeystore = { importKeystoreLauncher() },
                     onExportKeystore = {
-                        if (context.canHandleCreateDocument()) exportKeystoreLauncher.launch("Morphe.keystore")
-                        else importExportViewModel.exportKeystoreToDownloads()
+                        if (isTV) importExportViewModel.exportKeystoreToDownloads()
+                        else exportKeystoreLauncher.launch("Morphe.keystore")
                     },
-                    onImportSettings = { importSettingsLauncher.launch(JSON_MIMETYPE) },
+                    onImportSettings = { importSettingsLauncher() },
                     onExportSettings = {
-                        if (context.canHandleCreateDocument()) exportSettingsLauncher.launch("morphe_manager_settings.json")
-                        else importExportViewModel.exportManagerSettingsToDownloads()
+                        if (isTV) importExportViewModel.exportManagerSettingsToDownloads()
+                        else exportSettingsLauncher.launch("morphe_manager_settings.json")
                     },
                     onExportDebugLogs = {
-                        if (context.canHandleCreateDocument()) exportDebugLogsLauncher.launch(importExportViewModel.debugLogFileName)
-                        else importExportViewModel.exportDebugLogsToDownloads()
+                        if (isTV) importExportViewModel.exportDebugLogsToDownloads()
+                        else exportDebugLogsLauncher.launch(importExportViewModel.debugLogFileName)
                     },
                     onAboutClick = { showAboutDialog.value = true },
                     onChangelogClick = { showChangelogDialog.value = true }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -194,8 +194,12 @@ class ImportExportViewModel(
     fun canExport() = keystoreManager.hasKeystore()
 
     fun exportKeystore(target: Uri) = viewModelScope.launch {
-        keystoreManager.export(contentResolver.openOutputStream(target)!!)
-        app.toast(app.getString(R.string.settings_system_export_keystore_success))
+        uiSafe(app, R.string.settings_system_export_keystore_failed, "Failed to export keystore") {
+            withContext(Dispatchers.IO) {
+                keystoreManager.export(contentResolver.openOutputStream(target)!!)
+            }
+            app.toast(app.getString(R.string.settings_system_export_keystore_success))
+        }
     }
 
     fun importManagerSettings(source: Uri) = viewModelScope.launch {
@@ -404,7 +408,7 @@ class ImportExportViewModel(
     /**
      * Writes the debug log content to [writer]. Returns the logcat exit code.
      * Must be called from within a [Dispatchers.IO] context.
-     * Shared by [exportDebugLogs] (SAF target) and [exportDebugLogsToDownloads] (MediaStore target).
+     * Shared by [exportDebugLogs].
      */
     private suspend fun writeDebugLogContent(writer: BufferedWriter): Int = withContext(Dispatchers.IO) {
         val versionName = runCatching {
@@ -459,8 +463,10 @@ class ImportExportViewModel(
 
     fun exportDebugLogs(target: Uri) = viewModelScope.launch {
         val exitCode = try {
-            contentResolver.openOutputStream(target)!!.bufferedWriter().use { writer ->
-                writeDebugLogContent(writer)
+            withContext(Dispatchers.IO) {
+                contentResolver.openOutputStream(target)!!.bufferedWriter().use { writer ->
+                    writeDebugLogContent(writer)
+                }
             }
         } catch (e: CancellationException) {
             throw e
@@ -479,11 +485,9 @@ class ImportExportViewModel(
 
     /**
      * Opens a writable [OutputStream] to a new file in the public Downloads folder.
-     *
+     * Used as a fallback on Android TV where [android.content.Intent.ACTION_CREATE_DOCUMENT] is unavailable.
      * On API 29+ uses [MediaStore] (no storage permission required).
      * On older versions falls back to [Environment.getExternalStoragePublicDirectory].
-     *
-     * Returns null if the Downloads directory is unavailable.
      */
     private fun openDownloadsOutputStream(fileName: String, mimeType: String): OutputStream? {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -505,12 +509,11 @@ class ImportExportViewModel(
 
     /**
      * Exports the keystore to the Downloads folder.
-     * Used as a fallback on devices without DocumentsUI.
      */
     fun exportKeystoreToDownloads() = viewModelScope.launch {
         uiSafe(app, R.string.settings_system_export_keystore_failed, "Failed to export keystore to Downloads") {
             withContext(Dispatchers.IO) {
-                val stream = openDownloadsOutputStream("Morphe.keystore", "application/octet-stream")
+                val stream = openDownloadsOutputStream("Morphe.keystore", BIN_MIMETYPE)
                     ?: throw IllegalStateException("Cannot open Downloads output stream")
                 stream.use { keystoreManager.export(it) }
             }
@@ -520,14 +523,13 @@ class ImportExportViewModel(
 
     /**
      * Exports manager settings to the Downloads folder.
-     * Used as a fallback on devices without DocumentsUI.
      */
     fun exportManagerSettingsToDownloads() = viewModelScope.launch {
         uiSafe(app, R.string.settings_system_export_manager_settings_fail, "Failed to export settings to Downloads") {
             val snapshot = preferencesManager.exportSettings()
             val bundles = withContext(Dispatchers.IO) { patchBundleRepository.exportCustomBundles() }
             withContext(Dispatchers.IO) {
-                val stream = openDownloadsOutputStream("morphe_manager_settings.json", "application/json")
+                val stream = openDownloadsOutputStream("morphe_manager_settings.json", JSON_MIMETYPE)
                     ?: throw IllegalStateException("Cannot open Downloads output stream")
                 stream.use {
                     json.encodeToStream(
@@ -544,15 +546,12 @@ class ImportExportViewModel(
 
     /**
      * Exports debug logs to the Downloads folder.
-     * Used as a fallback on devices without DocumentsUI.
      */
     fun exportDebugLogsToDownloads() = viewModelScope.launch {
         uiSafe(app, R.string.settings_system_export_debug_logs_export_failed, "Failed to export debug logs to Downloads") {
-            val stream = openDownloadsOutputStream(debugLogFileName, "text/plain")
+            val stream = openDownloadsOutputStream(debugLogFileName, TEXT_MIMETYPE)
                 ?: throw IllegalStateException("Cannot open Downloads output stream")
-            stream.bufferedWriter().use { writer ->
-                writeDebugLogContent(writer)
-            }
+            stream.bufferedWriter().use { writer -> writeDebugLogContent(writer) }
             app.toast(app.getString(R.string.settings_system_export_debug_logs_export_success))
         }
     }

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -124,6 +124,7 @@ object KnownApps {
 const val APK_MIMETYPE  = "application/vnd.android.package-archive"
 const val JSON_MIMETYPE = "application/json"
 const val BIN_MIMETYPE  = "application/octet-stream"
+const val TEXT_MIMETYPE = "text/plain"
 const val MPP_MIMETYPE  = "application/vnd.ms-project"
 
 val APK_FILE_MIME_TYPES = arrayOf(
@@ -147,16 +148,10 @@ val APK_FILE_MIME_TYPES = arrayOf(
 //    "application/vnd.android.apks",
 //    "application/apks",
 )
-val APK_FILE_EXTENSIONS = setOf(
-    "apk",
-    "apkm",
-    "apks",
-    "xapk",
-    "zip"
-)
 
 val MPP_FILE_MIME_TYPES = arrayOf(
     BIN_MIMETYPE,
+    MPP_MIMETYPE,
 //    "application/x-zip-compressed"
     "*/*"
 )

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -6,15 +6,18 @@
 package app.morphe.manager.util
 
 import android.content.ContentResolver
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.app.UiModeManager
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import app.morphe.manager.data.platform.Filesystem
 import org.koin.compose.koinInject
 import java.io.File
@@ -117,16 +120,6 @@ fun Uri.readMppManifest(contentResolver: ContentResolver): MppManifest? =
     }.getOrNull()
 
 /**
- * Returns true if the device has an activity that can handle ACTION_CREATE_DOCUMENT.
- * Android TV and some stripped Android builds ship without DocumentsUI,
- * so CreateDocument contracts silently fail on them.
- */
-fun Context.canHandleCreateDocument(): Boolean {
-    val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply { type = "*/*" }
-    return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null
-}
-
-/**
  * Folder picker launcher with automatic permission handling
  * Only use this for operations that create multiple files/folders
  *
@@ -208,4 +201,64 @@ fun validateOptionPaths(options: Map<Int, Map<String, Map<String, Any?>>>): List
         }
     }
     return failures
+}
+
+/**
+ * [ActivityResultContract] that wraps ACTION_GET_CONTENT in a chooser so that
+ * all installed file managers appear as options - bypassing DocumentsUI which
+ * is the default (and often absent) handler on Android TV.
+ */
+class GetContentWithChooser(private val chooserTitle: String) : ActivityResultContract<Array<String>, Uri?>() {
+    override fun createIntent(context: Context, input: Array<String>): Intent {
+        val getContent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = if (input.size == 1) input[0] else "*/*"
+            if (input.size > 1) putExtra(Intent.EXTRA_MIME_TYPES, input)
+            addCategory(Intent.CATEGORY_OPENABLE)
+        }
+        return Intent.createChooser(getContent, chooserTitle)
+    }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? =
+        if (resultCode == android.app.Activity.RESULT_OK) intent?.data else null
+}
+
+/**
+ * Returns true if the device is an Android TV or Google TV.
+ */
+fun Context.isAndroidTv(): Boolean {
+    val uiModeManager = getSystemService(UiModeManager::class.java)
+    return uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
+}
+
+/**
+ * On Android TV uses [ActivityResultContracts.OpenDocument] which routes through
+ * DocumentsUI and shows registered storage providers (file managers).
+ * On phones/tablets uses [GetContentWithChooser] to show all compatible apps.
+ *
+ * @param mimeTypes MIME types passed to the picker. OpenDocument supports multiple types
+ *   natively; GetContentWithChooser uses the first entry as the ACTION_GET_CONTENT type.
+ */
+@Composable
+fun rememberAdaptiveFilePicker(
+    mimeTypes: Array<String>,
+    chooserTitle: String,
+    onResult: (Uri?) -> Unit,
+): () -> Unit {
+    val context = LocalContext.current
+    val isTV = remember { context.isAndroidTv() }
+
+    val tvLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri -> onResult(uri) }
+
+    val phoneLauncher = rememberLauncherForActivityResult(
+        contract = GetContentWithChooser(chooserTitle)
+    ) { uri -> onResult(uri) }
+
+    return remember(isTV) {
+        {
+            if (isTV) tvLauncher.launch(mimeTypes)
+            else phoneLauncher.launch(mimeTypes)
+        }
+    }
 }

--- a/app/src/main/java/app/morphe/manager/util/Util.kt
+++ b/app/src/main/java/app/morphe/manager/util/Util.kt
@@ -39,6 +39,7 @@ import kotlinx.datetime.format.Padding
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toInstant
 import kotlinx.datetime.toLocalDateTime
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty


### PR DESCRIPTION
- Replace `GetContent` with `GetContentWithChooser` (createChooser wrapper) so installed file managers appear on all devices including Android TV
- Use `OpenDocument` on Android TV, `GetContentWithChooser` on phones/tablets via `rememberAdaptiveFilePicker`
- Add `ToDownloads` fallback for export actions on Android TV where `CreateDocument` is unavailable (`MediaStore.Downloads`)
- Fix `exportKeystore` and `exportDebugLogs` blocking main thread by wrapping IO in `withContext(Dispatchers.IO)`