### PR TITLE
fix: Fix `Patch` button text contrast in `WarningBanner`

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -590,52 +589,50 @@ private fun WarningBanner(
         MaterialTheme.colorScheme.onPrimaryContainer
     }
 
-    CompositionLocalProvider(LocalContentColor provides contentColor) {
-        Column(
-            modifier = modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(12.dp))
-                .background(containerColor)
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(containerColor)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Header with icon
+        Row(
+            modifier = Modifier.wrapContentWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            // Header with icon
-            Row(
-                modifier = Modifier.wrapContentWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = contentColor,
-                    modifier = Modifier.size(20.dp)
-                )
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = contentColor,
-                    textAlign = TextAlign.Center
-                )
-            }
-
-            // Description
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(20.dp)
+            )
             Text(
-                text = description,
-                style = MaterialTheme.typography.bodySmall,
-                color = contentColor.copy(alpha = 0.9f),
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = contentColor,
                 textAlign = TextAlign.Center
             )
-
-            // Action button
-            PrimaryActionButton(
-                action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
-                accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
-                modifier = Modifier.fillMaxWidth()
-            )
         }
+
+        // Description
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = contentColor.copy(alpha = 0.9f),
+            textAlign = TextAlign.Center
+        )
+
+        // Action button
+        PrimaryActionButton(
+            action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
+            accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            modifier = Modifier.fillMaxWidth()
+        )
     }
 }
 
@@ -1291,15 +1288,7 @@ private fun PrimaryActionButton(
     } else {
         accentColor.copy(alpha = 0.18f)
     }
-    val parentContentColor = LocalContentColor.current
-    val contentColor = if (isExtremeAccent) {
-        MaterialTheme.colorScheme.onSurfaceVariant
-    } else {
-        // Use the parents content color when available inside WarningBanner which
-        // sets contentColor to onPrimaryContainer/onErrorContainer
-        // This paints proper contrast for custom accent colors
-        parentContentColor
-    }
+    val contentColor = MaterialTheme.colorScheme.onSurface
     Surface(
         onClick = action.onClick,
         enabled = action.enabled && !action.isLoading,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -329,6 +330,7 @@ fun InstalledAppInfoDialog(
                                     appliedPatches = appliedPatches,
                                     bundlesUsedSummary = bundlesUsedSummary,
                                     onShowPatches = { showAppliedPatchesDialog.value = true },
+                                    accentColor = appAccentColor
                                 )
                             }
                         }
@@ -360,6 +362,7 @@ fun InstalledAppInfoDialog(
                                     onClick = {
                                         onTriggerPatchFlow(installedApp.originalPackageName)
                                     },
+                                    accentColor = appAccentColor,
                                     isError = true
                                 )
                             }
@@ -379,6 +382,7 @@ fun InstalledAppInfoDialog(
                                     onClick = {
                                         onTriggerPatchFlow(installedApp.originalPackageName)
                                     },
+                                    accentColor = appAccentColor,
                                     isError = false
                                 )
                             }
@@ -460,6 +464,7 @@ fun InstalledAppInfoDialog(
                                             onClick = {
                                                 onTriggerPatchFlow(installedApp.originalPackageName)
                                             },
+                                            accentColor = appAccentColor,
                                             isError = true,
                                             modifier = Modifier.padding(horizontal = 20.dp)
                                         )
@@ -483,6 +488,7 @@ fun InstalledAppInfoDialog(
                                             onClick = {
                                                 onTriggerPatchFlow(installedApp.originalPackageName)
                                             },
+                                            accentColor = appAccentColor,
                                             isError = false,
                                             modifier = Modifier.padding(horizontal = 20.dp)
                                         )
@@ -502,6 +508,7 @@ fun InstalledAppInfoDialog(
                                     appliedPatches = appliedPatches,
                                     bundlesUsedSummary = bundlesUsedSummary,
                                     onShowPatches = { showAppliedPatchesDialog.value = true },
+                                    accentColor = appAccentColor
                                 )
                             }
                         }
