### PR TITLE
feat: Add "Use installed APK" button to APK availability dialog

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -844,11 +844,7 @@ class PatcherViewModel(
                         } finally {
                             withContext(Dispatchers.Main) {
                                 // Delete temporary input file after saving
-                                if (input.selectedApp is SelectedApp.Local && input.selectedApp.temporary) {
-                                    inputFile?.takeIf { it.exists() }?.delete()
-                                    inputFile = null
-                                    updateSplitStepRequirement(null)
-                                }
+                                cleanupTemporaryInput()
                                 refreshExportMetadata()
                                 _patcherSucceeded.value = true
                             }
@@ -1024,15 +1020,18 @@ class PatcherViewModel(
         patcherWorkerId?.uuid?.let(workManager::cancelWorkById)
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        patcherWorkerId?.uuid?.let(workManager::cancelWorkById)
-
+    private fun cleanupTemporaryInput() {
         if (input.selectedApp is SelectedApp.Local && input.selectedApp.temporary) {
             inputFile?.takeIf { it.exists() }?.delete()
             inputFile = null
             updateSplitStepRequirement(null)
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        patcherWorkerId?.uuid?.let(workManager::cancelWorkById)
+        cleanupTemporaryInput()
 
         // Clean up the installer temp directory (contains output.apk and any intermediate files).
         // This covers the case where the user navigates away before installing/exporting,


### PR DESCRIPTION
### What's new

Added `Use installed APK` button in the APK selection dialog

When patching an app that is already installed on device, Morphe now offers a shortcut button - `Use installed APK (vX.Y.Z)` - instead of requiring  to manually locate and pick the file. Tapping it copies the installed APK to a temporary location and starts patching
automatically.

### How it works:
- The button is available in expert mode only and appears when the installed app version is compatible with the selected patch bundle (respects the bundle's `compatibleVersions` field; universal patches always show it)
- If the installed app is already patched by Morphe (detected via certificate fingerprint), the button is hidden to avoid re-patching an already-patched build
- If a previously saved original APK of the same version already exists, only one button is shown to avoid duplicates
- For root users, the "original APK required" warning in the dialog is suppressed when the app is already installed, since root mount patching doesn't require re-installation
- The download instructions dialog also hides the "install the original first" step for root users when the app is already present