### PR TITLE
feat: add settings screen back button

### DIFF
--- a/app/src/main/java/app/morphe/manager/MainActivity.kt
+++ b/app/src/main/java/app/morphe/manager/MainActivity.kt
@@ -304,7 +304,10 @@ private fun MorpheManager(vm: MainViewModel) {
             }
 
             composable<Settings> {
-                SettingsScreen(homeViewModel = homeViewModel)
+                SettingsScreen(
+                    homeViewModel = homeViewModel,
+                    onBackClick = { navController.popBackStack() }
+                )
             }
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -69,6 +71,7 @@ private enum class SettingsTab(
 @Composable
 fun SettingsScreen(
     homeViewModel: HomeViewModel,
+    onBackClick: () -> Unit,
     themeViewModel: ThemeSettingsViewModel = koinViewModel(),
     importExportViewModel: ImportExportViewModel = koinViewModel(),
     patchOptionsViewModel: PatchOptionsViewModel = koinViewModel(),
@@ -164,6 +167,8 @@ fun SettingsScreen(
             .fillMaxSize()
             .statusBarsPadding()
     ) {
+        SettingsHeader(onBackClick = onBackClick)
+
         // Content area
         HorizontalPager(
             state = pagerState,
@@ -218,6 +223,40 @@ fun SettingsScreen(
                     pagerState.animateScrollToPage(tab.ordinal)
                 }
             }
+        )
+    }
+}
+
+@Composable
+private fun SettingsHeader(
+    onBackClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(
+            onClick = onBackClick,
+            modifier = Modifier.size(48.dp)
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                contentDescription = stringResource(R.string.back)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = stringResource(R.string.settings),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onBackground,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -718,6 +718,7 @@ The image dimensions must be as follows:
     <string name="patches">Patches</string>
     <string name="home">Home</string>
     <string name="settings">Settings</string>
+    <string name="back">Back</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="all">All</string>


### PR DESCRIPTION
## Summary

Adds a visible back button to the settings screen.

This gives users a clear way to return from settings without relying only on system gestures or navigation buttons, improving accessibility and discoverability.

Closes #396.

## Testing

* Ran `git diff --check`
* Confirmed the only `SettingsScreen` call site is updated
* Verified there is no existing reusable generic back/navigation string
* Verified `SettingsScreen` did not already have a top app bar/header
* Tried `.\gradlew.bat :app:compileDebugKotlin`, but local Android SDK configuration is missing:
  `SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or local.properties.`
