### PR TITLE
feat: Add monochrome adaptive icon generation

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -19,7 +19,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.*
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.RestartAlt
+import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,7 +39,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -112,9 +114,8 @@ private object AdaptiveIconConfig {
     const val SNAP_GUIDE_STROKE_WIDTH = 1.5f
     const val SNAP_GUIDE_ALPHA = 0.6f
 
-    // Default background color and alpha
+    // Default background color
     const val DEFAULT_BACKGROUND_COLOR = "#B3E5FC"
-    const val DEFAULT_BACKGROUND_ALPHA = 1f
 
     // Preview sizes
     val PREVIEW_SIZE = 130.dp
@@ -146,7 +147,6 @@ fun AdaptiveIconCreatorDialog(
     var foregroundUri by remember { mutableStateOf<Uri?>(null) }
     var foregroundBitmap by remember { mutableStateOf<Bitmap?>(null) }
     var backgroundColor by remember { mutableStateOf(AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR) }
-    var backgroundAlpha by remember { mutableFloatStateOf(AdaptiveIconConfig.DEFAULT_BACKGROUND_ALPHA) }
     val showColorPicker = remember { mutableStateOf(false) }
     val showInfoDialog = remember { mutableStateOf(false) }
 
@@ -198,7 +198,6 @@ fun AdaptiveIconCreatorDialog(
                     packageName = packageName,
                     foregroundBitmap = foregroundBitmap!!,
                     backgroundColor = backgroundColor,
-                    backgroundAlpha = backgroundAlpha,
                     scale = scale,
                     offsetX = offsetX,
                     offsetY = offsetY,
@@ -289,7 +288,6 @@ fun AdaptiveIconCreatorDialog(
                         AdaptiveIconPreview(
                             foregroundBitmap = foregroundBitmap,
                             backgroundColor = backgroundColor,
-                            backgroundAlpha = backgroundAlpha,
                             scale = scale,
                             offsetX = offsetX,
                             offsetY = offsetY,
@@ -512,9 +510,7 @@ fun AdaptiveIconCreatorDialog(
                             onClick = { showColorPicker.value = true },
                             modifier = Modifier.size(36.dp),
                             shape = CircleShape,
-                            color = parseColorToRgb(backgroundColor).let { (r, g, b) ->
-                                Color(r, g, b, backgroundAlpha)
-                            },
+                            color = parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) },
                             border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
                         ) {}
                         Text(
@@ -522,37 +518,6 @@ fun AdaptiveIconCreatorDialog(
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Medium,
                             color = LocalDialogTextColor.current
-                        )
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Opacity,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = LocalDialogSecondaryTextColor.current
-                        )
-                        Slider(
-                            value = backgroundAlpha,
-                            onValueChange = { backgroundAlpha = it },
-                            valueRange = 0f..1f,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Icon(
-                            imageVector = Icons.Outlined.Opacity,
-                            contentDescription = null,
-                            modifier = Modifier.size(22.dp),
-                            tint = LocalDialogSecondaryTextColor.current
-                        )
-                        Text(
-                            text = "${(backgroundAlpha * 100).toInt()}%",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = LocalDialogSecondaryTextColor.current,
-                            modifier = Modifier.width(32.dp),
-                            textAlign = TextAlign.End
                         )
                     }
                 }
@@ -629,7 +594,6 @@ fun AdaptiveIconCreatorDialog(
 private fun AdaptiveIconPreview(
     foregroundBitmap: Bitmap?,
     backgroundColor: String,
-    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
@@ -651,9 +615,7 @@ private fun AdaptiveIconPreview(
             .size(AdaptiveIconConfig.PREVIEW_SIZE)
             .clip(RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS))
             .background(
-                parseColorToRgb(backgroundColor).let { (r, g, b) ->
-                    Color(r, g, b, backgroundAlpha)
-                }
+                parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) }
             )
             .border(2.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS)),
         contentAlignment = Alignment.Center
@@ -971,7 +933,6 @@ private suspend fun createAdaptiveIcons(
     packageName: String,
     foregroundBitmap: Bitmap,
     backgroundColor: String,
-    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
@@ -1003,7 +964,6 @@ private suspend fun createAdaptiveIcons(
                 densityConfig = densityConfig,
                 foregroundBitmap = foregroundBitmap,
                 backgroundColor = backgroundColor,
-                backgroundAlpha = backgroundAlpha,
                 scale = scale,
                 offsetX = offsetX,
                 offsetY = offsetY,
@@ -1087,7 +1047,6 @@ private fun createIconsForDensity(
     densityConfig: AdaptiveIconConfig.DensityConfig,
     foregroundBitmap: Bitmap,
     backgroundColor: String,
-    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
@@ -1096,13 +1055,12 @@ private fun createIconsForDensity(
     val targetSize = densityConfig.size
     val mipmapDocDir = iconsDocDir.getOrCreateDir(densityConfig.folderName) ?: return
 
-    // Background bitmap (solid color with alpha support)
+    // Background bitmap (solid color)
     val backgroundBitmap = createBitmap(targetSize, targetSize)
     val canvas = Canvas(backgroundBitmap)
     val rgb = parseColorToRgb(backgroundColor)
     val paint = Paint().apply {
-        color = android.graphics.Color.argb(
-            (backgroundAlpha * 255).toInt(),
+        color = android.graphics.Color.rgb(
             (rgb.first * 255).toInt(),
             (rgb.second * 255).toInt(),
             (rgb.third * 255).toInt()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -382,7 +382,6 @@ fun AdaptiveIconCreatorDialog(
                             .fillMaxWidth()
                             .padding(horizontal = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Image,
@@ -390,6 +389,7 @@ fun AdaptiveIconCreatorDialog(
                             modifier = Modifier.size(14.dp),
                             tint = LocalDialogSecondaryTextColor.current
                         )
+                        Spacer(Modifier.width(8.dp))
                         Slider(
                             value = scale,
                             onValueChange = {
@@ -401,27 +401,30 @@ fun AdaptiveIconCreatorDialog(
                             valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
                             modifier = Modifier.weight(1f)
                         )
+                        Spacer(Modifier.width(8.dp))
                         Icon(
                             imageVector = Icons.Outlined.Image,
                             contentDescription = null,
                             modifier = Modifier.size(22.dp),
                             tint = LocalDialogSecondaryTextColor.current
                         )
+                        // Spacer inside AnimatedVisibility so the gap also animates away
                         AnimatedVisibility(
-                            visible = scale != 1f || offsetX != 0f || offsetY != 0f,
-                            enter = MorpheAnimations.expandFadeEnter,
-                            exit = MorpheAnimations.shrinkFadeExit
+                            visible = scale != 1f || offsetX != 0f || offsetY != 0f
                         ) {
-                            IconButton(
-                                onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.RestartAlt,
-                                    contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                    modifier = Modifier.size(24.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                            Row {
+                                Spacer(Modifier.width(8.dp))
+                                IconButton(
+                                    onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
+                                    modifier = Modifier.size(40.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.RestartAlt,
+                                        contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                        modifier = Modifier.size(24.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     }
@@ -451,7 +454,6 @@ fun AdaptiveIconCreatorDialog(
                             .fillMaxWidth()
                             .padding(horizontal = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Image,
@@ -459,6 +461,7 @@ fun AdaptiveIconCreatorDialog(
                             modifier = Modifier.size(14.dp),
                             tint = LocalDialogSecondaryTextColor.current
                         )
+                        Spacer(Modifier.width(8.dp))
                         Slider(
                             value = notificationScale,
                             onValueChange = {
@@ -470,27 +473,30 @@ fun AdaptiveIconCreatorDialog(
                             valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_NOTIFICATION_SCALE,
                             modifier = Modifier.weight(1f)
                         )
+                        Spacer(Modifier.width(8.dp))
                         Icon(
                             imageVector = Icons.Outlined.Image,
                             contentDescription = null,
                             modifier = Modifier.size(22.dp),
                             tint = LocalDialogSecondaryTextColor.current
                         )
+                        // Spacer inside AnimatedVisibility so the gap also animates away
                         AnimatedVisibility(
-                            visible = notificationScale != 1f,
-                            enter = MorpheAnimations.expandFadeEnter,
-                            exit = MorpheAnimations.shrinkFadeExit
+                            visible = notificationScale != 1f
                         ) {
-                            IconButton(
-                                onClick = { notificationScale = 1f },
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.RestartAlt,
-                                    contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                    modifier = Modifier.size(24.dp),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                            Row {
+                                Spacer(Modifier.width(8.dp))
+                                IconButton(
+                                    onClick = { notificationScale = 1f },
+                                    modifier = Modifier.size(40.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.RestartAlt,
+                                        contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                        modifier = Modifier.size(24.dp),
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -116,8 +116,8 @@ private object AdaptiveIconConfig {
     const val SNAP_GUIDE_ALPHA = 0.6f
 
     // Default background colors per system theme
-    const val DEFAULT_BACKGROUND_COLOR_LIGHT = "#E3F2FD"
-    const val DEFAULT_BACKGROUND_COLOR_DARK = "#1565C0"
+    const val DEFAULT_BACKGROUND_COLOR_LIGHT = "#9E9E9E"
+    const val DEFAULT_BACKGROUND_COLOR_DARK = "#FFFFFF"
 
     // Preview sizes
     val PREVIEW_SIZE = 150.dp

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -101,7 +101,7 @@ private object AdaptiveIconConfig {
     const val MIN_SCALE = 0.5f
     const val MAX_SCALE = 3.0f
     // Notification icon must not exceed the status bar slot boundary
-    const val MAX_NOTIFICATION_SCALE = 1f
+    const val MAX_NOTIFICATION_SCALE = 2.0f
     const val MAX_OFFSET = 200f
 
     // Snap to center thresholds (in pixels)
@@ -328,6 +328,28 @@ fun AdaptiveIconCreatorDialog(
                     }
                 }
 
+                // Safe zone legend
+                val legendColor = MaterialTheme.colorScheme.onSurface
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 36.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
+                        isDashed = false,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_inner)
+                    )
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
+                        isDashed = true,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_outer)
+                    )
+                }
+
                 // Adaptive scale slider
                 if (foregroundBitmap != null) {
                     Row(
@@ -378,28 +400,6 @@ fun AdaptiveIconCreatorDialog(
                             }
                         }
                     }
-                }
-
-                // Safe zone legend
-                val legendColor = MaterialTheme.colorScheme.onSurface
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 36.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    SafeZoneLegendItem(
-                        baseColor = legendColor,
-                        alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
-                        isDashed = false,
-                        text = stringResource(R.string.adaptive_icon_safe_zone_inner)
-                    )
-                    SafeZoneLegendItem(
-                        baseColor = legendColor,
-                        alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
-                        isDashed = true,
-                        text = stringResource(R.string.adaptive_icon_safe_zone_outer)
-                    )
                 }
 
                 // 3. Status bar notification preview, always visible

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -18,13 +18,7 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.BatteryFull
-import androidx.compose.material.icons.outlined.Image
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material.icons.outlined.RestartAlt
-import androidx.compose.material.icons.outlined.Save
-import androidx.compose.material.icons.outlined.SignalCellular4Bar
-import androidx.compose.material.icons.outlined.Wifi
+import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -47,6 +41,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.get
+import androidx.core.graphics.scale
 import androidx.documentfile.provider.DocumentFile
 import app.morphe.manager.R
 import app.morphe.manager.util.*
@@ -161,22 +156,27 @@ fun AdaptiveIconCreatorDialog(
     // Notification/monochrome icon transform state
     var notificationScale by remember { mutableFloatStateOf(1f) }
 
+    var showTransparencyWarning by remember { mutableStateOf(false) }
+
     val context = LocalContext.current
 
     // Foreground image picker, resets all transforms when a new image is loaded
     val openForegroundPicker = rememberAdaptiveFilePicker(mimeTypes = arrayOf("image/*")) { uri ->
         uri?.let {
             foregroundUri = it
+            showTransparencyWarning = false
             scope.launch(Dispatchers.IO) {
                 try {
                     val inputStream = context.contentResolver.openInputStream(it)
                     val bitmap = BitmapFactory.decodeStream(inputStream)
                     inputStream?.close()
                     foregroundBitmap = bitmap
+                    val hasTransparency = bitmap?.hasTransparentPixels() == true
                     // Reset transform when new image is loaded
                     withContext(Dispatchers.Main) {
                         scale = 1f; offsetX = 0f; offsetY = 0f
                         notificationScale = 1f
+                        showTransparencyWarning = !hasTransparency
                     }
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) { context.toast("Failed to load image: ${e.message}") }
@@ -264,6 +264,31 @@ fun AdaptiveIconCreatorDialog(
                     icon = Icons.Outlined.Image,
                     modifier = Modifier.fillMaxWidth()
                 )
+
+                // Transparency warning shown when the selected image has no transparent pixels
+                AnimatedVisibility(
+                    visible = showTransparencyWarning,
+                    enter = MorpheAnimations.expandFadeEnter,
+                    exit = MorpheAnimations.shrinkFadeExit
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Info,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                        Text(
+                            text = stringResource(R.string.adaptive_icon_no_transparency_warning),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
 
                 // 2. Preview row: adaptive on the left, monochrome on the right (when bitmap exists).
                 //    Each column takes equal weight so the previews fill available width side by side.
@@ -1327,4 +1352,16 @@ private fun saveXmlToDocFile(context: Context, dir: DocumentFile, fileName: Stri
     context.contentResolver.openOutputStream(file.uri, "wt")?.use { out ->
         out.write(content.toByteArray(Charsets.UTF_8))
     }
+}
+
+// Checks a scaled-down sample of the bitmap to determine if any pixel has transparency
+private fun Bitmap.hasTransparentPixels(): Boolean {
+    if (!hasAlpha()) return false
+    val sampleWidth = minOf(width, 64)
+    val sampleHeight = minOf(height, 64)
+    val scaled = this.scale(sampleWidth, sampleHeight, false)
+    val pixels = IntArray(sampleWidth * sampleHeight)
+    scaled.getPixels(pixels, 0, sampleWidth, 0, 0, sampleWidth, sampleHeight)
+    if (scaled !== this) scaled.recycle()
+    return pixels.any { android.graphics.Color.alpha(it) < 255 }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -988,10 +988,12 @@ private suspend fun createAdaptiveIcons(
         if (drawableDocDir != null) {
             val plainPaint = Paint().apply { isAntiAlias = true; isFilterBitmap = true; isDither = true }
 
-            // Monochrome adaptive layer: 108x108 viewport, using adaptive transforms
+            // Monochrome adaptive layer: render at 4x oversample to reduce scanline aliasing,
+            // then scale path coordinates back to the 108x108 viewport.
+            val monoOversample = 4
             val adaptiveMonoBmp = renderBitmapWithAdaptiveTransforms(
                 sourceBitmap = monochromeSrc,
-                targetSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT,
+                targetSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT * monoOversample,
                 scale = scale,
                 offsetX = offsetX,
                 offsetY = offsetY,
@@ -1001,6 +1003,7 @@ private suspend fun createAdaptiveIcons(
             val adaptiveMonoXml = createMonochromeVectorXml(
                 bitmap = adaptiveMonoBmp,
                 viewportSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT,
+                coordScale = 1f / monoOversample,
                 // System tints the monochrome layer; fill color is overridden at runtime
                 fillColor = "#FF000000"
             )
@@ -1218,8 +1221,9 @@ private fun renderBitmapWithNotificationTransforms(
 /**
  * Convert a bitmap's alpha channel to SVG/VectorDrawable path data using scanline spans.
  * Each row of opaque pixels (alpha > 127) is encoded as one or more horizontal rect commands.
+ * [coordScale] maps bitmap pixel coordinates to viewport units (use 1f/oversampleFactor for oversampled bitmaps).
  */
-private fun bitmapToVectorPathData(bitmap: Bitmap): String {
+private fun bitmapToVectorPathData(bitmap: Bitmap, coordScale: Float = 1f): String {
     val width = bitmap.width
     val height = bitmap.height
     val sb = StringBuilder()
@@ -1232,14 +1236,18 @@ private fun bitmapToVectorPathData(bitmap: Bitmap): String {
             if (opaque && spanStart == -1) {
                 spanStart = x
             } else if (!opaque && spanStart != -1) {
-                val w = x - spanStart
-                sb.append("M${spanStart},${y}h${w}v1h-${w}z")
+                val sx = spanStart * coordScale
+                val sy = y * coordScale
+                val sw = (x - spanStart) * coordScale
+                sb.append("M$sx,${sy}h${sw}v${coordScale}h-${sw}z")
                 spanStart = -1
             }
         }
         if (spanStart != -1) {
-            val w = width - spanStart
-            sb.append("M${spanStart},${y}h${w}v1h-${w}z")
+            val sx = spanStart * coordScale
+            val sy = y * coordScale
+            val sw = (width - spanStart) * coordScale
+            sb.append("M$sx,${sy}h${sw}v${coordScale}h-${sw}z")
         }
     }
     return sb.toString()
@@ -1248,9 +1256,10 @@ private fun bitmapToVectorPathData(bitmap: Bitmap): String {
 /**
  * Create an Android VectorDrawable XML string from a pre-rendered monochrome bitmap.
  * The bitmap's alpha channel defines the icon shape; [fillColor] sets the path fill.
+ * [coordScale] is forwarded to [bitmapToVectorPathData] for oversampled bitmaps.
  */
-private fun createMonochromeVectorXml(bitmap: Bitmap, viewportSize: Int, fillColor: String): String {
-    val pathData = bitmapToVectorPathData(bitmap)
+private fun createMonochromeVectorXml(bitmap: Bitmap, viewportSize: Int, coordScale: Float = 1f, fillColor: String): String {
+    val pathData = bitmapToVectorPathData(bitmap, coordScale)
     return """<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="${viewportSize}dp"

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -15,14 +15,16 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BatteryFull
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.SignalCellular4Bar
+import androidx.compose.material.icons.outlined.Wifi
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -37,7 +39,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -117,17 +118,11 @@ private object AdaptiveIconConfig {
     const val SNAP_GUIDE_ALPHA = 0.6f
 
     // Default background colors per system theme
-    const val DEFAULT_BACKGROUND_COLOR_LIGHT = "#9E9E9E"
-    const val DEFAULT_BACKGROUND_COLOR_DARK = "#FFFFFF"
-
-    // Preview sizes
+    // Used only as a ratio reference for safe zone corner calculations
     val PREVIEW_SIZE = 150.dp
-    val NOTIFICATION_PREVIEW_SIZE = 60.dp
 
     // Adaptive icon preview shape, squircle approximation matching Pixel launcher mask
     val PREVIEW_CORNER_RADIUS = 28.dp
-    // Proportional corner radius for small (52dp) preview tiles (≈21% of size, same ratio as adaptive)
-    val SMALL_PREVIEW_CORNER_RADIUS = 12.dp
 
     // Viewport sizes for XML VectorDrawable output
     const val MONOCHROME_ADAPTIVE_VIEWPORT = 108
@@ -149,12 +144,9 @@ fun AdaptiveIconCreatorDialog(
 
     var foregroundUri by remember { mutableStateOf<Uri?>(null) }
     var foregroundBitmap by remember { mutableStateOf<Bitmap?>(null) }
-    val isDarkTheme = isSystemInDarkTheme()
+    val primaryContainer = MaterialTheme.colorScheme.primaryContainer
     var backgroundColor by remember {
-        mutableStateOf(
-            if (isDarkTheme) AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_DARK
-            else AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_LIGHT
-        )
+        mutableStateOf(rgbToHex(primaryContainer.red, primaryContainer.green, primaryContainer.blue))
     }
     val showColorPicker = remember { mutableStateOf(false) }
     val showInfoDialog = remember { mutableStateOf(false) }
@@ -271,21 +263,16 @@ fun AdaptiveIconCreatorDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                // 2. Preview row: large adaptive circle on the left, small notification +
-                //    monochrome circles stacked vertically on the right (only when a source exists).
-                //    IntrinsicSize.Min lets the right column stretch to match the adaptive circle's height.
+                // 2. Preview row: adaptive on the left, monochrome on the right (when bitmap exists).
+                //    Each column takes equal weight so the previews fill available width side by side.
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(IntrinsicSize.Min),
-                    horizontalArrangement = Arrangement.spacedBy(
-                        40.dp,
-                        Alignment.CenterHorizontally
-                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Large adaptive preview
+                    // Adaptive icon preview, interactive
                     Column(
+                        modifier = Modifier.weight(1f),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
@@ -319,76 +306,28 @@ fun AdaptiveIconCreatorDialog(
                         )
                     }
 
-                    // Small previews, fill the same height as the adaptive column via SpaceBetween
-                    foregroundBitmap?.let { bitmap ->
-                        Column(
-                            modifier = Modifier.fillMaxHeight(),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            // Notification preview, white-on-dark, scale only
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.notification_icon_preview),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = LocalDialogSecondaryTextColor.current
-                                )
-                                NotificationIconCanvas(
-                                    bitmap = bitmap,
-                                    scale = notificationScale
-                                )
-                            }
-                            // Monochrome adaptive preview, non-interactive, mirrors adaptive transforms
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.adaptive_icon_monochrome_label),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = LocalDialogSecondaryTextColor.current
-                                )
-                                MonochromeAdaptiveCanvas(
-                                    bitmap = bitmap,
-                                    scale = scale,
-                                    offsetX = offsetX,
-                                    offsetY = offsetY
-                                )
-                            }
-                        }
+                    // Monochrome preview, always shown, mirrors adaptive transforms
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.adaptive_icon_monochrome_label),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
+                        MonochromeAdaptiveCanvas(
+                            bitmap = foregroundBitmap,
+                            scale = scale,
+                            offsetX = offsetX,
+                            offsetY = offsetY
+                        )
                     }
                 }
 
-                // Safe zone legend
-                val legendColor = MaterialTheme.colorScheme.onSurface
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 36.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    SafeZoneLegendItem(
-                        baseColor = legendColor,
-                        alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
-                        isDashed = false,
-                        text = stringResource(R.string.adaptive_icon_safe_zone_inner)
-                    )
-                    SafeZoneLegendItem(
-                        baseColor = legendColor,
-                        alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
-                        isDashed = true,
-                        text = stringResource(R.string.adaptive_icon_safe_zone_outer)
-                    )
-                }
-
-                // 3. Scale/offset sliders, grouped together, shown only when relevant
+                // Adaptive scale slider
                 if (foregroundBitmap != null) {
-                    HorizontalDivider()
-
-                    // Adaptive slider
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -396,13 +335,6 @@ fun AdaptiveIconCreatorDialog(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Text(
-                            text = stringResource(R.string.adaptive_icon_label),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                            color = LocalDialogSecondaryTextColor.current,
-                            modifier = Modifier.width(72.dp)
-                        )
                         Icon(
                             imageVector = Icons.Outlined.Image,
                             contentDescription = null,
@@ -444,8 +376,49 @@ fun AdaptiveIconCreatorDialog(
                             }
                         }
                     }
+                }
 
-                    // Notification slider
+                // Safe zone legend
+                val legendColor = MaterialTheme.colorScheme.onSurface
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 36.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
+                        isDashed = false,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_inner)
+                    )
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
+                        isDashed = true,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_outer)
+                    )
+                }
+
+                // 3. Status bar notification preview, always visible
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.notification_icon_preview),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = LocalDialogSecondaryTextColor.current,
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    )
+                    StatusBarPreview(
+                        bitmap = foregroundBitmap,
+                        scale = notificationScale
+                    )
+                }
+
+                // Notification scale slider
+                if (foregroundBitmap != null) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -453,13 +426,6 @@ fun AdaptiveIconCreatorDialog(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        Text(
-                            text = stringResource(R.string.notification_icon_preview),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontWeight = FontWeight.Medium,
-                            color = LocalDialogSecondaryTextColor.current,
-                            modifier = Modifier.width(72.dp)
-                        )
                         Icon(
                             imageVector = Icons.Outlined.Image,
                             contentDescription = null,
@@ -621,7 +587,6 @@ private fun AdaptiveIconPreview(
     // Guide color adapts to background brightness to keep circles visible
     val previewGuideColor = remember(backgroundColor) {
         val bgColor = backgroundColor.toColorOrNull()
-            ?: AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_LIGHT.toColorOrNull()
             ?: Color.Black
         if (bgColor.isDarkBackground()) Color.White else Color.Black
     }
@@ -630,7 +595,8 @@ private fun AdaptiveIconPreview(
 
     Box(
         modifier = Modifier
-            .size(AdaptiveIconConfig.PREVIEW_SIZE)
+            .fillMaxWidth()
+            .aspectRatio(1f)
             .clip(RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS))
             .background(
                 parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) }
@@ -772,110 +738,170 @@ private fun AdaptiveIconPreview(
 }
 
 /**
- * Notification icon preview (dark background).
- * Recolors all pixels white (alpha-preserving) to simulate Android notification rendering.
+ * Status bar simulation showing the notification icon at actual size with a dashed slot boundary.
+ * Accepts a nullable bitmap so the slot guide is visible before an image is selected.
  */
 @Composable
-private fun NotificationIconCanvas(
-    bitmap: Bitmap,
+private fun StatusBarPreview(
+    bitmap: Bitmap?,
     scale: Float
 ) {
-    val shape = RoundedCornerShape(AdaptiveIconConfig.SMALL_PREVIEW_CORNER_RADIUS)
+    val contentColor = MaterialTheme.colorScheme.onSurface
+    val guideColor = contentColor.copy(alpha = 0.5f)
+    val dashEffect = remember { PathEffect.dashPathEffect(floatArrayOf(3f, 3f), 0f) }
+    val shape = RoundedCornerShape(12.dp)
+    // Capture RGB components for use inside Canvas DrawScope
+    val iconR = contentColor.red * 255f
+    val iconG = contentColor.green * 255f
+    val iconB = contentColor.blue * 255f
+
     Box(
         modifier = Modifier
-            .size(AdaptiveIconConfig.NOTIFICATION_PREVIEW_SIZE)
+            .fillMaxWidth()
+            .height(44.dp)
             .clip(shape)
-            .background(Color(0xFF1A1A1A))
-            .border(1.dp, Color.White.copy(alpha = 0.15f), shape),
-        contentAlignment = Alignment.Center
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, shape)
+            .padding(horizontal = 16.dp),
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            val centerX = size.width / 2
-            val centerY = size.height / 2
-            val imageBitmap = bitmap.asImageBitmap()
-            val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
-            val (baseWidth, baseHeight) = if (imageAspect > 1f)
-                size.width to (size.width / imageAspect)
-            else
-                (size.height * imageAspect) to size.height
-            val scaledWidth = baseWidth * scale
-            val scaledHeight = baseHeight * scale
-            val left = centerX - scaledWidth / 2
-            val top = centerY - scaledHeight / 2
-            // Recolor all pixels white (alpha-preserving) to simulate how Android renders
-            // notification small icons in the status bar and notification drawer
-            drawImage(
-                image = imageBitmap,
-                dstOffset = IntOffset(left.toInt(), top.toInt()),
-                dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt()),
-                colorFilter = colorMatrix(
-                    androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
-                        0f, 0f, 0f, 0f, 255f,
-                        0f, 0f, 0f, 0f, 255f,
-                        0f, 0f, 0f, 0f, 255f,
-                        0f, 0f, 0f, 1f, 0f
-                    ))
+        // Left side: clock + notification icon
+        Row(
+            modifier = Modifier.align(Alignment.CenterStart),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Simulated clock
+            Text(
+                text = "9:41",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = contentColor
+            )
+            // Notification icon at actual status bar size (~20 dp) with slot boundary guide
+            Canvas(modifier = Modifier.size(20.dp)) {
+                // Dashed border marks the notification icon slot boundary; content outside
+                // this area is clipped by Android in the real status bar
+                val iconStroke = Stroke(width = 1.dp.toPx(), pathEffect = dashEffect)
+                drawRect(
+                    color = guideColor,
+                    topLeft = Offset(0.5f, 0.5f),
+                    size = androidx.compose.ui.geometry.Size(size.width - 1f, size.height - 1f),
+                    style = iconStroke
                 )
+                if (bitmap != null) {
+                    val centerX = size.width / 2
+                    val centerY = size.height / 2
+                    val imageBitmap = bitmap.asImageBitmap()
+                    val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+                    val (baseWidth, baseHeight) = if (imageAspect > 1f)
+                        size.width to (size.width / imageAspect)
+                    else
+                        (size.height * imageAspect) to size.height
+                    val scaledWidth = baseWidth * scale
+                    val scaledHeight = baseHeight * scale
+                    val left = centerX - scaledWidth / 2
+                    val top = centerY - scaledHeight / 2
+                    // Recolor all pixels to match onSurface (alpha-preserving); simulates how
+                    // Android renders notification small icons in the status bar
+                    drawImage(
+                        image = imageBitmap,
+                        dstOffset = IntOffset(left.toInt(), top.toInt()),
+                        dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt()),
+                        colorFilter = colorMatrix(
+                            androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
+                                0f, 0f, 0f, 0f, iconR,
+                                0f, 0f, 0f, 0f, iconG,
+                                0f, 0f, 0f, 0f, iconB,
+                                0f, 0f, 0f, 1f, 0f
+                            ))
+                        )
+                    )
+                }
+            }
+        }
+
+        // Right side: system status icons
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.SignalCellular4Bar,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = contentColor
+            )
+            Icon(
+                imageVector = Icons.Outlined.Wifi,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = contentColor
+            )
+            Icon(
+                imageVector = Icons.Outlined.BatteryFull,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = contentColor
             )
         }
     }
 }
 
 /**
- * Non-interactive monochrome adaptive icon preview (40dp, surfaceVariant background).
- * Mirrors the adaptive icon transforms so the result matches the generated XML layer.
- * Renders black (alpha-preserving); the system tints the layer at runtime.
+ * Non-interactive monochrome icon preview using theme accent colors to simulate launcher themed icons.
+ * Accepts a nullable bitmap so the colored background is visible before an image is selected.
  */
 @Composable
 private fun MonochromeAdaptiveCanvas(
-    bitmap: Bitmap,
+    bitmap: Bitmap?,
     scale: Float,
     offsetX: Float,
     offsetY: Float
 ) {
-    val density = LocalDensity.current.density
-    val shape = RoundedCornerShape(AdaptiveIconConfig.SMALL_PREVIEW_CORNER_RADIUS)
+    val shape = RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS)
+    // Read accent colors outside Canvas; must be stable across recompositions.
+    // Icon uses primaryContainer so it reads as a cutout from the onPrimaryContainer background.
+    val iconColor = MaterialTheme.colorScheme.primaryContainer
     Box(
         modifier = Modifier
-            .size(AdaptiveIconConfig.NOTIFICATION_PREVIEW_SIZE)
+            .fillMaxWidth()
+            .aspectRatio(1f)
             .clip(shape)
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), shape),
+            .background(MaterialTheme.colorScheme.onPrimaryContainer)
+            .border(2.dp, MaterialTheme.colorScheme.outline, shape),
         contentAlignment = Alignment.Center
     ) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            // Map adaptive transforms from the PREVIEW_SIZE canvas to this small circle.
-            // canvasRatio converts preview-canvas pixels to this canvas's pixels.
-            val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * density
-            val imageBitmap = bitmap.asImageBitmap()
-            val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
-            val (baseWidth, baseHeight) = if (imageAspect > 1f)
-                previewCanvasSize to (previewCanvasSize / imageAspect)
-            else
-                (previewCanvasSize * imageAspect) to previewCanvasSize
-            val scaledWidth = baseWidth * scale
-            val scaledHeight = baseHeight * scale
-            val canvasRatio = size.width / previewCanvasSize
-            val dstWidth = scaledWidth * canvasRatio
-            val dstHeight = scaledHeight * canvasRatio
-            val dstOffsetX = offsetX * canvasRatio
-            val dstOffsetY = offsetY * canvasRatio
-            val left = (size.width - dstWidth) / 2 + dstOffsetX
-            val top = (size.height - dstHeight) / 2 + dstOffsetY
-            // Force all channels to black (alpha-preserving); system applies accent tint at runtime
-            drawImage(
-                image = imageBitmap,
-                dstOffset = IntOffset(left.toInt(), top.toInt()),
-                dstSize = IntSize(dstWidth.toInt(), dstHeight.toInt()),
-                colorFilter = colorMatrix(
-                    androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
-                        0f, 0f, 0f, 0f, 0f,
-                        0f, 0f, 0f, 0f, 0f,
-                        0f, 0f, 0f, 0f, 0f,
-                        0f, 0f, 0f, 1f, 0f
-                    ))
+        if (bitmap != null) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                // Image fitting mirrors AdaptiveIconPreview: fill the canvas dimension that matches
+                // the image's longer edge, then scale/offset using the shared state values.
+                val imageBitmap = bitmap.asImageBitmap()
+                val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+                val (baseWidth, baseHeight) = if (imageAspect > 1f)
+                    size.width to (size.width / imageAspect)
+                else
+                    (size.width * imageAspect) to size.width
+                val scaledWidth = baseWidth * scale
+                val scaledHeight = baseHeight * scale
+                val left = (size.width - scaledWidth) / 2 + offsetX
+                val top = (size.height - scaledHeight) / 2 + offsetY
+                // Force all channels to the accent foreground color (alpha-preserving);
+                // launchers apply the same tint at runtime
+                drawImage(
+                    image = imageBitmap,
+                    dstOffset = IntOffset(left.toInt(), top.toInt()),
+                    dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt()),
+                    colorFilter = colorMatrix(
+                        androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
+                            0f, 0f, 0f, 0f, iconColor.red * 255,
+                            0f, 0f, 0f, 0f, iconColor.green * 255,
+                            0f, 0f, 0f, 0f, iconColor.blue * 255,
+                            0f, 0f, 0f, 1f, 0f
+                        ))
+                    )
                 )
-            )
+            }
         }
     }
 }
@@ -1024,7 +1050,7 @@ private suspend fun createAdaptiveIcons(
             val adaptiveMonoXml = createMonochromeVectorXml(
                 bitmap = adaptiveMonoBmp,
                 viewportSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT,
-                coordScale = 1f / monoOversample,
+                coordinateScale = 1f / monoOversample,
                 // System tints the monochrome layer; fill color is overridden at runtime
                 fillColor = "#FF000000"
             )
@@ -1240,9 +1266,9 @@ private fun renderBitmapWithNotificationTransforms(
 /**
  * Convert a bitmap's alpha channel to SVG/VectorDrawable path data using scanline spans.
  * Each row of opaque pixels (alpha > 127) is encoded as one or more horizontal rect commands.
- * [coordScale] maps bitmap pixel coordinates to viewport units (use 1f/oversampleFactor for oversampled bitmaps).
+ * [coordinateScale] maps bitmap pixel coordinates to viewport units (use 1f/oversampleFactor for oversampled bitmaps).
  */
-private fun bitmapToVectorPathData(bitmap: Bitmap, coordScale: Float = 1f): String {
+private fun bitmapToVectorPathData(bitmap: Bitmap, coordinateScale: Float = 1f): String {
     val width = bitmap.width
     val height = bitmap.height
     val sb = StringBuilder()
@@ -1255,18 +1281,18 @@ private fun bitmapToVectorPathData(bitmap: Bitmap, coordScale: Float = 1f): Stri
             if (opaque && spanStart == -1) {
                 spanStart = x
             } else if (!opaque && spanStart != -1) {
-                val sx = spanStart * coordScale
-                val sy = y * coordScale
-                val sw = (x - spanStart) * coordScale
-                sb.append("M$sx,${sy}h${sw}v${coordScale}h-${sw}z")
+                val sx = spanStart * coordinateScale
+                val sy = y * coordinateScale
+                val sw = (x - spanStart) * coordinateScale
+                sb.append("M$sx,${sy}h${sw}v${coordinateScale}h-${sw}z")
                 spanStart = -1
             }
         }
         if (spanStart != -1) {
-            val sx = spanStart * coordScale
-            val sy = y * coordScale
-            val sw = (width - spanStart) * coordScale
-            sb.append("M$sx,${sy}h${sw}v${coordScale}h-${sw}z")
+            val sx = spanStart * coordinateScale
+            val sy = y * coordinateScale
+            val sw = (width - spanStart) * coordinateScale
+            sb.append("M$sx,${sy}h${sw}v${coordinateScale}h-${sw}z")
         }
     }
     return sb.toString()
@@ -1275,10 +1301,10 @@ private fun bitmapToVectorPathData(bitmap: Bitmap, coordScale: Float = 1f): Stri
 /**
  * Create an Android VectorDrawable XML string from a pre-rendered monochrome bitmap.
  * The bitmap's alpha channel defines the icon shape; [fillColor] sets the path fill.
- * [coordScale] is forwarded to [bitmapToVectorPathData] for oversampled bitmaps.
+ * [coordinateScale] is forwarded to [bitmapToVectorPathData] for oversampled bitmaps.
  */
-private fun createMonochromeVectorXml(bitmap: Bitmap, viewportSize: Int, coordScale: Float = 1f, fillColor: String): String {
-    val pathData = bitmapToVectorPathData(bitmap, coordScale)
+private fun createMonochromeVectorXml(bitmap: Bitmap, viewportSize: Int, coordinateScale: Float = 1f, fillColor: String): String {
+    val pathData = bitmapToVectorPathData(bitmap, coordinateScale)
     return """<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="${viewportSize}dp"

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -1031,9 +1031,9 @@ private suspend fun createAdaptiveIcons(
         if (drawableDocDir != null) {
             val plainPaint = Paint().apply { isAntiAlias = true; isFilterBitmap = true; isDither = true }
 
-            // Monochrome adaptive layer: render at 4x oversample to reduce scanline aliasing,
-            // then scale path coordinates back to the 108x108 viewport.
-            val monoOversample = 4
+            // Monochrome adaptive layer: render at 16x oversample (1728x1728) so each scanline
+            // is 0.0625 viewport units tall, making stair-stepping sub-pixel on all densities.
+            val monoOversample = 16
             val adaptiveMonoBmp = renderBitmapWithAdaptiveTransforms(
                 sourceBitmap = monochromeSrc,
                 targetSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT * monoOversample,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -19,10 +19,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Image
-import androidx.compose.material.icons.outlined.Info
-import androidx.compose.material.icons.outlined.RestartAlt
-import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,6 +33,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -43,6 +41,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
+import androidx.core.graphics.get
 import androidx.documentfile.provider.DocumentFile
 import app.morphe.manager.R
 import app.morphe.manager.util.*
@@ -69,6 +68,9 @@ private object AdaptiveIconConfig {
     const val BACKGROUND_FILE_NAME = "morphe_adaptive_background_custom.png"
     const val FOREGROUND_FILE_NAME = "morphe_adaptive_foreground_custom.png"
     const val NOTIFICATION_FILE_NAME = "morphe_notification_icon_custom.png"
+    const val NOTIFICATION_XML_FILE_NAME = "morphe_notification_icon_custom.xml"
+    const val MONOCHROME_ADAPTIVE_FILE_NAME = "morphe_adaptive_monochrome_custom.xml"
+    const val DRAWABLE_FOLDER_NAME = "drawable"
 
     // Density folders and sizes
     val DENSITY_CONFIGS = listOf(
@@ -110,17 +112,28 @@ private object AdaptiveIconConfig {
     const val SNAP_GUIDE_STROKE_WIDTH = 1.5f
     const val SNAP_GUIDE_ALPHA = 0.6f
 
-    // Default background color
+    // Default background color and alpha
     const val DEFAULT_BACKGROUND_COLOR = "#B3E5FC"
+    const val DEFAULT_BACKGROUND_ALPHA = 1f
 
     // Preview sizes
-    val PREVIEW_SIZE = 200.dp
-    val NOTIFICATION_PREVIEW_SIZE = 40.dp
+    val PREVIEW_SIZE = 130.dp
+    val NOTIFICATION_PREVIEW_SIZE = 52.dp
+
+    // Adaptive icon preview shape, squircle approximation matching Pixel launcher mask
+    val PREVIEW_CORNER_RADIUS = 28.dp
+    // Proportional corner radius for small (52dp) preview tiles (≈21% of size, same ratio as adaptive)
+    val SMALL_PREVIEW_CORNER_RADIUS = 12.dp
+
+    // Viewport sizes for XML VectorDrawable output
+    const val MONOCHROME_ADAPTIVE_VIEWPORT = 108
+    const val NOTIFICATION_XML_VIEWPORT = 24
 }
 
 /**
  * Dialog for creating adaptive icons with foreground and background customization.
- * Generates icons in proper sizes for all screen densities.
+ * Generates icons in proper sizes for all screen densities, plus XML VectorDrawable
+ * files for the monochrome adaptive layer and notification icon.
  */
 @Composable
 fun AdaptiveIconCreatorDialog(
@@ -133,24 +146,22 @@ fun AdaptiveIconCreatorDialog(
     var foregroundUri by remember { mutableStateOf<Uri?>(null) }
     var foregroundBitmap by remember { mutableStateOf<Bitmap?>(null) }
     var backgroundColor by remember { mutableStateOf(AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR) }
+    var backgroundAlpha by remember { mutableFloatStateOf(AdaptiveIconConfig.DEFAULT_BACKGROUND_ALPHA) }
     val showColorPicker = remember { mutableStateOf(false) }
+    val showInfoDialog = remember { mutableStateOf(false) }
 
-    // Scaling and positioning state (adaptive icon)
+    // Adaptive icon transform state
     var scale by remember { mutableFloatStateOf(1f) }
     var offsetX by remember { mutableFloatStateOf(0f) }
     var offsetY by remember { mutableFloatStateOf(0f) }
 
-    // Scaling and positioning state (notification icon)
+    // Notification/monochrome icon transform state
     var notificationScale by remember { mutableFloatStateOf(1f) }
-    var notificationOffsetX by remember { mutableFloatStateOf(0f) }
-    var notificationOffsetY by remember { mutableFloatStateOf(0f) }
 
     val context = LocalContext.current
 
-    // Foreground image picker
-    val openForegroundPicker = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf("image/*")
-    ) { uri ->
+    // Foreground image picker, resets all transforms when a new image is loaded
+    val openForegroundPicker = rememberAdaptiveFilePicker(mimeTypes = arrayOf("image/*")) { uri ->
         uri?.let {
             foregroundUri = it
             scope.launch(Dispatchers.IO) {
@@ -161,23 +172,16 @@ fun AdaptiveIconCreatorDialog(
                     foregroundBitmap = bitmap
                     // Reset transform when new image is loaded
                     withContext(Dispatchers.Main) {
-                        scale = 1f
-                        offsetX = 0f
-                        offsetY = 0f
+                        scale = 1f; offsetX = 0f; offsetY = 0f
                         notificationScale = 1f
-                        notificationOffsetX = 0f
-                        notificationOffsetY = 0f
                     }
                 } catch (e: Exception) {
-                    withContext(Dispatchers.Main) {
-                        context.toast("Failed to load image: ${e.message}")
-                    }
+                    withContext(Dispatchers.Main) { context.toast("Failed to load image: ${e.message}") }
                 }
             }
         }
     }
 
-    // Folder picker for saving
     val successMessage = stringResource(R.string.adaptive_icon_created_success)
     val failureMessage = stringResource(R.string.adaptive_icon_creation_failed)
 
@@ -191,12 +195,11 @@ fun AdaptiveIconCreatorDialog(
                     packageName = packageName,
                     foregroundBitmap = foregroundBitmap!!,
                     backgroundColor = backgroundColor,
+                    backgroundAlpha = backgroundAlpha,
                     scale = scale,
                     offsetX = offsetX,
                     offsetY = offsetY,
-                    notificationScale = notificationScale,
-                    notificationOffsetX = notificationOffsetX,
-                    notificationOffsetY = notificationOffsetY
+                    notificationScale = notificationScale
                 )
                 withContext(Dispatchers.Main) {
                     if (success != null) {
@@ -208,9 +211,7 @@ fun AdaptiveIconCreatorDialog(
                     }
                 }
             } catch (e: Exception) {
-                withContext(Dispatchers.Main) {
-                    context.toast("Failed to create icon: ${e.message}")
-                }
+                withContext(Dispatchers.Main) { context.toast("Failed to create icon: ${e.message}") }
             }
         }
     }
@@ -218,130 +219,33 @@ fun AdaptiveIconCreatorDialog(
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.adaptive_icon_create),
-        compactPadding = true,
-        footer = {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Explanation text
-                AnimatedVisibility(
-                    visible = foregroundBitmap != null,
-                    enter = MorpheAnimations.expandFadeEnter,
-                    exit = MorpheAnimations.shrinkFadeExit
-                ) {
-                    InfoBadge(
-                        text = stringResource(
-                            R.string.adaptive_icon_folder_explanation,
-                            AdaptiveIconConfig.BRANDING_FOLDER_NAME,
-                            AdaptiveIconConfig.iconFolderName(packageName)
-                        ),
-                        style = InfoBadgeStyle.Primary,
-                        icon = Icons.Outlined.Info,
-                        isExpanded = true
-                    )
-                }
-
-                // Create button
-                MorpheDialogButton(
-                    text = stringResource(R.string.adaptive_icon_create),
-                    onClick = { openFolderPicker() },
-                    enabled = foregroundBitmap != null,
-                    icon = Icons.Outlined.Save,
-                    modifier = Modifier.fillMaxWidth()
+        titleTrailingContent = {
+            IconButton(onClick = { showInfoDialog.value = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(R.string.adaptive_icon_guide),
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+        },
+        compactPadding = true,
+        footer = {
+            MorpheDialogButton(
+                text = stringResource(R.string.adaptive_icon_create),
+                onClick = { openFolderPicker() },
+                enabled = foregroundBitmap != null,
+                icon = Icons.Outlined.Save,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            // Instructions
-            InfoBadge(
-                text = stringResource(R.string.adaptive_icon_instructions),
-                style = InfoBadgeStyle.Primary,
-                icon = Icons.Outlined.Info,
-                isExpanded = true
-            )
-
-            // Adaptive icon preview with safe zones
-            AdaptiveIconPreview(
-                foregroundBitmap = foregroundBitmap,
-                backgroundColor = backgroundColor,
-                scale = scale,
-                offsetX = offsetX,
-                offsetY = offsetY,
-                onScaleChange = { newScale ->
-                    scale = newScale.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE)
-                },
-                onOffsetChange = { newOffsetX, newOffsetY ->
-                    offsetX = newOffsetX.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                    offsetY = newOffsetY.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                },
-                onBackgroundColorClick = { showColorPicker.value = true }
-            )
-
-            // Reset adaptive transform button
-            if (foregroundBitmap != null && (scale != 1f || offsetX != 0f || offsetY != 0f)) {
-                TextButton(
-                    onClick = {
-                        scale = 1f
-                        offsetX = 0f
-                        offsetY = 0f
-                    },
-                    modifier = Modifier.align(Alignment.CenterHorizontally)
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.RestartAlt,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(R.string.adaptive_icon_reset_transform))
-                }
-            }
-
-            // Notification icon preview
-            if (foregroundBitmap != null) {
-                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-
-                NotificationIconPreview(
-                    foregroundBitmap = foregroundBitmap!!,
-                    scale = notificationScale,
-                    offsetX = notificationOffsetX,
-                    offsetY = notificationOffsetY,
-                    onScaleChange = { newScale ->
-                        notificationScale = newScale.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE)
-                    },
-                    onOffsetChange = { newOffsetX, newOffsetY ->
-                        notificationOffsetX = newOffsetX.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                        notificationOffsetY = newOffsetY.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                    }
-                )
-
-                if (notificationScale != 1f || notificationOffsetX != 0f || notificationOffsetY != 0f) {
-                    TextButton(
-                        onClick = {
-                            notificationScale = 1f
-                            notificationOffsetX = 0f
-                            notificationOffsetY = 0f
-                        },
-                        modifier = Modifier.align(Alignment.CenterHorizontally)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.RestartAlt,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.adaptive_icon_reset_transform))
-                    }
-                }
-            }
-
-            // Foreground selection
-            MorpheDialogButton(
+            // Foreground image picker
+            MorpheDialogOutlinedButton(
                 text = if (foregroundUri == null)
                     stringResource(R.string.adaptive_icon_select_image)
                 else
@@ -350,6 +254,276 @@ fun AdaptiveIconCreatorDialog(
                 icon = Icons.Outlined.Image,
                 modifier = Modifier.fillMaxWidth()
             )
+
+            // 2. Preview row: large adaptive circle on the left, small notification +
+            //    monochrome circles stacked vertically on the right (only when a source exists).
+            //    IntrinsicSize.Min lets the right column stretch to match the adaptive circle's height.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min),
+                horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Large adaptive preview
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.adaptive_icon_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = LocalDialogSecondaryTextColor.current
+                    )
+                    AdaptiveIconPreview(
+                        foregroundBitmap = foregroundBitmap,
+                        backgroundColor = backgroundColor,
+                        backgroundAlpha = backgroundAlpha,
+                        scale = scale,
+                        offsetX = offsetX,
+                        offsetY = offsetY,
+                        onScaleChange = { scale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
+                        onOffsetChange = { x, y ->
+                            offsetX = x.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
+                            offsetY = y.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
+                        }
+                    )
+                }
+
+                // Small previews, fill the same height as the adaptive column via SpaceBetween
+                foregroundBitmap?.let { bitmap ->
+                    Column(
+                        modifier = Modifier.fillMaxHeight(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        // Notification preview, white-on-dark, scale only
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.notification_icon_preview),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = LocalDialogSecondaryTextColor.current
+                            )
+                            NotificationIconCanvas(
+                                bitmap = bitmap,
+                                scale = notificationScale
+                            )
+                        }
+                        // Monochrome adaptive preview, non-interactive, mirrors adaptive transforms
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.adaptive_icon_monochrome_label),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = LocalDialogSecondaryTextColor.current
+                            )
+                            MonochromeAdaptiveCanvas(
+                                bitmap = bitmap,
+                                scale = scale,
+                                offsetX = offsetX,
+                                offsetY = offsetY
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Safe zone legend
+            val legendColor = MaterialTheme.colorScheme.onSurface
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 36.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                SafeZoneLegendItem(
+                    baseColor = legendColor,
+                    alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
+                    isDashed = false,
+                    text = stringResource(R.string.adaptive_icon_safe_zone_inner)
+                )
+                SafeZoneLegendItem(
+                    baseColor = legendColor,
+                    alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
+                    isDashed = true,
+                    text = stringResource(R.string.adaptive_icon_safe_zone_outer)
+                )
+            }
+
+            // 3. Scale/offset sliders, grouped together, shown only when relevant
+            if (foregroundBitmap != null) {
+                HorizontalDivider()
+
+                // Adaptive slider
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.adaptive_icon_label),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = LocalDialogSecondaryTextColor.current,
+                        modifier = Modifier.width(72.dp)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Image,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    Slider(
+                        value = scale,
+                        onValueChange = { scale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
+                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Image,
+                        contentDescription = null,
+                        modifier = Modifier.size(22.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    AnimatedVisibility(
+                        visible = scale != 1f || offsetX != 0f || offsetY != 0f,
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        IconButton(
+                            onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
+                            modifier = Modifier.size(40.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.RestartAlt,
+                                contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+
+                // Notification slider
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.notification_icon_preview),
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.Medium,
+                        color = LocalDialogSecondaryTextColor.current,
+                        modifier = Modifier.width(72.dp)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Image,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    Slider(
+                        value = notificationScale,
+                        onValueChange = { notificationScale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
+                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Image,
+                        contentDescription = null,
+                        modifier = Modifier.size(22.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    AnimatedVisibility(
+                        visible = notificationScale != 1f,
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        IconButton(
+                            onClick = { notificationScale = 1f },
+                            modifier = Modifier.size(40.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.RestartAlt,
+                                contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider()
+
+            // 4. Background color picker and alpha slider on separate rows
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Surface(
+                        onClick = { showColorPicker.value = true },
+                        modifier = Modifier.size(36.dp),
+                        shape = CircleShape,
+                        color = parseColorToRgb(backgroundColor).let { (r, g, b) ->
+                            Color(r, g, b, backgroundAlpha)
+                        },
+                        border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
+                    ) {}
+                    Text(
+                        text = stringResource(R.string.adaptive_icon_background_color),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = LocalDialogTextColor.current
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Opacity,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    Slider(
+                        value = backgroundAlpha,
+                        onValueChange = { backgroundAlpha = it },
+                        valueRange = 0f..1f,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Icon(
+                        imageVector = Icons.Outlined.Opacity,
+                        contentDescription = null,
+                        modifier = Modifier.size(22.dp),
+                        tint = LocalDialogSecondaryTextColor.current
+                    )
+                    Text(
+                        text = "${(backgroundAlpha * 100).toInt()}%",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = LocalDialogSecondaryTextColor.current,
+                        modifier = Modifier.width(32.dp),
+                        textAlign = TextAlign.End
+                    )
+                }
+            }
         }
     }
 
@@ -365,446 +539,346 @@ fun AdaptiveIconCreatorDialog(
             onDismiss = { showColorPicker.value = false }
         )
     }
+
+    // Icon creation guide dialog
+    if (showInfoDialog.value) {
+        MorpheDialog(
+            onDismissRequest = { showInfoDialog.value = false },
+            title = stringResource(R.string.adaptive_icon_guide),
+            footer = {
+                MorpheDialogButton(
+                    text = stringResource(android.R.string.ok),
+                    onClick = { showInfoDialog.value = false },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                AdaptiveIconGuideSection(
+                    title = stringResource(R.string.adaptive_icon_guide_png_title),
+                    body = stringResource(R.string.adaptive_icon_guide_png_body)
+                )
+                AdaptiveIconGuideSection(
+                    title = stringResource(R.string.adaptive_icon_guide_safe_zones_title),
+                    body = stringResource(R.string.adaptive_icon_guide_safe_zones_body)
+                )
+                AdaptiveIconGuideSection(
+                    title = stringResource(R.string.adaptive_icon_guide_notification_title),
+                    body = stringResource(R.string.adaptive_icon_guide_notification_body)
+                )
+                AdaptiveIconGuideSection(
+                    title = stringResource(R.string.adaptive_icon_guide_monochrome_title),
+                    body = stringResource(R.string.adaptive_icon_guide_monochrome_body)
+                )
+            }
+        }
+    }
 }
 
 /**
- * Preview component showing adaptive icon with safe zones and transform gestures.
+ * Adaptive icon preview circle with safe-zone guides and pinch/pan gesture support.
+ * Scale slider and reset button are rendered by the caller below the preview row.
  */
-@SuppressLint("LocalContextResourcesRead")
 @Composable
 private fun AdaptiveIconPreview(
     foregroundBitmap: Bitmap?,
     backgroundColor: String,
-    scale: Float,
-    offsetX: Float,
-    offsetY: Float,
-    onScaleChange: (Float) -> Unit,
-    onOffsetChange: (Float, Float) -> Unit,
-    onBackgroundColorClick: () -> Unit
-) {
-    // Color for guides and safe zones inside the preview canvas
-    val previewGuideColor = remember(backgroundColor) {
-        val bgColor = backgroundColor.toColorOrNull()
-            ?: AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR.toColorOrNull()
-            ?: Color.Black
-        if (bgColor.isDarkBackground()) Color.White else Color.Black
-    }
-
-    // Color for the legend
-    val legendColor = MaterialTheme.colorScheme.onSurface
-
-    // Dashed effect for snap guides and outer safe zone
-    val dashEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 6f), 0f)
-
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing)
-    ) {
-        Text(
-            text = stringResource(R.string.adaptive_icon_preview),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-            color = LocalDialogTextColor.current
-        )
-        Text(
-            text = stringResource(R.string.adaptive_icon_preview_hint),
-            style = MaterialTheme.typography.bodySmall,
-            color = LocalDialogSecondaryTextColor.current,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 8.dp)
-        )
-
-        Box(
-            modifier = Modifier
-                .size(AdaptiveIconConfig.PREVIEW_SIZE)
-                .clip(CircleShape)
-                .background(
-                    parseColorToRgb(backgroundColor).let { (r, g, b) ->
-                        Color(r, g, b)
-                    }
-                )
-                .border(2.dp, MaterialTheme.colorScheme.outline, CircleShape),
-            contentAlignment = Alignment.Center
-        ) {
-            if (foregroundBitmap != null) {
-                var currentScale by remember { mutableFloatStateOf(scale) }
-                var currentOffsetX by remember { mutableFloatStateOf(offsetX) }
-                var currentOffsetY by remember { mutableFloatStateOf(offsetY) }
-
-                // Sync with parent state
-                LaunchedEffect(scale, offsetX, offsetY) {
-                    currentScale = scale
-                    currentOffsetX = offsetX
-                    currentOffsetY = offsetY
-                }
-
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .pointerInput(Unit) {
-                            detectTransformGestures { _, pan, zoom, _ ->
-                                // Apply zoom
-                                currentScale *= zoom
-
-                                // Apply pan
-                                var newOffsetX = currentOffsetX + pan.x
-                                var newOffsetY = currentOffsetY + pan.y
-
-                                // Snap to center when close
-                                if (abs(newOffsetX) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetX = 0f
-                                if (abs(newOffsetY) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetY = 0f
-
-                                currentOffsetX = newOffsetX
-                                currentOffsetY = newOffsetY
-
-                                // Update parent state
-                                onScaleChange(currentScale)
-                                onOffsetChange(currentOffsetX, currentOffsetY)
-                            }
-                        }
-                ) {
-                    val centerX = size.width / 2
-                    val centerY = size.height / 2
-
-                    // Draw foreground image
-                    val imageBitmap = foregroundBitmap.asImageBitmap()
-
-                    // Calculate base size by fitting image to canvas while maintaining aspect ratio
-                    val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
-                    val canvasAspect = size.width / size.height  // For square canvas this is 1.0
-
-                    val (baseWidth, baseHeight) = if (imageAspect > canvasAspect) {
-                        // Image is wider - fit to width
-                        size.width to (size.width / imageAspect)
-                    } else {
-                        // Image is taller - fit to height
-                        (size.height * imageAspect) to size.height
-                    }
-
-                    // Apply user scale to the fitted size
-                    val scaledWidth = baseWidth * currentScale
-                    val scaledHeight = baseHeight * currentScale
-
-                    // Calculate position with offset
-                    val left = centerX - (scaledWidth / 2) + currentOffsetX
-                    val top = centerY - (scaledHeight / 2) + currentOffsetY
-
-                    drawImage(
-                        image = imageBitmap,
-                        dstOffset = IntOffset(left.toInt(), top.toInt()),
-                        dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt())
-                    )
-
-                    // Draw dashed snap guides when close to center
-                    if (abs(currentOffsetX) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD ||
-                        abs(currentOffsetY) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD) {
-
-                        // Vertical center line
-                        if (abs(currentOffsetX) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD) {
-                            drawLine(
-                                color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SNAP_GUIDE_ALPHA),
-                                start = Offset(centerX, 0f),
-                                end = Offset(centerX, size.height),
-                                strokeWidth = AdaptiveIconConfig.SNAP_GUIDE_STROKE_WIDTH,
-                                pathEffect = dashEffect
-                            )
-                        }
-
-                        // Horizontal center line
-                        if (abs(currentOffsetY) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD) {
-                            drawLine(
-                                color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SNAP_GUIDE_ALPHA),
-                                start = Offset(0f, centerY),
-                                end = Offset(size.width, centerY),
-                                strokeWidth = AdaptiveIconConfig.SNAP_GUIDE_STROKE_WIDTH,
-                                pathEffect = dashEffect
-                            )
-                        }
-                    }
-
-                    // Outer safe zone (66% – mask area)
-                    drawCircle(
-                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA),
-                        radius = size.width * AdaptiveIconConfig.SAFE_ZONE_OUTER / 2,
-                        center = Offset(centerX, centerY),
-                        style = Stroke(
-                            width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH,
-                            pathEffect = dashEffect
-                        )
-                    )
-
-                    // Inner safe zone (42% – always visible)
-                    drawCircle(
-                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA),
-                        radius = size.width * AdaptiveIconConfig.SAFE_ZONE_INNER / 2,
-                        center = Offset(centerX, centerY),
-                        style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH)
-                    )
-                }
-            } else {
-                // Empty state – show only safe zones
-                Canvas(modifier = Modifier.fillMaxSize()) {
-                    val centerX = size.width / 2
-                    val centerY = size.height / 2
-
-                    // Outer safe zone – dashed
-                    drawCircle(
-                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA),
-                        radius = size.width * AdaptiveIconConfig.SAFE_ZONE_OUTER / 2,
-                        center = Offset(centerX, centerY),
-                        style = Stroke(
-                            width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH,
-                            pathEffect = dashEffect
-                        )
-                    )
-
-                    // Inner safe zone – solid
-                    drawCircle(
-                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA),
-                        radius = size.width * AdaptiveIconConfig.SAFE_ZONE_INNER / 2,
-                        center = Offset(centerX, centerY),
-                        style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH)
-                    )
-                }
-            }
-        }
-
-        // Background color picker row
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(R.string.adaptive_icon_background_color),
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = LocalDialogTextColor.current,
-                modifier = Modifier.weight(1f)
-            )
-            Surface(
-                onClick = onBackgroundColorClick,
-                modifier = Modifier.size(40.dp),
-                shape = CircleShape,
-                color = parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) },
-                border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
-            ) {}
-        }
-
-        // Safe zone legend
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            SafeZoneLegendItem(
-                baseColor = legendColor,
-                alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
-                isDashed = false,
-                text = stringResource(R.string.adaptive_icon_safe_zone_inner)
-            )
-            SafeZoneLegendItem(
-                baseColor = legendColor,
-                alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
-                isDashed = true,
-                text = stringResource(R.string.adaptive_icon_safe_zone_outer)
-            )
-        }
-
-        // Scale slider
-        if (foregroundBitmap != null) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Image,
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Slider(
-                    value = scale,
-                    onValueChange = { onScaleChange(it) },
-                    valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
-                    modifier = Modifier.weight(1f)
-                )
-                Icon(
-                    imageVector = Icons.Outlined.Image,
-                    contentDescription = null,
-                    modifier = Modifier.size(22.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
-    }
-}
-
-/**
- * Preview for the notification icon - dark background simulating the status bar.
- * The foreground is drawn white (alpha-preserving) to reflect how Android renders
- * notification small icons.
- */
-@Composable
-private fun NotificationIconPreview(
-    foregroundBitmap: Bitmap,
+    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
     onScaleChange: (Float) -> Unit,
     onOffsetChange: (Float, Float) -> Unit
 ) {
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing)
+    // Guide color adapts to background brightness to keep circles visible
+    val previewGuideColor = remember(backgroundColor) {
+        val bgColor = backgroundColor.toColorOrNull()
+            ?: AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR.toColorOrNull()
+            ?: Color.Black
+        if (bgColor.isDarkBackground()) Color.White else Color.Black
+    }
+    // Dashed effect for snap guides and outer safe zone
+    val dashEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 6f), 0f)
+
+    Box(
+        modifier = Modifier
+            .size(AdaptiveIconConfig.PREVIEW_SIZE)
+            .clip(RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS))
+            .background(
+                parseColorToRgb(backgroundColor).let { (r, g, b) ->
+                    Color(r, g, b, backgroundAlpha)
+                }
+            )
+            .border(2.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(AdaptiveIconConfig.PREVIEW_CORNER_RADIUS)),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            text = stringResource(R.string.notification_icon_preview),
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.Bold,
-            color = LocalDialogTextColor.current
-        )
+        if (foregroundBitmap != null) {
+            var currentScale by remember { mutableFloatStateOf(scale) }
+            var currentOffsetX by remember { mutableFloatStateOf(offsetX) }
+            var currentOffsetY by remember { mutableFloatStateOf(offsetY) }
 
-        // Status-bar context strip
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(Color(0xFF1A1A1A))
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            // The notification icon canvas
-            Box(
+            LaunchedEffect(scale, offsetX, offsetY) {
+                currentScale = scale
+                currentOffsetX = offsetX
+                currentOffsetY = offsetY
+            }
+
+            Canvas(
                 modifier = Modifier
-                    .size(AdaptiveIconConfig.NOTIFICATION_PREVIEW_SIZE)
-                    .clip(CircleShape)
-                    .background(Color(0xFF1A1A1A))
-                    .border(1.dp, Color.White.copy(alpha = 0.15f), CircleShape),
-                contentAlignment = Alignment.Center
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, pan, zoom, _ ->
+                            currentScale *= zoom
+                            var newOffsetX = currentOffsetX + pan.x
+                            var newOffsetY = currentOffsetY + pan.y
+                            if (abs(newOffsetX) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetX = 0f
+                            if (abs(newOffsetY) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetY = 0f
+                            currentOffsetX = newOffsetX
+                            currentOffsetY = newOffsetY
+                            onScaleChange(currentScale)
+                            onOffsetChange(currentOffsetX, currentOffsetY)
+                        }
+                    }
             ) {
-                var currentOffsetX by remember { mutableFloatStateOf(offsetX) }
-                var currentOffsetY by remember { mutableFloatStateOf(offsetY) }
+                val centerX = size.width / 2
+                val centerY = size.height / 2
 
-                LaunchedEffect(offsetX, offsetY) {
-                    currentOffsetX = offsetX
-                    currentOffsetY = offsetY
+                // Draw foreground image
+                val imageBitmap = foregroundBitmap.asImageBitmap()
+
+                // Calculate base size by fitting image to canvas while maintaining aspect ratio
+                val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+                val canvasAspect = size.width / size.height  // For square canvas this is 1.0
+
+                val (baseWidth, baseHeight) = if (imageAspect > canvasAspect) {
+                    // Image is wider - fit to width
+                    size.width to (size.width / imageAspect)
+                } else {
+                    // Image is taller - fit to height
+                    (size.height * imageAspect) to size.height
                 }
 
-                Canvas(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .pointerInput(Unit) {
-                            detectTransformGestures { _, pan, _, _ ->
-                                var newOffsetX = currentOffsetX + pan.x
-                                var newOffsetY = currentOffsetY + pan.y
-                                if (abs(newOffsetX) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetX = 0f
-                                if (abs(newOffsetY) < AdaptiveIconConfig.SNAP_THRESHOLD) newOffsetY = 0f
-                                currentOffsetX = newOffsetX
-                                currentOffsetY = newOffsetY
-                                onOffsetChange(currentOffsetX, currentOffsetY)
-                            }
-                        }
-                ) {
-                    val centerX = size.width / 2
-                    val centerY = size.height / 2
-                    val imageBitmap = foregroundBitmap.asImageBitmap()
-                    val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+                // Apply user scale to the fitted size
+                val scaledWidth = baseWidth * currentScale
+                val scaledHeight = baseHeight * currentScale
 
-                    val (baseWidth, baseHeight) = if (imageAspect > 1f)
-                        size.width to (size.width / imageAspect)
-                    else
-                        (size.height * imageAspect) to size.height
+                // Calculate position with offset
+                val left = centerX - (scaledWidth / 2) + currentOffsetX
+                val top = centerY - (scaledHeight / 2) + currentOffsetY
 
-                    val scaledWidth = baseWidth * scale
-                    val scaledHeight = baseHeight * scale
-                    val left = centerX - scaledWidth / 2 + currentOffsetX
-                    val top = centerY - scaledHeight / 2 + currentOffsetY
+                drawImage(
+                    image = imageBitmap,
+                    dstOffset = IntOffset(left.toInt(), top.toInt()),
+                    dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt())
+                )
 
-                    drawImage(
-                        image = imageBitmap,
-                        dstOffset = IntOffset(left.toInt(), top.toInt()),
-                        dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt()),
-                        colorFilter = colorMatrix(
-                            androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
-                                0f, 0f, 0f, 0f, 255f,
-                                0f, 0f, 0f, 0f, 255f,
-                                0f, 0f, 0f, 0f, 255f,
-                                0f, 0f, 0f, 1f, 0f
-                            ))
-                        )
+                // Draw dashed snap guides when close to center
+                if (abs(currentOffsetX) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD) {
+                    // Vertical center line
+                    drawLine(
+                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SNAP_GUIDE_ALPHA),
+                        start = Offset(centerX, 0f),
+                        end = Offset(centerX, size.height),
+                        strokeWidth = AdaptiveIconConfig.SNAP_GUIDE_STROKE_WIDTH,
+                        pathEffect = dashEffect
                     )
                 }
-            }
+                if (abs(currentOffsetY) < AdaptiveIconConfig.SNAP_GUIDE_THRESHOLD) {
+                    // Horizontal center line
+                    drawLine(
+                        color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SNAP_GUIDE_ALPHA),
+                        start = Offset(0f, centerY),
+                        end = Offset(size.width, centerY),
+                        strokeWidth = AdaptiveIconConfig.SNAP_GUIDE_STROKE_WIDTH,
+                        pathEffect = dashEffect
+                    )
+                }
 
-            // Placeholder notification text to give context
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Box(
-                    modifier = Modifier
-                        .width(100.dp)
-                        .height(8.dp)
-                        .clip(RoundedCornerShape(4.dp))
-                        .background(Color.White.copy(alpha = 0.4f))
+                // Outer safe zone (66%, mask area)
+                val outerSize = size.width * AdaptiveIconConfig.SAFE_ZONE_OUTER
+                val outerCorner = outerSize * (AdaptiveIconConfig.PREVIEW_CORNER_RADIUS.value / AdaptiveIconConfig.PREVIEW_SIZE.value)
+                drawRoundRect(
+                    color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA),
+                    topLeft = Offset(centerX - outerSize / 2, centerY - outerSize / 2),
+                    size = androidx.compose.ui.geometry.Size(outerSize, outerSize),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(outerCorner),
+                    style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH, pathEffect = dashEffect)
                 )
-                Box(
-                    modifier = Modifier
-                        .width(60.dp)
-                        .height(6.dp)
-                        .clip(RoundedCornerShape(3.dp))
-                        .background(Color.White.copy(alpha = 0.2f))
+                // Inner safe zone (42%, always visible)
+                val innerSize = size.width * AdaptiveIconConfig.SAFE_ZONE_INNER
+                val innerCorner = innerSize * (AdaptiveIconConfig.PREVIEW_CORNER_RADIUS.value / AdaptiveIconConfig.PREVIEW_SIZE.value)
+                drawRoundRect(
+                    color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA),
+                    topLeft = Offset(centerX - innerSize / 2, centerY - innerSize / 2),
+                    size = androidx.compose.ui.geometry.Size(innerSize, innerSize),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(innerCorner),
+                    style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH)
+                )
+            }
+        } else {
+            // Empty state, show only safe zones
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val centerX = size.width / 2
+                val centerY = size.height / 2
+                // Outer safe zone, dashed
+                val outerSize = size.width * AdaptiveIconConfig.SAFE_ZONE_OUTER
+                val outerCorner = outerSize * (AdaptiveIconConfig.PREVIEW_CORNER_RADIUS.value / AdaptiveIconConfig.PREVIEW_SIZE.value)
+                drawRoundRect(
+                    color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA),
+                    topLeft = Offset(centerX - outerSize / 2, centerY - outerSize / 2),
+                    size = androidx.compose.ui.geometry.Size(outerSize, outerSize),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(outerCorner),
+                    style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH, pathEffect = dashEffect)
+                )
+                // Inner safe zone, solid
+                val innerSize = size.width * AdaptiveIconConfig.SAFE_ZONE_INNER
+                val innerCorner = innerSize * (AdaptiveIconConfig.PREVIEW_CORNER_RADIUS.value / AdaptiveIconConfig.PREVIEW_SIZE.value)
+                drawRoundRect(
+                    color = previewGuideColor.copy(alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA),
+                    topLeft = Offset(centerX - innerSize / 2, centerY - innerSize / 2),
+                    size = androidx.compose.ui.geometry.Size(innerSize, innerSize),
+                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(innerCorner),
+                    style = Stroke(width = AdaptiveIconConfig.SAFE_ZONE_STROKE_WIDTH)
                 )
             }
         }
+    }
+}
 
-        // Scale slider
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Image,
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                tint = LocalDialogSecondaryTextColor.current
-            )
-            Slider(
-                value = scale,
-                onValueChange = { onScaleChange(it) },
-                valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
-                modifier = Modifier.weight(1f)
-            )
-            Icon(
-                imageVector = Icons.Outlined.Image,
-                contentDescription = null,
-                modifier = Modifier.size(22.dp),
-                tint = LocalDialogSecondaryTextColor.current
+/**
+ * Notification icon preview (dark background).
+ * Recolors all pixels white (alpha-preserving) to simulate Android notification rendering.
+ */
+@Composable
+private fun NotificationIconCanvas(
+    bitmap: Bitmap,
+    scale: Float
+) {
+    val shape = RoundedCornerShape(AdaptiveIconConfig.SMALL_PREVIEW_CORNER_RADIUS)
+    Box(
+        modifier = Modifier
+            .size(AdaptiveIconConfig.NOTIFICATION_PREVIEW_SIZE)
+            .clip(shape)
+            .background(Color(0xFF1A1A1A))
+            .border(1.dp, Color.White.copy(alpha = 0.15f), shape),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val centerX = size.width / 2
+            val centerY = size.height / 2
+            val imageBitmap = bitmap.asImageBitmap()
+            val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+            val (baseWidth, baseHeight) = if (imageAspect > 1f)
+                size.width to (size.width / imageAspect)
+            else
+                (size.height * imageAspect) to size.height
+            val scaledWidth = baseWidth * scale
+            val scaledHeight = baseHeight * scale
+            val left = centerX - scaledWidth / 2
+            val top = centerY - scaledHeight / 2
+            // Recolor all pixels white (alpha-preserving) to simulate how Android renders
+            // notification small icons in the status bar and notification drawer
+            drawImage(
+                image = imageBitmap,
+                dstOffset = IntOffset(left.toInt(), top.toInt()),
+                dstSize = IntSize(scaledWidth.toInt(), scaledHeight.toInt()),
+                colorFilter = colorMatrix(
+                    androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
+                        0f, 0f, 0f, 0f, 255f,
+                        0f, 0f, 0f, 0f, 255f,
+                        0f, 0f, 0f, 0f, 255f,
+                        0f, 0f, 0f, 1f, 0f
+                    ))
+                )
             )
         }
+    }
+}
 
+/**
+ * Non-interactive monochrome adaptive icon preview (40dp, surfaceVariant background).
+ * Mirrors the adaptive icon transforms so the result matches the generated XML layer.
+ * Renders black (alpha-preserving); the system tints the layer at runtime.
+ */
+@Composable
+private fun MonochromeAdaptiveCanvas(
+    bitmap: Bitmap,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float
+) {
+    val density = LocalDensity.current.density
+    val shape = RoundedCornerShape(AdaptiveIconConfig.SMALL_PREVIEW_CORNER_RADIUS)
+    Box(
+        modifier = Modifier
+            .size(AdaptiveIconConfig.NOTIFICATION_PREVIEW_SIZE)
+            .clip(shape)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), shape),
+        contentAlignment = Alignment.Center
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            // Map adaptive transforms from the PREVIEW_SIZE canvas to this small circle.
+            // canvasRatio converts preview-canvas pixels to this canvas's pixels.
+            val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * density
+            val imageBitmap = bitmap.asImageBitmap()
+            val imageAspect = imageBitmap.width.toFloat() / imageBitmap.height.toFloat()
+            val (baseWidth, baseHeight) = if (imageAspect > 1f)
+                previewCanvasSize to (previewCanvasSize / imageAspect)
+            else
+                (previewCanvasSize * imageAspect) to previewCanvasSize
+            val scaledWidth = baseWidth * scale
+            val scaledHeight = baseHeight * scale
+            val canvasRatio = size.width / previewCanvasSize
+            val dstWidth = scaledWidth * canvasRatio
+            val dstHeight = scaledHeight * canvasRatio
+            val dstOffsetX = offsetX * canvasRatio
+            val dstOffsetY = offsetY * canvasRatio
+            val left = (size.width - dstWidth) / 2 + dstOffsetX
+            val top = (size.height - dstHeight) / 2 + dstOffsetY
+            // Force all channels to black (alpha-preserving); system applies accent tint at runtime
+            drawImage(
+                image = imageBitmap,
+                dstOffset = IntOffset(left.toInt(), top.toInt()),
+                dstSize = IntSize(dstWidth.toInt(), dstHeight.toInt()),
+                colorFilter = colorMatrix(
+                    androidx.compose.ui.graphics.ColorMatrix(floatArrayOf(
+                        0f, 0f, 0f, 0f, 0f,
+                        0f, 0f, 0f, 0f, 0f,
+                        0f, 0f, 0f, 0f, 0f,
+                        0f, 0f, 0f, 1f, 0f
+                    ))
+                )
+            )
+        }
+    }
+}
+
+/**
+ * One section of the icon creation guide: bold title followed by a description.
+ */
+@Composable
+private fun AdaptiveIconGuideSection(title: String, body: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
-            text = stringResource(R.string.notification_icon_preview_hint),
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = LocalDialogTextColor.current
+        )
+        Text(
+            text = body,
             style = MaterialTheme.typography.bodySmall,
-            color = LocalDialogSecondaryTextColor.current,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(horizontal = 8.dp)
+            color = LocalDialogSecondaryTextColor.current
         )
     }
 }
 
 /**
- * Legend item for safe zones – shows a small circle with solid or dashed stroke.
+ * Legend item for safe zones, shows a small circle with solid or dashed stroke.
  */
 @Composable
 private fun SafeZoneLegendItem(
@@ -814,20 +888,17 @@ private fun SafeZoneLegendItem(
     text: String
 ) {
     val itemColor = baseColor.copy(alpha = alpha)
-
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Canvas(modifier = Modifier.size(16.dp)) {
             val dashEffect = if (isDashed) PathEffect.dashPathEffect(floatArrayOf(8f, 6f), 0f) else null
-            drawCircle(
+            val corner = size.minDimension * 0.25f
+            drawRoundRect(
                 color = itemColor,
-                radius = size.minDimension / 2,
-                style = Stroke(
-                    width = 2.5f,
-                    pathEffect = dashEffect
-                )
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(corner),
+                style = Stroke(width = 2.5f, pathEffect = dashEffect)
             )
         }
         Text(
@@ -857,12 +928,11 @@ private suspend fun createAdaptiveIcons(
     packageName: String,
     foregroundBitmap: Bitmap,
     backgroundColor: String,
+    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
-    notificationScale: Float,
-    notificationOffsetX: Float,
-    notificationOffsetY: Float
+    notificationScale: Float
 ): String? = withContext(Dispatchers.IO) {
     try {
         val baseDocDir = DocumentFile.fromTreeUri(context, baseUri) ?: return@withContext null
@@ -882,7 +952,7 @@ private suspend fun createAdaptiveIcons(
         // Get preview density for offset calculations
         val previewDensity = context.resources.displayMetrics.density
 
-        // Create icons for all densities
+        // Generate adaptive icon PNGs (foreground + background) for all densities
         AdaptiveIconConfig.DENSITY_CONFIGS.forEach { densityConfig ->
             createIconsForDensity(
                 context = context,
@@ -890,6 +960,7 @@ private suspend fun createAdaptiveIcons(
                 densityConfig = densityConfig,
                 foregroundBitmap = foregroundBitmap,
                 backgroundColor = backgroundColor,
+                backgroundAlpha = backgroundAlpha,
                 scale = scale,
                 offsetX = offsetX,
                 offsetY = offsetY,
@@ -897,20 +968,60 @@ private suspend fun createAdaptiveIcons(
             )
         }
 
-        // Create notification icons for all densities.
-        // The notification icon is the foreground with the same transforms applied,
-        // recolored to solid white to match Material Design guidelines for notification icons
+        // Monochrome and notification outputs are always derived from the foreground bitmap
+        val monochromeSrc = foregroundBitmap
+
+        // Generate notification icon PNGs for all densities
         AdaptiveIconConfig.NOTIFICATION_DENSITY_CONFIGS.forEach { densityConfig ->
             createNotificationIconForDensity(
                 context = context,
                 iconsDocDir = iconsDocDir,
                 densityConfig = densityConfig,
-                foregroundBitmap = foregroundBitmap,
+                sourceBitmap = monochromeSrc,
                 scale = notificationScale,
-                offsetX = notificationOffsetX,
-                offsetY = notificationOffsetY,
                 previewDensity = previewDensity
             )
+        }
+
+        // Generate XML VectorDrawable files in a 'drawable' folder
+        val drawableDocDir = iconsDocDir.getOrCreateDir(AdaptiveIconConfig.DRAWABLE_FOLDER_NAME)
+        if (drawableDocDir != null) {
+            val plainPaint = Paint().apply { isAntiAlias = true; isFilterBitmap = true; isDither = true }
+
+            // Monochrome adaptive layer: 108x108 viewport, using adaptive transforms
+            val adaptiveMonoBmp = renderBitmapWithAdaptiveTransforms(
+                sourceBitmap = monochromeSrc,
+                targetSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT,
+                scale = scale,
+                offsetX = offsetX,
+                offsetY = offsetY,
+                previewDensity = previewDensity,
+                paint = plainPaint
+            )
+            val adaptiveMonoXml = createMonochromeVectorXml(
+                bitmap = adaptiveMonoBmp,
+                viewportSize = AdaptiveIconConfig.MONOCHROME_ADAPTIVE_VIEWPORT,
+                // System tints the monochrome layer; fill color is overridden at runtime
+                fillColor = "#FF000000"
+            )
+            adaptiveMonoBmp.recycle()
+            saveXmlToDocFile(context, drawableDocDir, AdaptiveIconConfig.MONOCHROME_ADAPTIVE_FILE_NAME, adaptiveMonoXml)
+
+            // Notification icon XML: 24x24 viewport, using notification transforms
+            val notifMonoBmp = renderBitmapWithNotificationTransforms(
+                sourceBitmap = monochromeSrc,
+                targetSize = AdaptiveIconConfig.NOTIFICATION_XML_VIEWPORT,
+                scale = notificationScale,
+                previewDensity = previewDensity,
+                paint = plainPaint
+            )
+            val notifMonoXml = createMonochromeVectorXml(
+                bitmap = notifMonoBmp,
+                viewportSize = AdaptiveIconConfig.NOTIFICATION_XML_VIEWPORT,
+                fillColor = "#FFFFFFFF"
+            )
+            notifMonoBmp.recycle()
+            saveXmlToDocFile(context, drawableDocDir, AdaptiveIconConfig.NOTIFICATION_XML_FILE_NAME, notifMonoXml)
         }
 
         // Convert back to a real path so the patcher can reference it as a patch option value
@@ -922,7 +1033,7 @@ private suspend fun createAdaptiveIcons(
 }
 
 /**
- * Create icon files for a specific density.
+ * Create foreground and background icon files for a specific density.
  */
 private fun createIconsForDensity(
     context: Context,
@@ -930,6 +1041,7 @@ private fun createIconsForDensity(
     densityConfig: AdaptiveIconConfig.DensityConfig,
     foregroundBitmap: Bitmap,
     backgroundColor: String,
+    backgroundAlpha: Float,
     scale: Float,
     offsetX: Float,
     offsetY: Float,
@@ -938,12 +1050,13 @@ private fun createIconsForDensity(
     val targetSize = densityConfig.size
     val mipmapDocDir = iconsDocDir.getOrCreateDir(densityConfig.folderName) ?: return
 
-    // Background bitmap (solid color)
+    // Background bitmap (solid color with alpha support)
     val backgroundBitmap = createBitmap(targetSize, targetSize)
     val canvas = Canvas(backgroundBitmap)
     val rgb = parseColorToRgb(backgroundColor)
     val paint = Paint().apply {
-        color = android.graphics.Color.rgb(
+        color = android.graphics.Color.argb(
+            (backgroundAlpha * 255).toInt(),
             (rgb.first * 255).toInt(),
             (rgb.second * 255).toInt(),
             (rgb.third * 255).toInt()
@@ -952,111 +1065,46 @@ private fun createIconsForDensity(
     canvas.drawRect(0f, 0f, targetSize.toFloat(), targetSize.toFloat(), paint)
 
     // Create foreground bitmap with scaling and offset
-    val foregroundScaled = createBitmap(targetSize, targetSize)
-    val foregroundCanvas = Canvas(foregroundScaled)
-
-    // Preview canvas size in pixels
-    val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * previewDensity
-
-    // Calculate base size by fitting image to canvas (same logic as preview)
-    val imageAspect = foregroundBitmap.width.toFloat() / foregroundBitmap.height.toFloat()
-
-    val (baseWidth, baseHeight) = if (imageAspect > 1.0f) {
-        // Image is wider - fit to width
-        previewCanvasSize to (previewCanvasSize / imageAspect)
-    } else {
-        // Image is taller - fit to height
-        (previewCanvasSize * imageAspect) to previewCanvasSize
-    }
-
-    // Apply user scale to the fitted size
-    val scaledWidth = baseWidth * scale
-    val scaledHeight = baseHeight * scale
-
-    // Convert to target bitmap coordinates
-    val targetScaledWidth = scaledWidth * (targetSize / previewCanvasSize)
-    val targetScaledHeight = scaledHeight * (targetSize / previewCanvasSize)
-
-    // Convert offsets from preview canvas pixels to target bitmap pixels
-    val targetOffsetX = offsetX * (targetSize / previewCanvasSize)
-    val targetOffsetY = offsetY * (targetSize / previewCanvasSize)
-
-    val left = (targetSize - targetScaledWidth) / 2 + targetOffsetX
-    val top = (targetSize - targetScaledHeight) / 2 + targetOffsetY
-
-    // Create Paint with antialiasing and bicubic filtering for high-quality scaling
-    val bitmapPaint = Paint().apply {
-        isAntiAlias = true
-        isFilterBitmap = true
-        isDither = true
-    }
-    foregroundCanvas.drawBitmap(foregroundBitmap, null, RectF(left, top, left + targetScaledWidth, top + targetScaledHeight), bitmapPaint)
+    // Paint with antialiasing and bicubic filtering for high-quality scaling
+    val bitmapPaint = Paint().apply { isAntiAlias = true; isFilterBitmap = true; isDither = true }
+    val foregroundScaled = renderBitmapWithAdaptiveTransforms(
+        sourceBitmap = foregroundBitmap,
+        targetSize = targetSize,
+        scale = scale,
+        offsetX = offsetX,
+        offsetY = offsetY,
+        previewDensity = previewDensity,
+        paint = bitmapPaint
+    )
 
     mipmapDocDir.getOrCreateFile("image/png", AdaptiveIconConfig.BACKGROUND_FILE_NAME)
-        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out
-            -> backgroundBitmap.compress(Bitmap.CompressFormat.PNG, 100, out) } }
+        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out ->
+            backgroundBitmap.compress(Bitmap.CompressFormat.PNG, 100, out) } }
 
     mipmapDocDir.getOrCreateFile("image/png", AdaptiveIconConfig.FOREGROUND_FILE_NAME)
-        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out
-            -> foregroundScaled.compress(Bitmap.CompressFormat.PNG, 100, out) } }
+        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out ->
+            foregroundScaled.compress(Bitmap.CompressFormat.PNG, 100, out) } }
 
     backgroundBitmap.recycle()
     foregroundScaled.recycle()
 }
 
 /**
- * Create a notification icon for a specific density.
- *
- * Takes the foreground with the same scale/offset transforms applied and recolors
- * all pixels to solid white (preserving alpha) to match Material Design guidelines
- * for notification small icons.
+ * Create a notification icon PNG for a specific density.
+ * The source bitmap is recolored white (alpha-preserving) per Material Design guidelines.
  */
 private fun createNotificationIconForDensity(
     context: Context,
     iconsDocDir: DocumentFile,
     densityConfig: AdaptiveIconConfig.DensityConfig,
-    foregroundBitmap: Bitmap,
+    sourceBitmap: Bitmap,
     scale: Float,
-    offsetX: Float,
-    offsetY: Float,
     previewDensity: Float
 ) {
     val targetSize = densityConfig.size
 
     // Create drawable-<dpi> directory inside the icons folder
     val drawableDocDir = iconsDocDir.getOrCreateDir(densityConfig.folderName) ?: return
-
-    val notificationBitmap = createBitmap(targetSize, targetSize)
-    val canvas = Canvas(notificationBitmap)
-
-    // The notification icon should fill its small canvas the same way the foreground
-    // fills the adaptive icon safe zone. We therefore express the user's transform
-    // relative to the safe zone size and then map it onto the full notification canvas
-    val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * previewDensity
-    val imageAspect = foregroundBitmap.width.toFloat() / foregroundBitmap.height.toFloat()
-
-    // Size of the outer safe zone in preview canvas pixels
-    val safeZoneSize = previewCanvasSize * AdaptiveIconConfig.SAFE_ZONE_OUTER
-
-    // Base fitted size - fitted to safe zone, not the full canvas
-    val (baseWidth, baseHeight) = if (imageAspect > 1.0f) {
-        safeZoneSize to (safeZoneSize / imageAspect)
-    } else {
-        (safeZoneSize * imageAspect) to safeZoneSize
-    }
-
-    // Apply user scale, then map to target notification canvas size
-    val scaledWidth = baseWidth * scale
-    val scaledHeight = baseHeight * scale
-    val targetScaledWidth = scaledWidth * (targetSize / safeZoneSize)
-    val targetScaledHeight = scaledHeight * (targetSize / safeZoneSize)
-
-    // Offset is also relative to the safe zone so that the same visual shift
-    // the user sees in the preview is preserved in the notification icon
-    val targetOffsetX = offsetX * (targetSize / safeZoneSize)
-    val targetOffsetY = offsetY * (targetSize / safeZoneSize)
-    val left = (targetSize - targetScaledWidth) / 2 + targetOffsetX
-    val top = (targetSize - targetScaledHeight) / 2 + targetOffsetY
 
     // ColorMatrix that turns every pixel white while keeping its alpha channel intact:
     //   R = 1, G = 1, B = 1, A = original alpha
@@ -1072,11 +1120,155 @@ private fun createNotificationIconForDensity(
         )))
     }
 
-    canvas.drawBitmap(foregroundBitmap, null, RectF(left, top, left + targetScaledWidth, top + targetScaledHeight), whitePaint)
+    val notificationBitmap = renderBitmapWithNotificationTransforms(
+        sourceBitmap = sourceBitmap,
+        targetSize = targetSize,
+        scale = scale,
+        previewDensity = previewDensity,
+        paint = whitePaint
+    )
 
     drawableDocDir.getOrCreateFile("image/png", AdaptiveIconConfig.NOTIFICATION_FILE_NAME)
-        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out
-            -> notificationBitmap.compress(Bitmap.CompressFormat.PNG, 100, out) } }
+        ?.let { context.contentResolver.openOutputStream(it.uri)?.use { out ->
+            notificationBitmap.compress(Bitmap.CompressFormat.PNG, 100, out) } }
 
     notificationBitmap.recycle()
+}
+
+/**
+ * Render [sourceBitmap] into a [targetSize]×[targetSize] canvas using the same
+ * coordinate mapping as the adaptive icon preview (fitted to full preview canvas).
+ */
+private fun renderBitmapWithAdaptiveTransforms(
+    sourceBitmap: Bitmap,
+    targetSize: Int,
+    scale: Float,
+    offsetX: Float,
+    offsetY: Float,
+    previewDensity: Float,
+    paint: Paint = Paint().apply { isAntiAlias = true; isFilterBitmap = true }
+): Bitmap {
+    val result = createBitmap(targetSize, targetSize)
+    val canvas = Canvas(result)
+    // Preview canvas size in pixels, the coordinate origin for scale/offset values
+    val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * previewDensity
+    // Calculate base size by fitting image to canvas (same logic as preview composable)
+    val imageAspect = sourceBitmap.width.toFloat() / sourceBitmap.height.toFloat()
+    val (baseWidth, baseHeight) = if (imageAspect > 1f) {
+        // Image is wider - fit to width
+        previewCanvasSize to (previewCanvasSize / imageAspect)
+    } else {
+        // Image is taller - fit to height
+        (previewCanvasSize * imageAspect) to previewCanvasSize
+    }
+    // Apply user scale to the fitted size
+    val scaledWidth = baseWidth * scale
+    val scaledHeight = baseHeight * scale
+    // Map from preview-canvas coordinates to target-bitmap coordinates
+    val ratio = targetSize / previewCanvasSize
+    val targetScaledWidth = scaledWidth * ratio
+    val targetScaledHeight = scaledHeight * ratio
+    // Convert offsets from preview-canvas pixels to target-bitmap pixels
+    val targetOffsetX = offsetX * ratio
+    val targetOffsetY = offsetY * ratio
+    val left = (targetSize - targetScaledWidth) / 2 + targetOffsetX
+    val top = (targetSize - targetScaledHeight) / 2 + targetOffsetY
+    canvas.drawBitmap(sourceBitmap, null, RectF(left, top, left + targetScaledWidth, top + targetScaledHeight), paint)
+    return result
+}
+
+/**
+ * Render [sourceBitmap] into a [targetSize]×[targetSize] canvas using the notification
+ * icon coordinate mapping (fitted to the outer safe zone region).
+ */
+private fun renderBitmapWithNotificationTransforms(
+    sourceBitmap: Bitmap,
+    targetSize: Int,
+    scale: Float,
+    previewDensity: Float,
+    paint: Paint = Paint().apply { isAntiAlias = true; isFilterBitmap = true }
+): Bitmap {
+    val result = createBitmap(targetSize, targetSize)
+    val canvas = Canvas(result)
+    // The notification icon should fill its small canvas the same way the foreground
+    // fills the adaptive icon safe zone. We therefore express the user's transform
+    // relative to the safe zone size and then map it onto the full notification canvas.
+    val previewCanvasSize = AdaptiveIconConfig.PREVIEW_SIZE.value * previewDensity
+    // Size of the outer safe zone in preview canvas pixels
+    val safeZoneSize = previewCanvasSize * AdaptiveIconConfig.SAFE_ZONE_OUTER
+    // Base fitted size, fitted to safe zone, not the full canvas
+    val imageAspect = sourceBitmap.width.toFloat() / sourceBitmap.height.toFloat()
+    val (baseWidth, baseHeight) = if (imageAspect > 1f) {
+        safeZoneSize to (safeZoneSize / imageAspect)
+    } else {
+        (safeZoneSize * imageAspect) to safeZoneSize
+    }
+    // Apply user scale, then map to target notification canvas size
+    val scaledWidth = baseWidth * scale
+    val scaledHeight = baseHeight * scale
+    val ratio = targetSize / safeZoneSize
+    val targetScaledWidth = scaledWidth * ratio
+    val targetScaledHeight = scaledHeight * ratio
+    val left = (targetSize - targetScaledWidth) / 2
+    val top = (targetSize - targetScaledHeight) / 2
+    canvas.drawBitmap(sourceBitmap, null, RectF(left, top, left + targetScaledWidth, top + targetScaledHeight), paint)
+    return result
+}
+
+/**
+ * Convert a bitmap's alpha channel to SVG/VectorDrawable path data using scanline spans.
+ * Each row of opaque pixels (alpha > 127) is encoded as one or more horizontal rect commands.
+ */
+private fun bitmapToVectorPathData(bitmap: Bitmap): String {
+    val width = bitmap.width
+    val height = bitmap.height
+    val sb = StringBuilder()
+    // Each row is scanned left-to-right; adjacent opaque pixels are merged into spans,
+    // so the number of path commands equals the number of horizontal spans, not pixels.
+    for (y in 0 until height) {
+        var spanStart = -1
+        for (x in 0 until width) {
+            val opaque = android.graphics.Color.alpha(bitmap[x, y]) > 127
+            if (opaque && spanStart == -1) {
+                spanStart = x
+            } else if (!opaque && spanStart != -1) {
+                val w = x - spanStart
+                sb.append("M${spanStart},${y}h${w}v1h-${w}z")
+                spanStart = -1
+            }
+        }
+        if (spanStart != -1) {
+            val w = width - spanStart
+            sb.append("M${spanStart},${y}h${w}v1h-${w}z")
+        }
+    }
+    return sb.toString()
+}
+
+/**
+ * Create an Android VectorDrawable XML string from a pre-rendered monochrome bitmap.
+ * The bitmap's alpha channel defines the icon shape; [fillColor] sets the path fill.
+ */
+private fun createMonochromeVectorXml(bitmap: Bitmap, viewportSize: Int, fillColor: String): String {
+    val pathData = bitmapToVectorPathData(bitmap)
+    return """<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="${viewportSize}dp"
+    android:height="${viewportSize}dp"
+    android:viewportWidth="$viewportSize"
+    android:viewportHeight="$viewportSize">
+    <path
+        android:fillColor="$fillColor"
+        android:pathData="$pathData" />
+</vector>"""
+}
+
+/**
+ * Write an XML string to a DocumentFile, truncating any previous content.
+ */
+private fun saveXmlToDocFile(context: Context, dir: DocumentFile, fileName: String, content: String) {
+    val file = dir.getOrCreateFile("text/xml", fileName) ?: return
+    context.contentResolver.openOutputStream(file.uri, "wt")?.use { out ->
+        out.write(content.toByteArray(Charsets.UTF_8))
+    }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -100,6 +100,8 @@ private object AdaptiveIconConfig {
     // Transform constraints
     const val MIN_SCALE = 0.5f
     const val MAX_SCALE = 3.0f
+    // Notification icon must not exceed the status bar slot boundary
+    const val MAX_NOTIFICATION_SCALE = 1f
     const val MAX_OFFSET = 200f
 
     // Snap to center thresholds (in pixels)
@@ -437,10 +439,10 @@ fun AdaptiveIconCreatorDialog(
                             onValueChange = {
                                 notificationScale = it.coerceIn(
                                     AdaptiveIconConfig.MIN_SCALE,
-                                    AdaptiveIconConfig.MAX_SCALE
+                                    AdaptiveIconConfig.MAX_NOTIFICATION_SCALE
                                 )
                             },
-                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
+                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_NOTIFICATION_SCALE,
                             modifier = Modifier.weight(1f)
                         )
                         Icon(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -15,8 +15,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Image
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -114,12 +115,13 @@ private object AdaptiveIconConfig {
     const val SNAP_GUIDE_STROKE_WIDTH = 1.5f
     const val SNAP_GUIDE_ALPHA = 0.6f
 
-    // Default background color
-    const val DEFAULT_BACKGROUND_COLOR = "#B3E5FC"
+    // Default background colors per system theme
+    const val DEFAULT_BACKGROUND_COLOR_LIGHT = "#E3F2FD"
+    const val DEFAULT_BACKGROUND_COLOR_DARK = "#1565C0"
 
     // Preview sizes
-    val PREVIEW_SIZE = 130.dp
-    val NOTIFICATION_PREVIEW_SIZE = 52.dp
+    val PREVIEW_SIZE = 150.dp
+    val NOTIFICATION_PREVIEW_SIZE = 60.dp
 
     // Adaptive icon preview shape, squircle approximation matching Pixel launcher mask
     val PREVIEW_CORNER_RADIUS = 28.dp
@@ -146,7 +148,13 @@ fun AdaptiveIconCreatorDialog(
 
     var foregroundUri by remember { mutableStateOf<Uri?>(null) }
     var foregroundBitmap by remember { mutableStateOf<Bitmap?>(null) }
-    var backgroundColor by remember { mutableStateOf(AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR) }
+    val isDarkTheme = isSystemInDarkTheme()
+    var backgroundColor by remember {
+        mutableStateOf(
+            if (isDarkTheme) AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_DARK
+            else AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_LIGHT
+        )
+    }
     val showColorPicker = remember { mutableStateOf(false) }
     val showInfoDialog = remember { mutableStateOf(false) }
 
@@ -496,28 +504,30 @@ fun AdaptiveIconCreatorDialog(
 
                 HorizontalDivider()
 
-                // 4. Background color picker and alpha slider on separate rows
-                Column(
+                // 4. Background color swatch - tap to open picker
+                Text(
+                    text = stringResource(R.string.adaptive_icon_background_color),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = LocalDialogSecondaryTextColor.current,
                     modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                    textAlign = TextAlign.Center
+                )
+                val swatchColor = parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) }
+                Surface(
+                    onClick = { showColorPicker.value = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = swatchColor,
+                    border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Surface(
-                            onClick = { showColorPicker.value = true },
-                            modifier = Modifier.size(36.dp),
-                            shape = CircleShape,
-                            color = parseColorToRgb(backgroundColor).let { (r, g, b) -> Color(r, g, b) },
-                            border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
-                        ) {}
+                    Box(contentAlignment = Alignment.Center) {
                         Text(
-                            text = stringResource(R.string.adaptive_icon_background_color),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = LocalDialogTextColor.current
+                            text = backgroundColor.uppercase(),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = if (swatchColor.requiresLightContent()) Color.White else Color.Black
                         )
                     }
                 }
@@ -603,7 +613,7 @@ private fun AdaptiveIconPreview(
     // Guide color adapts to background brightness to keep circles visible
     val previewGuideColor = remember(backgroundColor) {
         val bgColor = backgroundColor.toColorOrNull()
-            ?: AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR.toColorOrNull()
+            ?: AdaptiveIconConfig.DEFAULT_BACKGROUND_COLOR_LIGHT.toColorOrNull()
             ?: Color.Black
         if (bgColor.isDarkBackground()) Color.White else Color.Black
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -185,9 +185,12 @@ fun AdaptiveIconCreatorDialog(
     val successMessage = stringResource(R.string.adaptive_icon_created_success)
     val failureMessage = stringResource(R.string.adaptive_icon_creation_failed)
 
+    var isCreating by remember { mutableStateOf(false) }
+
     // Folder picker for saving
     val openFolderPicker = rememberFolderPicker { uri ->
         scope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) { isCreating = true }
             try {
                 val success = createAdaptiveIcons(
                     context = context,
@@ -202,6 +205,7 @@ fun AdaptiveIconCreatorDialog(
                     notificationScale = notificationScale
                 )
                 withContext(Dispatchers.Main) {
+                    isCreating = false
                     if (success != null) {
                         context.toast(successMessage)
                         onIconCreated(success)
@@ -211,13 +215,16 @@ fun AdaptiveIconCreatorDialog(
                     }
                 }
             } catch (e: Exception) {
-                withContext(Dispatchers.Main) { context.toast("Failed to create icon: ${e.message}") }
+                withContext(Dispatchers.Main) {
+                    isCreating = false
+                    context.toast("Failed to create icon: ${e.message}")
+                }
             }
         }
     }
 
     MorpheDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.adaptive_icon_create),
         titleTrailingContent = {
             IconButton(onClick = { showInfoDialog.value = true }) {
@@ -234,294 +241,330 @@ fun AdaptiveIconCreatorDialog(
             MorpheDialogButton(
                 text = stringResource(R.string.adaptive_icon_create),
                 onClick = { openFolderPicker() },
-                enabled = foregroundBitmap != null,
+                enabled = foregroundBitmap != null && !isCreating,
                 icon = Icons.Outlined.Save,
                 modifier = Modifier.fillMaxWidth()
             )
         }
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            // Foreground image picker
-            MorpheDialogOutlinedButton(
-                text = if (foregroundUri == null)
-                    stringResource(R.string.adaptive_icon_select_image)
-                else
-                    stringResource(R.string.adaptive_icon_change_image),
-                onClick = { openForegroundPicker() },
-                icon = Icons.Outlined.Image,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            // 2. Preview row: large adaptive circle on the left, small notification +
-            //    monochrome circles stacked vertically on the right (only when a source exists).
-            //    IntrinsicSize.Min lets the right column stretch to match the adaptive circle's height.
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(IntrinsicSize.Min),
-                horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.CenterHorizontally),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Large adaptive preview
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.adaptive_icon_label),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
-                    AdaptiveIconPreview(
-                        foregroundBitmap = foregroundBitmap,
-                        backgroundColor = backgroundColor,
-                        backgroundAlpha = backgroundAlpha,
-                        scale = scale,
-                        offsetX = offsetX,
-                        offsetY = offsetY,
-                        onScaleChange = { scale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
-                        onOffsetChange = { x, y ->
-                            offsetX = x.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                            offsetY = y.coerceIn(-AdaptiveIconConfig.MAX_OFFSET, AdaptiveIconConfig.MAX_OFFSET)
-                        }
-                    )
-                }
-
-                // Small previews, fill the same height as the adaptive column via SpaceBetween
-                foregroundBitmap?.let { bitmap ->
-                    Column(
-                        modifier = Modifier.fillMaxHeight(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        // Notification preview, white-on-dark, scale only
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.notification_icon_preview),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = LocalDialogSecondaryTextColor.current
-                            )
-                            NotificationIconCanvas(
-                                bitmap = bitmap,
-                                scale = notificationScale
-                            )
-                        }
-                        // Monochrome adaptive preview, non-interactive, mirrors adaptive transforms
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(
-                                text = stringResource(R.string.adaptive_icon_monochrome_label),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = LocalDialogSecondaryTextColor.current
-                            )
-                            MonochromeAdaptiveCanvas(
-                                bitmap = bitmap,
-                                scale = scale,
-                                offsetX = offsetX,
-                                offsetY = offsetY
-                            )
-                        }
-                    }
-                }
-            }
-
-            // Safe zone legend
-            val legendColor = MaterialTheme.colorScheme.onSurface
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(start = 36.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                SafeZoneLegendItem(
-                    baseColor = legendColor,
-                    alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
-                    isDashed = false,
-                    text = stringResource(R.string.adaptive_icon_safe_zone_inner)
-                )
-                SafeZoneLegendItem(
-                    baseColor = legendColor,
-                    alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
-                    isDashed = true,
-                    text = stringResource(R.string.adaptive_icon_safe_zone_outer)
-                )
-            }
-
-            // 3. Scale/offset sliders, grouped together, shown only when relevant
-            if (foregroundBitmap != null) {
-                HorizontalDivider()
-
-                // Adaptive slider
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.adaptive_icon_label),
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium,
-                        color = LocalDialogSecondaryTextColor.current,
-                        modifier = Modifier.width(72.dp)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    Slider(
-                        value = scale,
-                        onValueChange = { scale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
-                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(22.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    AnimatedVisibility(
-                        visible = scale != 1f || offsetX != 0f || offsetY != 0f,
-                        enter = MorpheAnimations.expandFadeEnter,
-                        exit = MorpheAnimations.shrinkFadeExit
-                    ) {
-                        IconButton(
-                            onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
-                            modifier = Modifier.size(40.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.RestartAlt,
-                                contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-
-                // Notification slider
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.notification_icon_preview),
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.Medium,
-                        color = LocalDialogSecondaryTextColor.current,
-                        modifier = Modifier.width(72.dp)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    Slider(
-                        value = notificationScale,
-                        onValueChange = { notificationScale = it.coerceIn(AdaptiveIconConfig.MIN_SCALE, AdaptiveIconConfig.MAX_SCALE) },
-                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(22.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    AnimatedVisibility(
-                        visible = notificationScale != 1f,
-                        enter = MorpheAnimations.expandFadeEnter,
-                        exit = MorpheAnimations.shrinkFadeExit
-                    ) {
-                        IconButton(
-                            onClick = { notificationScale = 1f },
-                            modifier = Modifier.size(40.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.RestartAlt,
-                                contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                modifier = Modifier.size(24.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                    }
-                }
-            }
-
-            HorizontalDivider()
-
-            // 4. Background color picker and alpha slider on separate rows
+        Box(modifier = Modifier.fillMaxWidth()) {
             Column(
                 modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
+                // Foreground image picker
+                MorpheDialogOutlinedButton(
+                    text = if (foregroundUri == null)
+                        stringResource(R.string.adaptive_icon_select_image)
+                    else
+                        stringResource(R.string.adaptive_icon_change_image),
+                    onClick = { openForegroundPicker() },
+                    icon = Icons.Outlined.Image,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // 2. Preview row: large adaptive circle on the left, small notification +
+                //    monochrome circles stacked vertically on the right (only when a source exists).
+                //    IntrinsicSize.Min lets the right column stretch to match the adaptive circle's height.
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min),
+                    horizontalArrangement = Arrangement.spacedBy(
+                        40.dp,
+                        Alignment.CenterHorizontally
+                    ),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Surface(
-                        onClick = { showColorPicker.value = true },
-                        modifier = Modifier.size(36.dp),
-                        shape = CircleShape,
-                        color = parseColorToRgb(backgroundColor).let { (r, g, b) ->
-                            Color(r, g, b, backgroundAlpha)
-                        },
-                        border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
-                    ) {}
-                    Text(
-                        text = stringResource(R.string.adaptive_icon_background_color),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = LocalDialogTextColor.current
+                    // Large adaptive preview
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.adaptive_icon_label),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
+                        AdaptiveIconPreview(
+                            foregroundBitmap = foregroundBitmap,
+                            backgroundColor = backgroundColor,
+                            backgroundAlpha = backgroundAlpha,
+                            scale = scale,
+                            offsetX = offsetX,
+                            offsetY = offsetY,
+                            onScaleChange = {
+                                scale = it.coerceIn(
+                                    AdaptiveIconConfig.MIN_SCALE,
+                                    AdaptiveIconConfig.MAX_SCALE
+                                )
+                            },
+                            onOffsetChange = { x, y ->
+                                offsetX = x.coerceIn(
+                                    -AdaptiveIconConfig.MAX_OFFSET,
+                                    AdaptiveIconConfig.MAX_OFFSET
+                                )
+                                offsetY = y.coerceIn(
+                                    -AdaptiveIconConfig.MAX_OFFSET,
+                                    AdaptiveIconConfig.MAX_OFFSET
+                                )
+                            }
+                        )
+                    }
+
+                    // Small previews, fill the same height as the adaptive column via SpaceBetween
+                    foregroundBitmap?.let { bitmap ->
+                        Column(
+                            modifier = Modifier.fillMaxHeight(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            // Notification preview, white-on-dark, scale only
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.notification_icon_preview),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = LocalDialogSecondaryTextColor.current
+                                )
+                                NotificationIconCanvas(
+                                    bitmap = bitmap,
+                                    scale = notificationScale
+                                )
+                            }
+                            // Monochrome adaptive preview, non-interactive, mirrors adaptive transforms
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.adaptive_icon_monochrome_label),
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = LocalDialogSecondaryTextColor.current
+                                )
+                                MonochromeAdaptiveCanvas(
+                                    bitmap = bitmap,
+                                    scale = scale,
+                                    offsetX = offsetX,
+                                    offsetY = offsetY
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Safe zone legend
+                val legendColor = MaterialTheme.colorScheme.onSurface
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 36.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_INNER_ALPHA,
+                        isDashed = false,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_inner)
+                    )
+                    SafeZoneLegendItem(
+                        baseColor = legendColor,
+                        alpha = AdaptiveIconConfig.SAFE_ZONE_OUTER_ALPHA,
+                        isDashed = true,
+                        text = stringResource(R.string.adaptive_icon_safe_zone_outer)
                     )
                 }
-                Row(
+
+                // 3. Scale/offset sliders, grouped together, shown only when relevant
+                if (foregroundBitmap != null) {
+                    HorizontalDivider()
+
+                    // Adaptive slider
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.adaptive_icon_label),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            color = LocalDialogSecondaryTextColor.current,
+                            modifier = Modifier.width(72.dp)
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.Image,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        Slider(
+                            value = scale,
+                            onValueChange = {
+                                scale = it.coerceIn(
+                                    AdaptiveIconConfig.MIN_SCALE,
+                                    AdaptiveIconConfig.MAX_SCALE
+                                )
+                            },
+                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.Image,
+                            contentDescription = null,
+                            modifier = Modifier.size(22.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        AnimatedVisibility(
+                            visible = scale != 1f || offsetX != 0f || offsetY != 0f,
+                            enter = MorpheAnimations.expandFadeEnter,
+                            exit = MorpheAnimations.shrinkFadeExit
+                        ) {
+                            IconButton(
+                                onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.RestartAlt,
+                                    contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                    modifier = Modifier.size(24.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+
+                    // Notification slider
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.notification_icon_preview),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            color = LocalDialogSecondaryTextColor.current,
+                            modifier = Modifier.width(72.dp)
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.Image,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        Slider(
+                            value = notificationScale,
+                            onValueChange = {
+                                notificationScale = it.coerceIn(
+                                    AdaptiveIconConfig.MIN_SCALE,
+                                    AdaptiveIconConfig.MAX_SCALE
+                                )
+                            },
+                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.Image,
+                            contentDescription = null,
+                            modifier = Modifier.size(22.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        AnimatedVisibility(
+                            visible = notificationScale != 1f,
+                            enter = MorpheAnimations.expandFadeEnter,
+                            exit = MorpheAnimations.shrinkFadeExit
+                        ) {
+                            IconButton(
+                                onClick = { notificationScale = 1f },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.RestartAlt,
+                                    contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                                    modifier = Modifier.size(24.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    }
+                }
+
+                HorizontalDivider()
+
+                // 4. Background color picker and alpha slider on separate rows
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Opacity,
-                        contentDescription = null,
-                        modifier = Modifier.size(14.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    Slider(
-                        value = backgroundAlpha,
-                        onValueChange = { backgroundAlpha = it },
-                        valueRange = 0f..1f,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Opacity,
-                        contentDescription = null,
-                        modifier = Modifier.size(22.dp),
-                        tint = LocalDialogSecondaryTextColor.current
-                    )
-                    Text(
-                        text = "${(backgroundAlpha * 100).toInt()}%",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = LocalDialogSecondaryTextColor.current,
-                        modifier = Modifier.width(32.dp),
-                        textAlign = TextAlign.End
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Surface(
+                            onClick = { showColorPicker.value = true },
+                            modifier = Modifier.size(36.dp),
+                            shape = CircleShape,
+                            color = parseColorToRgb(backgroundColor).let { (r, g, b) ->
+                                Color(r, g, b, backgroundAlpha)
+                            },
+                            border = BorderStroke(2.dp, MaterialTheme.colorScheme.outline)
+                        ) {}
+                        Text(
+                            text = stringResource(R.string.adaptive_icon_background_color),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = LocalDialogTextColor.current
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Opacity,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        Slider(
+                            value = backgroundAlpha,
+                            onValueChange = { backgroundAlpha = it },
+                            valueRange = 0f..1f,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.Opacity,
+                            contentDescription = null,
+                            modifier = Modifier.size(22.dp),
+                            tint = LocalDialogSecondaryTextColor.current
+                        )
+                        Text(
+                            text = "${(backgroundAlpha * 100).toInt()}%",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LocalDialogSecondaryTextColor.current,
+                            modifier = Modifier.width(32.dp),
+                            textAlign = TextAlign.End
+                        )
+                    }
+                }
+            }
+            if (isCreating) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
                 }
             }
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.ColorFilter.Companion.colorMatrix
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -536,7 +537,14 @@ fun AdaptiveIconCreatorDialog(
                 Box(
                     modifier = Modifier
                         .matchParentSize()
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f)),
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f))
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                                }
+                            }
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -290,7 +290,6 @@ fun HeaderCreatorDialog(
                                 .fillMaxWidth()
                                 .padding(horizontal = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Outlined.Image,
@@ -298,12 +297,14 @@ fun HeaderCreatorDialog(
                                 modifier = Modifier.size(16.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            Spacer(Modifier.width(8.dp))
                             Slider(
                                 value = lightScale,
                                 onValueChange = { lightScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
                                 valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
                                 modifier = Modifier.weight(1f)
                             )
+                            Spacer(Modifier.width(8.dp))
                             Icon(
                                 imageVector = Icons.Outlined.Image,
                                 contentDescription = null,
@@ -311,15 +312,18 @@ fun HeaderCreatorDialog(
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             AnimatedVisibility(visible = lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
-                                IconButton(
-                                    onClick = { lightScale = 1f; lightOffsetX = 0f; lightOffsetY = 0f },
-                                    modifier = Modifier.size(40.dp)
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.RestartAlt,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
+                                Row {
+                                    Spacer(Modifier.width(8.dp))
+                                    IconButton(
+                                        onClick = { lightScale = 1f; lightOffsetX = 0f; lightOffsetY = 0f },
+                                        modifier = Modifier.size(40.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.RestartAlt,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -367,7 +371,6 @@ fun HeaderCreatorDialog(
                             .fillMaxWidth()
                             .padding(horizontal = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Image,
@@ -375,12 +378,14 @@ fun HeaderCreatorDialog(
                             modifier = Modifier.size(16.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                        Spacer(Modifier.width(8.dp))
                         Slider(
                             value = darkScale,
                             onValueChange = { darkScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
                             valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
                             modifier = Modifier.weight(1f)
                         )
+                        Spacer(Modifier.width(8.dp))
                         Icon(
                             imageVector = Icons.Outlined.Image,
                             contentDescription = null,
@@ -388,15 +393,18 @@ fun HeaderCreatorDialog(
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         AnimatedVisibility(visible = darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
-                            IconButton(
-                                onClick = { darkScale = 1f; darkOffsetX = 0f; darkOffsetY = 0f },
-                                modifier = Modifier.size(40.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.RestartAlt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp)
-                                )
+                            Row {
+                                Spacer(Modifier.width(8.dp))
+                                IconButton(
+                                    onClick = { darkScale = 1f; darkOffsetX = 0f; darkOffsetY = 0f },
+                                    modifier = Modifier.size(40.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.RestartAlt,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -177,8 +177,11 @@ fun HeaderCreatorDialog(
     // Whether all required images are provided
     val canCreate = darkHeaderBitmap != null && (!showLightVariant || lightHeaderBitmap != null)
 
+    var isCreating by remember { mutableStateOf(false) }
+
     val openFolderPicker = rememberFolderPicker { uri ->
         scope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) { isCreating = true }
             try {
                 val success = createHeaderFiles(
                     context = context,
@@ -196,6 +199,7 @@ fun HeaderCreatorDialog(
                     darkOffsetY = darkOffsetY
                 )
                 withContext(Dispatchers.Main) {
+                    isCreating = false
                     if (success != null) {
                         context.toast(successMessage)
                         onHeaderCreated(success)
@@ -206,6 +210,7 @@ fun HeaderCreatorDialog(
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
+                    isCreating = false
                     context.toast("Failed to create header: ${e.message}")
                 }
             }
@@ -215,7 +220,7 @@ fun HeaderCreatorDialog(
     val showInfoDialog = remember { mutableStateOf(false) }
 
     MorpheDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.header_creator_create),
         titleTrailingContent = {
             IconButton(onClick = { showInfoDialog.value = true }) {
@@ -232,16 +237,17 @@ fun HeaderCreatorDialog(
             MorpheDialogButton(
                 text = stringResource(R.string.header_creator_create),
                 onClick = { openFolderPicker() },
-                enabled = canCreate,
+                enabled = canCreate && !isCreating,
                 icon = Icons.Outlined.Save,
                 modifier = Modifier.fillMaxWidth()
             )
         }
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
-        ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
+            ) {
             // Light header section
             if (showLightVariant) {
                 Text(
@@ -409,6 +415,17 @@ fun HeaderCreatorDialog(
                 icon = Icons.Outlined.DarkMode,
                 modifier = Modifier.fillMaxWidth()
             )
+            }
+            if (isCreating) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -405,7 +406,14 @@ fun HeaderCreatorDialog(
                 Box(
                     modifier = Modifier
                         .matchParentSize()
-                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f)),
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.8f))
+                        .pointerInput(Unit) {
+                            awaitPointerEventScope {
+                                while (true) {
+                                    awaitPointerEvent(PointerEventPass.Initial).changes.forEach { it.consume() }
+                                }
+                            }
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -9,7 +9,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.*
 import android.net.Uri
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -213,56 +212,36 @@ fun HeaderCreatorDialog(
         }
     }
 
+    val showInfoDialog = remember { mutableStateOf(false) }
+
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.header_creator_create),
-        compactPadding = false,
-        footer = {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Explanation text
-                AnimatedVisibility(
-                    visible = canCreate,
-                    enter = MorpheAnimations.expandFadeEnter,
-                    exit = MorpheAnimations.shrinkFadeExit
-                ) {
-                    InfoBadge(
-                        text = stringResource(
-                            R.string.header_creator_folder_explanation,
-                            HeaderConfig.BRANDING_FOLDER_NAME,
-                            HeaderConfig.headerFolderName(packageName)
-                        ),
-                        style = InfoBadgeStyle.Primary,
-                        icon = Icons.Outlined.Info,
-                        isExpanded = true
-                    )
-                }
-
-                // Create button
-                MorpheDialogButton(
-                    text = stringResource(R.string.header_creator_create),
-                    onClick = { openFolderPicker() },
-                    enabled = canCreate,
-                    icon = Icons.Outlined.Save,
-                    modifier = Modifier.fillMaxWidth()
+        titleTrailingContent = {
+            IconButton(onClick = { showInfoDialog.value = true }) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = stringResource(R.string.header_creator_guide),
+                    modifier = Modifier.size(24.dp),
+                    tint = LocalDialogTextColor.current
                 )
             }
+        },
+        compactPadding = false,
+        footer = {
+            MorpheDialogButton(
+                text = stringResource(R.string.header_creator_create),
+                onClick = { openFolderPicker() },
+                enabled = canCreate,
+                icon = Icons.Outlined.Save,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
         ) {
-            // Instructions
-            InfoBadge(
-                text = stringResource(R.string.header_creator_instructions),
-                style = InfoBadgeStyle.Primary,
-                icon = Icons.Outlined.Info,
-                isExpanded = true
-            )
-
             // Light header section
             if (showLightVariant) {
                 Text(
@@ -431,6 +410,55 @@ fun HeaderCreatorDialog(
                 modifier = Modifier.fillMaxWidth()
             )
         }
+    }
+
+    if (showInfoDialog.value) {
+        MorpheDialog(
+            onDismissRequest = { showInfoDialog.value = false },
+            title = stringResource(R.string.header_creator_guide),
+            footer = {
+                MorpheDialogButton(
+                    text = stringResource(android.R.string.ok),
+                    onClick = { showInfoDialog.value = false },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                HeaderCreatorGuideSection(
+                    title = stringResource(R.string.header_creator_guide_image_title),
+                    body = stringResource(R.string.header_creator_guide_image_body)
+                )
+                HeaderCreatorGuideSection(
+                    title = stringResource(R.string.header_creator_guide_themes_title),
+                    body = stringResource(R.string.header_creator_guide_themes_body)
+                )
+                HeaderCreatorGuideSection(
+                    title = stringResource(R.string.header_creator_guide_positioning_title),
+                    body = stringResource(R.string.header_creator_guide_positioning_body)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderCreatorGuideSection(title: String, body: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = LocalDialogTextColor.current
+        )
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodySmall,
+            color = LocalDialogSecondaryTextColor.current
+        )
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -248,32 +248,117 @@ fun HeaderCreatorDialog(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
             ) {
-            // Light header section
-            if (showLightVariant) {
+                // Light header section
+                if (showLightVariant) {
+                    Text(
+                        text = stringResource(R.string.header_creator_light_theme),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = LocalDialogTextColor.current
+                    )
+
+                    HeaderPreview(
+                        headerBitmap = lightHeaderBitmap,
+                        scale = lightScale,
+                        offsetX = lightOffsetX,
+                        offsetY = lightOffsetY,
+                        isDarkTheme = false,
+                        onScaleChange = { newScale ->
+                            lightScale = newScale.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE)
+                        },
+                        onOffsetChange = { newOffsetX, newOffsetY ->
+                            lightOffsetX = newOffsetX.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
+                            lightOffsetY = newOffsetY.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
+                        }
+                    )
+
+                    // Scale slider and reset button for light header
+                    if (lightHeaderBitmap != null) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.Image,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Slider(
+                                value = lightScale,
+                                onValueChange = { lightScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
+                                valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Icon(
+                                imageVector = Icons.Outlined.Image,
+                                contentDescription = null,
+                                modifier = Modifier.size(22.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        if (lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
+                            TextButton(
+                                onClick = {
+                                    lightScale = 1f
+                                    lightOffsetX = 0f
+                                    lightOffsetY = 0f
+                                },
+                                modifier = Modifier.align(Alignment.CenterHorizontally)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.RestartAlt,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(stringResource(R.string.adaptive_icon_reset_transform))
+                            }
+                        }
+                    }
+
+                    MorpheDialogButton(
+                        text = if (lightHeaderUri == null)
+                            stringResource(R.string.adaptive_icon_select_image)
+                        else
+                            stringResource(R.string.adaptive_icon_change_image),
+                        onClick = { openLightHeaderPicker() },
+                        icon = Icons.Outlined.LightMode,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
+                    HorizontalDivider()
+                }
+
+                // Dark header section
                 Text(
-                    text = stringResource(R.string.header_creator_light_theme),
+                    text = stringResource(R.string.header_creator_dark_theme),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = LocalDialogTextColor.current
                 )
 
                 HeaderPreview(
-                    headerBitmap = lightHeaderBitmap,
-                    scale = lightScale,
-                    offsetX = lightOffsetX,
-                    offsetY = lightOffsetY,
-                    isDarkTheme = false,
+                    headerBitmap = darkHeaderBitmap,
+                    scale = darkScale,
+                    offsetX = darkOffsetX,
+                    offsetY = darkOffsetY,
+                    isDarkTheme = true,
                     onScaleChange = { newScale ->
-                        lightScale = newScale.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE)
+                        darkScale = newScale.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE)
                     },
                     onOffsetChange = { newOffsetX, newOffsetY ->
-                        lightOffsetX = newOffsetX.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
-                        lightOffsetY = newOffsetY.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
+                        darkOffsetX = newOffsetX.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
+                        darkOffsetY = newOffsetY.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
                     }
                 )
 
-                // Scale slider and reset button for light header
-                if (lightHeaderBitmap != null) {
+                // Scale slider and reset button for dark header
+                if (darkHeaderBitmap != null) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -288,8 +373,8 @@ fun HeaderCreatorDialog(
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                         Slider(
-                            value = lightScale,
-                            onValueChange = { lightScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
+                            value = darkScale,
+                            onValueChange = { darkScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
                             valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
                             modifier = Modifier.weight(1f)
                         )
@@ -301,12 +386,12 @@ fun HeaderCreatorDialog(
                         )
                     }
 
-                    if (lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
+                    if (darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
                         TextButton(
                             onClick = {
-                                lightScale = 1f
-                                lightOffsetX = 0f
-                                lightOffsetY = 0f
+                                darkScale = 1f
+                                darkOffsetX = 0f
+                                darkOffsetY = 0f
                             },
                             modifier = Modifier.align(Alignment.CenterHorizontally)
                         ) {
@@ -322,99 +407,14 @@ fun HeaderCreatorDialog(
                 }
 
                 MorpheDialogButton(
-                    text = if (lightHeaderUri == null)
+                    text = if (darkHeaderUri == null)
                         stringResource(R.string.adaptive_icon_select_image)
                     else
                         stringResource(R.string.adaptive_icon_change_image),
-                    onClick = { openLightHeaderPicker() },
-                    icon = Icons.Outlined.LightMode,
+                    onClick = { openDarkHeaderPicker() },
+                    icon = Icons.Outlined.DarkMode,
                     modifier = Modifier.fillMaxWidth()
                 )
-
-                HorizontalDivider()
-            }
-
-            // Dark header section
-            Text(
-                text = stringResource(R.string.header_creator_dark_theme),
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.Bold,
-                color = LocalDialogTextColor.current
-            )
-
-            HeaderPreview(
-                headerBitmap = darkHeaderBitmap,
-                scale = darkScale,
-                offsetX = darkOffsetX,
-                offsetY = darkOffsetY,
-                isDarkTheme = true,
-                onScaleChange = { newScale ->
-                    darkScale = newScale.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE)
-                },
-                onOffsetChange = { newOffsetX, newOffsetY ->
-                    darkOffsetX = newOffsetX.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
-                    darkOffsetY = newOffsetY.coerceIn(-HeaderConfig.MAX_OFFSET, HeaderConfig.MAX_OFFSET)
-                }
-            )
-
-            // Scale slider and reset button for dark header
-            if (darkHeaderBitmap != null) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Slider(
-                        value = darkScale,
-                        onValueChange = { darkScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
-                        valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
-                        modifier = Modifier.weight(1f)
-                    )
-                    Icon(
-                        imageVector = Icons.Outlined.Image,
-                        contentDescription = null,
-                        modifier = Modifier.size(22.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-
-                if (darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
-                    TextButton(
-                        onClick = {
-                            darkScale = 1f
-                            darkOffsetX = 0f
-                            darkOffsetY = 0f
-                        },
-                        modifier = Modifier.align(Alignment.CenterHorizontally)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.RestartAlt,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.adaptive_icon_reset_transform))
-                    }
-                }
-            }
-
-            MorpheDialogButton(
-                text = if (darkHeaderUri == null)
-                    stringResource(R.string.adaptive_icon_select_image)
-                else
-                    stringResource(R.string.adaptive_icon_change_image),
-                onClick = { openDarkHeaderPicker() },
-                icon = Icons.Outlined.DarkMode,
-                modifier = Modifier.fillMaxWidth()
-            )
             }
             if (isCreating) {
                 Box(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.*
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -257,6 +258,16 @@ fun HeaderCreatorDialog(
                         color = LocalDialogTextColor.current
                     )
 
+                    MorpheDialogOutlinedButton(
+                        text = if (lightHeaderUri == null)
+                            stringResource(R.string.adaptive_icon_select_image)
+                        else
+                            stringResource(R.string.adaptive_icon_change_image),
+                        onClick = { openLightHeaderPicker() },
+                        icon = Icons.Outlined.LightMode,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+
                     HeaderPreview(
                         headerBitmap = lightHeaderBitmap,
                         scale = lightScale,
@@ -272,7 +283,6 @@ fun HeaderCreatorDialog(
                         }
                     )
 
-                    // Scale slider and reset button for light header
                     if (lightHeaderBitmap != null) {
                         Row(
                             modifier = Modifier
@@ -299,37 +309,20 @@ fun HeaderCreatorDialog(
                                 modifier = Modifier.size(22.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant
                             )
-                        }
-
-                        if (lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
-                            TextButton(
-                                onClick = {
-                                    lightScale = 1f
-                                    lightOffsetX = 0f
-                                    lightOffsetY = 0f
-                                },
-                                modifier = Modifier.align(Alignment.CenterHorizontally)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.RestartAlt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Text(stringResource(R.string.adaptive_icon_reset_transform))
+                            AnimatedVisibility(visible = lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
+                                IconButton(
+                                    onClick = { lightScale = 1f; lightOffsetX = 0f; lightOffsetY = 0f },
+                                    modifier = Modifier.size(40.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.RestartAlt,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
                             }
                         }
                     }
-
-                    MorpheDialogButton(
-                        text = if (lightHeaderUri == null)
-                            stringResource(R.string.adaptive_icon_select_image)
-                        else
-                            stringResource(R.string.adaptive_icon_change_image),
-                        onClick = { openLightHeaderPicker() },
-                        icon = Icons.Outlined.LightMode,
-                        modifier = Modifier.fillMaxWidth()
-                    )
 
                     HorizontalDivider()
                 }
@@ -340,6 +333,16 @@ fun HeaderCreatorDialog(
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = LocalDialogTextColor.current
+                )
+
+                MorpheDialogOutlinedButton(
+                    text = if (darkHeaderUri == null)
+                        stringResource(R.string.adaptive_icon_select_image)
+                    else
+                        stringResource(R.string.adaptive_icon_change_image),
+                    onClick = { openDarkHeaderPicker() },
+                    icon = Icons.Outlined.DarkMode,
+                    modifier = Modifier.fillMaxWidth()
                 )
 
                 HeaderPreview(
@@ -357,7 +360,6 @@ fun HeaderCreatorDialog(
                     }
                 )
 
-                // Scale slider and reset button for dark header
                 if (darkHeaderBitmap != null) {
                     Row(
                         modifier = Modifier
@@ -384,37 +386,20 @@ fun HeaderCreatorDialog(
                             modifier = Modifier.size(22.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                    }
-
-                    if (darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
-                        TextButton(
-                            onClick = {
-                                darkScale = 1f
-                                darkOffsetX = 0f
-                                darkOffsetY = 0f
-                            },
-                            modifier = Modifier.align(Alignment.CenterHorizontally)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.RestartAlt,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(stringResource(R.string.adaptive_icon_reset_transform))
+                        AnimatedVisibility(visible = darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
+                            IconButton(
+                                onClick = { darkScale = 1f; darkOffsetX = 0f; darkOffsetY = 0f },
+                                modifier = Modifier.size(40.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.RestartAlt,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
                         }
                     }
                 }
-
-                MorpheDialogButton(
-                    text = if (darkHeaderUri == null)
-                        stringResource(R.string.adaptive_icon_select_image)
-                    else
-                        stringResource(R.string.adaptive_icon_change_image),
-                    onClick = { openDarkHeaderPicker() },
-                    icon = Icons.Outlined.DarkMode,
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
             if (isCreating) {
                 Box(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.util.requiresLightContent
 
 // Constants
 object MorpheDefaults {
@@ -266,11 +267,14 @@ fun MorpheSwitch(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
+    val thumbColor = MaterialTheme.colorScheme.onPrimary
+    val iconColor = if (thumbColor.requiresLightContent()) Color.White else Color.Black
     Switch(
         checked = checked,
         onCheckedChange = onCheckedChange,
         modifier = modifier,
         enabled = enabled,
+        colors = SwitchDefaults.colors(checkedIconColor = iconColor),
         thumbContent = {
             Icon(
                 imageVector = if (checked) Icons.Filled.Check else Icons.Filled.Close,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,13 +237,18 @@ Outer zone (dashed): may be clipped by the launcher mask - keep important detail
 
     <!-- Header Creator -->
     <string name="header_creator_create">Create custom header</string>
-    <string name="header_creator_instructions">Choose images for light and dark themes, then adjust with pinch-to-zoom gestures</string>
     <string name="header_creator_light_theme">Light theme header</string>
     <string name="header_creator_dark_theme">Dark theme header</string>
     <string name="header_creator_no_image">No image selected</string>
     <string name="header_creator_success">Header created successfully</string>
     <string name="header_creator_failed">Failed to create header</string>
-    <string name="header_creator_folder_explanation">Select where to create \'%1$s/%2$s\' folder with generated header files</string>
+    <string name="header_creator_guide">Header creation guide</string>
+    <string name="header_creator_guide_image_title">Image requirements</string>
+    <string name="header_creator_guide_image_body">Use any image file (PNG or JPEG). For best results, use a wide-format image with an approximately 2.7:1 aspect ratio. PNG files with transparent backgrounds will blend naturally with the app theme.</string>
+    <string name="header_creator_guide_themes_title">Light and dark themes</string>
+    <string name="header_creator_guide_themes_body">Most apps require separate images for the light and dark themes. Some apps (such as YouTube Music) only use the dark theme, so only that section is shown.</string>
+    <string name="header_creator_guide_positioning_title">Positioning and scaling</string>
+    <string name="header_creator_guide_positioning_body">Use pinch-to-zoom and drag gestures directly in the preview to position and scale your image. Snap guides appear when the image is near the center. You can also use the slider below the preview.</string>
 
     <!-- Home Screen - App Info Screen -->
     <string name="home_app_info_uninstall_app_confirmation">Are you sure you want to uninstall this app?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -219,6 +219,7 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
     <string name="adaptive_icon_reset_transform">Reset position and scale</string>
     <string name="adaptive_icon_safe_zone_inner">Safe zone (always visible)</string>
     <string name="adaptive_icon_safe_zone_outer">Mask zone (may be clipped)</string>
+    <string name="adaptive_icon_no_transparency_warning">Image has no transparent pixels. The result may look incorrect</string>
     <string name="adaptive_icon_created_success">Adaptive icon created successfully</string>
     <string name="adaptive_icon_creation_failed">Failed to create adaptive icon</string>
     <string name="adaptive_icon_label">Adaptive</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,9 +213,6 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
 
     <!-- Adaptive Icon Creator -->
     <string name="adaptive_icon_create">Create adaptive icon</string>
-    <string name="adaptive_icon_instructions">Choose a foreground image, select a background color, then use the slider or pinch gestures to adjust the preview</string>
-    <string name="adaptive_icon_preview">Adaptive icon preview</string>
-    <string name="adaptive_icon_preview_hint">For the best result, keep your icon within the solid inner circle</string>
     <string name="adaptive_icon_select_image">Select image</string>
     <string name="adaptive_icon_change_image">Change image</string>
     <string name="adaptive_icon_background_color">Background color</string>
@@ -224,9 +221,19 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
     <string name="adaptive_icon_safe_zone_outer">Mask zone (may be clipped)</string>
     <string name="adaptive_icon_created_success">Adaptive icon created successfully</string>
     <string name="adaptive_icon_creation_failed">Failed to create adaptive icon</string>
-    <string name="adaptive_icon_folder_explanation">Select where to create \'%1$s/%2$s\' folder with generated icon files</string>
-    <string name="notification_icon_preview">Notification icon preview</string>
-    <string name="notification_icon_preview_hint">Use the slider to resize. Drag to reposition</string>
+    <string name="adaptive_icon_label">Adaptive</string>
+    <string name="adaptive_icon_monochrome_label">Monochrome</string>
+    <string name="adaptive_icon_guide">Icon creation guide</string>
+    <string name="adaptive_icon_guide_png_title">Use a PNG with a transparent background</string>
+    <string name="adaptive_icon_guide_png_body">The foreground must be a PNG file with a transparent background. A solid-colored background will look incorrect - the background color should come from the background picker below.</string>
+    <string name="adaptive_icon_guide_safe_zones_title">Safe zones</string>
+    <string name="adaptive_icon_guide_safe_zones_body">"Inner zone (solid): content is always fully visible on all launcher shapes.
+Outer zone (dashed): may be clipped by the launcher mask - keep important details inside the inner zone."</string>
+    <string name="adaptive_icon_guide_notification_title">Notification icon</string>
+    <string name="adaptive_icon_guide_notification_body">Generated automatically from the foreground image. Adjust its size using the Notification slider. All visible content appears white in the status bar.</string>
+    <string name="adaptive_icon_guide_monochrome_title">Monochrome icon</string>
+    <string name="adaptive_icon_guide_monochrome_body">Generated automatically from the foreground image using the same adaptive icon transforms. It appears tinted with the wallpaper accent color on Android 13 and later.</string>
+    <string name="notification_icon_preview">Notification</string>
 
     <!-- Header Creator -->
     <string name="header_creator_create">Create custom header</string>


### PR DESCRIPTION
## Summary
  - Add monochrome icon preview alongside the adaptive icon preview, showing how the icon looks in themed launcher modes
  - Redesign the notification icon preview as a realistic status bar
  - Default adaptive icon background color is now derived from the wallpaper accent color
  - Show a warning when the selected image has no transparent background, as this will likely produce an incorrect result
  - Disable all controls while the icon is being saved to prevent accidental interaction
  - Add an info button in the dialog header that opens a step-by-step guide on how to create a proper icon
___
![Screenshot_2026-05-21-01-07-42-931_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/838a30e4-f573-4681-a358-4abf889f81d0)