@@ -574,19 +581,22 @@ private fun WarningBanner(
     buttonText: String,
     buttonIcon: ImageVector,
     onClick: () -> Unit,
+    accentColor: Color,
     modifier: Modifier = Modifier,
     isError: Boolean = false
 ) {
-    val containerColor = if (isError) {
-        MaterialTheme.colorScheme.errorContainer
+    val baseColor = if (isError) MaterialTheme.colorScheme.error else accentColor
+    val isExtremeAccent = baseColor.luminance() !in 0.04f..0.92f
+    val containerColor = if (isExtremeAccent) {
+        MaterialTheme.colorScheme.surfaceVariant
     } else {
-        MaterialTheme.colorScheme.primaryContainer
+        baseColor.copy(alpha = 0.15f)
     }
-
-    val contentColor = if (isError) {
-        MaterialTheme.colorScheme.onErrorContainer
+    val contentColor = if (isExtremeAccent) {
+        MaterialTheme.colorScheme.onSurfaceVariant
     } else {
-        MaterialTheme.colorScheme.onPrimaryContainer
+        if (baseColor.compositeOver(MaterialTheme.colorScheme.surface, 0.15f)
+            .requiresLightContent()) Color.White else Color.Black
     }
 
     Column(
@@ -630,7 +640,8 @@ private fun WarningBanner(
         // Action button
         PrimaryActionButton(
             action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
-            accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+            accentColor = baseColor,
+            contentColorOverride = contentColor,
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -887,6 +898,7 @@ private fun InfoSection(
     appliedPatches: Map<Int, Set<String>>?,
     bundlesUsedSummary: String,
     onShowPatches: () -> Unit,
+    accentColor: Color,
     modifier: Modifier = Modifier
 ) {
     val totalPatches = appliedPatches?.values?.sumOf { it.size } ?: 0
@@ -939,6 +951,7 @@ private fun InfoSection(
                 icon = Icons.Outlined.DoneAll,
                 label = stringResource(R.string.home_app_info_applied_patches),
                 value = pluralStringResource(R.plurals.patch_count, totalPatches, totalPatches),
+                accentColor = accentColor,
                 onAction = onShowPatches
             )
         }
@@ -996,6 +1009,7 @@ private fun InfoRowWithAction(
     icon: ImageVector,
     label: String,
     value: String,
+    accentColor: Color,
     onAction: () -> Unit,
 ) {
     Row(
@@ -1030,7 +1044,12 @@ private fun InfoRowWithAction(
         ActionPillButton(
             onClick = onAction,
             icon = Icons.AutoMirrored.Outlined.List,
-            contentDescription = stringResource(R.string.view)
+            contentDescription = stringResource(R.string.view),
+            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                containerColor = accentColor.copy(alpha = 0.18f),
+                contentColor = if (accentColor.compositeOver(MaterialTheme.colorScheme.surface, 0.18f)
+                    .requiresLightContent()) Color.White else Color.Black
+            )
         )
     }
 }
@@ -1279,7 +1298,8 @@ private fun LoadingOrIcon(isLoading: Boolean, action: ActionItem, tint: Color) {
 private fun PrimaryActionButton(
     action: ActionItem,
     accentColor: Color,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentColorOverride: Color? = null
 ) {
     // Match the header background level: tinted surface instead of full accent
     val isExtremeAccent = accentColor.luminance() !in 0.04f..0.92f
@@ -1288,7 +1308,12 @@ private fun PrimaryActionButton(
     } else {
         accentColor.copy(alpha = 0.18f)
     }
-    val contentColor = MaterialTheme.colorScheme.onSurface
+    val contentColor = contentColorOverride ?: if (isExtremeAccent) {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    } else {
+        if (accentColor.compositeOver(MaterialTheme.colorScheme.surface, 0.18f)
+            .requiresLightContent()) Color.White else Color.Black
+    }
     Surface(
         onClick = action.onClick,
         enabled = action.enabled && !action.isLoading,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -589,50 +589,52 @@ private fun WarningBanner(
         MaterialTheme.colorScheme.onPrimaryContainer
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .background(containerColor)
-            .padding(12.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        // Header with icon
-        Row(
-            modifier = Modifier.wrapContentWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(containerColor)
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = contentColor,
-                modifier = Modifier.size(20.dp)
-            )
+            // Header with icon
+            Row(
+                modifier = Modifier.wrapContentWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.size(20.dp)
+                )
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = contentColor,
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            // Description
             Text(
-                text = title,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = contentColor,
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = contentColor.copy(alpha = 0.9f),
                 textAlign = TextAlign.Center
             )
+
+            // Action button
+            PrimaryActionButton(
+                action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
+                accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
-
-        // Description
-        Text(
-            text = description,
-            style = MaterialTheme.typography.bodySmall,
-            color = contentColor.copy(alpha = 0.9f),
-            textAlign = TextAlign.Center
-        )
-
-        // Action button
-        PrimaryActionButton(
-            action = ActionItem(text = buttonText, icon = buttonIcon, onClick = onClick),
-            accentColor = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
-            modifier = Modifier.fillMaxWidth()
-        )
     }
 }
 
@@ -1288,7 +1290,15 @@ private fun PrimaryActionButton(
     } else {
         accentColor.copy(alpha = 0.18f)
     }
-    val contentColor = MaterialTheme.colorScheme.onSurface
+    val parentContentColor = LocalContentColor.current
+    val contentColor = if (isExtremeAccent) {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    } else {
+        // Use the parents content color when available inside WarningBanner which
+        // sets contentColor to onPrimaryContainer/onErrorContainer
+        // This paints proper contrast for custom accent colors
+        parentContentColor
+    }
     Surface(
         onClick = action.onClick,
         enabled = action.enabled && !action.isLoading,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -150,7 +151,8 @@ private fun DialogContent(
     if (noPadding) {
         CompositionLocalProvider(
             LocalDialogTextColor provides textColor,
-            LocalDialogSecondaryTextColor provides secondaryTextColor
+            LocalDialogSecondaryTextColor provides secondaryTextColor,
+            LocalContentColor provides textColor
         ) {
             Column(
                 modifier = Modifier
@@ -218,7 +220,8 @@ private fun DialogContent(
             // Content area with conditional scrolling
             CompositionLocalProvider(
                 LocalDialogTextColor provides textColor,
-                LocalDialogSecondaryTextColor provides secondaryTextColor
+                LocalDialogSecondaryTextColor provides secondaryTextColor,
+                LocalContentColor provides textColor
             ) {
                 if (scrollable) {
                     // Automatic scroll for regular content
@@ -249,7 +252,8 @@ private fun DialogContent(
                 ) {
                     CompositionLocalProvider(
                         LocalDialogTextColor provides textColor,
-                        LocalDialogSecondaryTextColor provides secondaryTextColor
+                        LocalDialogSecondaryTextColor provides secondaryTextColor,
+                        LocalContentColor provides textColor
                     ) {
                         footer()
                     }

--- a/app/src/main/java/app/morphe/manager/util/ColorUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/ColorUtils.kt
@@ -1,23 +1,17 @@
 package app.morphe.manager.util
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.toColorInt
 
 /**
- * Determine if a color represents a dark background
+ * Determine if a color represents a dark background.
  */
 fun Color.isDarkBackground(): Boolean = luminance() < 0.5f
 
 /**
- * Get luminance from a Color
- */
-fun Color.luminance(): Float {
-    return 0.299f * red + 0.587f * green + 0.114f * blue
-}
-
-/**
- * Lighten a color by mixing with white
+ * Lighten a color by mixing with white.
  */
 fun Color.lighten(factor: Float): Color {
     return Color(
@@ -29,7 +23,7 @@ fun Color.lighten(factor: Float): Color {
 }
 
 /**
- * Darken a color by mixing with black
+ * Darken a color by mixing with black.
  */
 fun Color.darken(factor: Float): Color {
     return Color(
@@ -76,7 +70,7 @@ fun String?.toColorOrNull(): Color? {
 }
 
 /**
- * Parse color string to RGB float values (0-1 range)
+ * Parse color string to RGB float values (0-1 range).
  */
 fun parseColorToRgb(color: String): Triple<Float, Float, Float> {
     return color.toColorOrNull()?.let {
@@ -85,8 +79,8 @@ fun parseColorToRgb(color: String): Triple<Float, Float, Float> {
 }
 
 /**
- * Parse hex color string to RGB float values
- * Supports both #RRGGBB and #AARRGGBB formats
+ * Parse hex color string to RGB float values.
+ * Supports both #RRGGBB and #AARRGGBB formats.
  */
 fun parseHexToRgb(hex: String): Triple<Float, Float, Float>? {
     return hex.toColorOrNull()?.let {
@@ -95,7 +89,7 @@ fun parseHexToRgb(hex: String): Triple<Float, Float, Float>? {
 }
 
 /**
- * Convert RGB float values to hex string
+ * Convert RGB float values to hex string.
  */
 fun rgbToHex(r: Float, g: Float, b: Float): String {
     return Color(r, g, b).toHexString(includeAlpha = false)

--- a/app/src/main/java/app/morphe/manager/util/ColorUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/ColorUtils.kt
@@ -60,6 +60,21 @@ fun Color.ensureContrast(
     else lighten((minLuminanceDiff - diff + 0.05f).coerceIn(0f, 0.8f))
 }
 
+/**
+ * Composites this color at [alpha] over [background] and returns the opaque result.
+ */
+fun Color.compositeOver(background: Color, alpha: Float = this.alpha): Color = Color(
+    red   = background.red   * (1f - alpha) + red   * alpha,
+    green = background.green * (1f - alpha) + green * alpha,
+    blue  = background.blue  * (1f - alpha) + blue  * alpha,
+)
+
+/**
+ * Returns true if this color, when used as a background, requires light (white) content for contrast.
+ * Uses WCAG relative luminance threshold.
+ */
+fun Color.requiresLightContent(): Boolean = luminance() <= 0.179f
+
 fun String?.toColorOrNull(): Color? {
     val value = this?.trim().orEmpty()
     if (value.isEmpty()) return null


### PR DESCRIPTION
Fixes #550

Banner and action button colors now derive from `appAccentColor` using WCAG-based compositing (`compositeOver` + `requiresLightContent` added to `ColorUtils`) instead of hardcoded `onSurface`. `MorpheDialog` propagates `LocalContentColor` for correct inheritance downstream.