### PR TITLE
feat: Open expert dialog when APK shared from file manager

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,6 +93,23 @@
                 <data android:mimeType="application/vnd.ms-project" />
             </intent-filter>
 
+            <!-- Receive APK-family files shared via system share sheet (Expert mode) -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/vnd.android.package-archive" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/x-apkm" />
+                <data android:mimeType="application/x-apks" />
+                <data android:mimeType="application/x-xapk" />
+                <data android:mimeType="application/xapk" />
+                <data android:mimeType="application/vnd.android.xapk" />
+                <data android:mimeType="application/vnd.android.apkm" />
+                <data android:mimeType="application/apkm" />
+                <data android:mimeType="application/vnd.android.apks" />
+                <data android:mimeType="application/apks" />
+            </intent-filter>
+
             <!-- Deep link: App Links (https://morphe.software/add-source?github=...) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/app/morphe/manager/MainActivity.kt
+++ b/app/src/main/java/app/morphe/manager/MainActivity.kt
@@ -2,6 +2,7 @@ package app.morphe.manager
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
@@ -44,10 +45,7 @@ import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.MainViewModel
 import app.morphe.manager.ui.viewmodel.PatcherViewModel
 import app.morphe.manager.ui.viewmodel.ThemeSettingsViewModel
-import app.morphe.manager.util.UpdateNotificationManager
-import app.morphe.manager.util.hasMppExtension
-import app.morphe.manager.util.parseLocaleCode
-import app.morphe.manager.util.readLanguageFromPrefs
+import app.morphe.manager.util.*
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -123,6 +121,20 @@ class MainActivity : AppCompatActivity() {
      * Only GitHub and GitLab URLs are accepted for safety.
      */
     private fun handleDeepLinkIntent(intent: Intent?, vm: MainViewModel) {
+        // Handle APK-family file shared via system share sheet (.apk/.apks/.xapk/.apkm).
+        if (intent?.action == Intent.ACTION_SEND) {
+            val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                intent.getParcelableExtra(Intent.EXTRA_STREAM)
+            }
+            if (uri != null && uri.hasApkExtension(contentResolver)) {
+                vm.pendingExternalApkUri = uri
+            }
+            return
+        }
+
         val data = intent?.data ?: return
 
         // Handle .mpp file open from file manager
@@ -240,6 +252,14 @@ private fun MorpheManager(vm: MainViewModel) {
                     vm.pendingMppUri?.let { uri ->
                         homeViewModel.setPendingMpp(uri)
                         vm.pendingMppUri = null
+                    }
+                }
+
+                // Handle .apk file shared via share sheet
+                LaunchedEffect(vm.pendingExternalApkUri) {
+                    vm.pendingExternalApkUri?.let { uri ->
+                        vm.pendingExternalApkUri = null
+                        homeViewModel.handleExternalApkUri(uri)
                     }
                 }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1628,6 +1628,26 @@ class HomeViewModel(
     }
 
     /**
+     * Called when an APK is shared to Morphe via the system share sheet.
+     * Shows a toast and returns early if expert mode is disabled.
+     * Otherwise, waits until [installedAppsLoading] is false before triggering [handleApkSelection].
+     */
+    fun handleExternalApkUri(uri: Uri) {
+        viewModelScope.launch {
+            if (!isExpertMode()) {
+                app.toast(app.getString(R.string.home_external_apk_expert_mode_required))
+                return@launch
+            }
+            // Wait for patches to be ready. Cap at 30 s to avoid hanging forever when
+            // no patch sources are configured (installedAppsLoading never clears in that case)
+            withTimeoutOrNull(30_000L) {
+                snapshotFlow { installedAppsLoading }.first { !it }
+            }
+            handleApkSelection(uri)
+        }
+    }
+
+    /**
      * Handle APK file selection.
      */
     fun handleApkSelection(uri: Uri?) {

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/MainViewModel.kt
@@ -32,5 +32,13 @@ class MainViewModel(
      */
     var pendingMppUri: Uri? by mutableStateOf(null)
 
+    /**
+     * Set by [app.morphe.manager.MainActivity.handleDeepLinkIntent] when an APK-family file
+     * is shared to Morphe via the system share sheet.
+     * HomeScreen observes this via LaunchedEffect, triggers
+     * [app.morphe.manager.ui.viewmodel.HomeViewModel.handleExternalApkUri], then resets to null.
+     */
+    var pendingExternalApkUri: Uri? by mutableStateOf(null)
+
     data class DeepLinkSource(val url: String, val name: String?)
 }

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -160,3 +160,6 @@ val MPP_FILE_MIME_TYPES = arrayOf(
 //    "application/x-zip-compressed"
     "*/*"
 )
+
+/** File extensions recognized as APK-family archives that Morphe can patch. */
+val APK_EXTENSIONS = setOf("apk", "apks", "xapk", "apkm")

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -84,6 +84,13 @@ fun Uri.displayName(contentResolver: ContentResolver): String? =
 fun Uri.hasMppExtension(contentResolver: ContentResolver): Boolean =
     displayName(contentResolver)?.endsWith(".mpp", ignoreCase = true) == true
 
+/**
+ * Returns true if the URI refers to an APK-family file.
+ * Used to filter generic octet-stream shares down to only recognized APK archives.
+ */
+fun Uri.hasApkExtension(contentResolver: ContentResolver): Boolean =
+    displayName(contentResolver)?.substringAfterLast('.', "")?.lowercase() in APK_EXTENSIONS
+
 
 /**
  * Reads and parses the META-INF/MANIFEST.MF entry from a .mpp patch bundle URI.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="home_invalid_apk_unreadable">Could not read the file. Check that \'External Storage\' is not battery restricted</string>
     <string name="home_invalid_apk_not_an_apk">The selected file is not a valid APK</string>
     <string name="home_invalid_apk_io_error">Failed to open the file. Please try again</string>
+    <string name="home_external_apk_expert_mode_required">This feature is only available in Expert mode</string>
 
     <!-- Home Screen - Dialog 4: Expert Mode Dialog -->
     <string name="expert_mode_title">Expert mode</string>


### PR DESCRIPTION
## Changes

 - Adds support for sharing APK-family files (_.apk, .apks, .xapk, .apkm_) directly to `Morphe` via the system share sheet.
 - When `Expert mode` is enabled, `Morphe` waits for patch sources to finish loading, then automatically opens the `Expert mode` dialog pre-loaded with the shared file - ready to select patches and proceed to patching.
 - If `Expert mode` is disabled, a toast is shown prompting the user to enable it.

### How to use
 - Long-press any APK file in your file manager → `Share` → `Morphe`.