### PR TITLE
feat: Add built-in file picker

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -103,6 +103,8 @@ class PreferencesManager(
     val installationTime = LongPreference(dataStore, "manager_installation_time", 0L)
     val disablePatchVersionCompatCheck = booleanPreference("disable_patch_version_compatibility_check", false)
 
+    val useCustomFilePicker = booleanPreference("use_custom_file_picker", true)
+
     /**  Hidden preference to track if prerelease was auto-enabled. */
     private val prereleaseAutoEnabled = booleanPreference("prerelease_auto_enabled", false)
 

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -130,6 +130,13 @@ class PreferencesManager(
                 patcherProcessMemoryLimit.update(adaptive)
             }
 
+            // TODO: remove after 1.18.0 stable - migrates expert mode users who upgraded before
+            //  custom file picker toggle existed; without this they'd get the new default (false)
+            //  even though they should have it on.
+            if (useExpertMode.get() && !customFilePickerUserConfigured.get()) {
+                useCustomFilePicker.update(true)
+            }
+
             // Auto-enable prereleases for dev versions
             if (isDevVersion() && !prereleaseAutoEnabled.get()) {
                 Log.d(tag, "Dev version detected (${BuildConfig.VERSION_NAME}), auto-enabling prereleases")

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -104,6 +104,7 @@ class PreferencesManager(
     val disablePatchVersionCompatCheck = booleanPreference("disable_patch_version_compatibility_check", false)
 
     val useCustomFilePicker = booleanPreference("use_custom_file_picker", true)
+    val lastFilePickerPath = stringPreference("last_file_picker_path", "")
 
     /**  Hidden preference to track if prerelease was auto-enabled. */
     private val prereleaseAutoEnabled = booleanPreference("prerelease_auto_enabled", false)

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -105,6 +105,7 @@ class PreferencesManager(
 
     val useCustomFilePicker = booleanPreference("use_custom_file_picker", true)
     val lastFilePickerPath = stringPreference("last_file_picker_path", "")
+    val filePickerSortMode = stringPreference("file_picker_sort_mode", "NAME_ASC")
 
     /**  Hidden preference to track if prerelease was auto-enabled. */
     private val prereleaseAutoEnabled = booleanPreference("prerelease_auto_enabled", false)

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -103,9 +103,12 @@ class PreferencesManager(
     val installationTime = LongPreference(dataStore, "manager_installation_time", 0L)
     val disablePatchVersionCompatCheck = booleanPreference("disable_patch_version_compatibility_check", false)
 
-    val useCustomFilePicker = booleanPreference("use_custom_file_picker", true)
+    val useCustomFilePicker = booleanPreference("use_custom_file_picker", false)
     val lastFilePickerPath = stringPreference("last_file_picker_path", "")
     val filePickerSortMode = stringPreference("file_picker_sort_mode", "NAME_ASC")
+
+    /** Tracks whether the user has explicitly toggled the custom file picker preference. */
+    val customFilePickerUserConfigured = booleanPreference("custom_file_picker_user_configured", false)
 
     /**  Hidden preference to track if prerelease was auto-enabled. */
     private val prereleaseAutoEnabled = booleanPreference("prerelease_auto_enabled", false)

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -115,19 +115,21 @@ fun HomeScreen(
     }
 
     val openApkPicker = rememberAdaptiveFilePicker(
-        mimeTypes = APK_FILE_MIME_TYPES
-    ) { uri -> uri?.let { homeViewModel.handleApkSelection(it) } }
+        mimeTypes = APK_FILE_MIME_TYPES,
+        onResult = { uri -> uri?.let { homeViewModel.handleApkSelection(it) } }
+    )
 
     val openBundlePicker = rememberAdaptiveFilePicker(
-        mimeTypes = MPP_FILE_MIME_TYPES
-    ) { uri ->
-        uri?.let {
-            homeViewModel.selectedBundleUri = it
-            homeViewModel.selectedBundlePath = it.displayName(context.contentResolver)
-                ?: it.lastPathSegment
-                ?: it.toString()
+        mimeTypes = MPP_FILE_MIME_TYPES,
+        onResult = { uri ->
+            uri?.let {
+                homeViewModel.selectedBundleUri = it
+                homeViewModel.selectedBundlePath = it.displayName(context.contentResolver)
+                    ?: it.lastPathSegment
+                    ?: it.toString()
+            }
         }
-    }
+    )
 
     val installAppsPermissionLauncher = rememberLauncherForActivityResult(
         contract = RequestInstallAppsContract

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -100,12 +100,14 @@ fun SettingsScreen(
     val showChangelogDialog = remember { mutableStateOf(false) }
 
     val importKeystoreLauncher = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf("*/*")
-    ) { uri -> uri?.let { importExportViewModel.startKeystoreImport(it) } }
+        mimeTypes = arrayOf("*/*"),
+        onResult = { uri -> uri?.let { importExportViewModel.startKeystoreImport(it) } }
+    )
 
     val importSettingsLauncher = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE)
-    ) { uri -> uri?.let { importExportViewModel.importManagerSettings(it) } }
+        mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
+        onResult = { uri -> uri?.let { importExportViewModel.importManagerSettings(it) } }
+    )
 
     // Export launchers
     val exportKeystoreLauncher = rememberLauncherForActivityResult(

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -101,11 +101,17 @@ fun SettingsScreen(
 
     val importKeystoreLauncher = rememberAdaptiveFilePicker(
         mimeTypes = arrayOf("*/*"),
+        customPickerMimeTypes = arrayOf(
+            "application/x-pkcs12",
+            "application/x-java-keystore",
+            "application/vnd.morphe.keystore",
+        ),
         onResult = { uri -> uri?.let { importExportViewModel.startKeystoreImport(it) } }
     )
 
     val importSettingsLauncher = rememberAdaptiveFilePicker(
         mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
+        customPickerMimeTypes = arrayOf(JSON_MIMETYPE),
         onResult = { uri -> uri?.let { importExportViewModel.importManagerSettings(it) } }
     )
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -1433,10 +1433,11 @@ private fun FilePathInputOption(
     val isInvalid = required && value.isBlank()
 
     val filePicker = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf("*/*")
-    ) { uri ->
-        uri?.toFilePath()?.let { onValueChange(it) }
-    }
+        mimeTypes = arrayOf("*/*"),
+        onResult = { uri ->
+            uri?.toFilePath()?.let { onValueChange(it) }
+        }
+    )
 
     Column(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
@@ -79,8 +79,8 @@ fun SystemTabContent(
             )
         }
 
-        // Storage Management
-        StorageManagementSection(
+        // Files & Storage
+        FilesAndStorageSection(
             settingsViewModel = settingsViewModel,
             importExportViewModel = importExportViewModel
         )

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
@@ -12,19 +12,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.InstallMobile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
 import app.morphe.manager.ui.screen.settings.system.*
-import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.ui.screen.shared.SectionCard
+import app.morphe.manager.ui.screen.shared.SectionTitle
 import app.morphe.manager.ui.viewmodel.ImportExportViewModel
 import app.morphe.manager.ui.viewmodel.SettingsViewModel
 
@@ -45,10 +43,6 @@ fun SystemTabContent(
     onChangelogClick: () -> Unit
 ) {
     val useExpertMode by settingsViewModel.prefs.useExpertMode.getAsState()
-    val useCustomFilePicker by settingsViewModel.prefs.useCustomFilePicker.getAsState()
-
-    val enabledState = stringResource(R.string.enabled)
-    val disabledState = stringResource(R.string.disabled)
 
     Column(
         modifier = Modifier
@@ -82,30 +76,6 @@ fun SystemTabContent(
                 onImportSettings = onImportSettings,
                 onExportSettings = onExportSettings,
                 onExportDebugLogs = onExportDebugLogs
-            )
-        }
-
-        // Files
-        SectionTitle(
-            text = stringResource(R.string.settings_system_files),
-            icon = Icons.Outlined.FolderOpen
-        )
-
-        SectionCard {
-            RichSettingsItem(
-                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
-                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
-                title = stringResource(R.string.settings_system_custom_file_picker),
-                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
-                trailingContent = {
-                    MorpheSwitch(
-                        checked = useCustomFilePicker,
-                        onCheckedChange = null,
-                        modifier = Modifier.semantics {
-                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
-                        }
-                    )
-                }
             )
         }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/SystemTabContent.kt
@@ -12,17 +12,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FolderOpen
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.InstallMobile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
 import app.morphe.manager.ui.screen.settings.system.*
-import app.morphe.manager.ui.screen.shared.SectionCard
-import app.morphe.manager.ui.screen.shared.SectionTitle
+import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.ImportExportViewModel
 import app.morphe.manager.ui.viewmodel.SettingsViewModel
 
@@ -43,6 +45,10 @@ fun SystemTabContent(
     onChangelogClick: () -> Unit
 ) {
     val useExpertMode by settingsViewModel.prefs.useExpertMode.getAsState()
+    val useCustomFilePicker by settingsViewModel.prefs.useCustomFilePicker.getAsState()
+
+    val enabledState = stringResource(R.string.enabled)
+    val disabledState = stringResource(R.string.disabled)
 
     Column(
         modifier = Modifier
@@ -76,6 +82,30 @@ fun SystemTabContent(
                 onImportSettings = onImportSettings,
                 onExportSettings = onExportSettings,
                 onExportDebugLogs = onExportDebugLogs
+            )
+        }
+
+        // Files
+        SectionTitle(
+            text = stringResource(R.string.settings_system_files),
+            icon = Icons.Outlined.FolderOpen
+        )
+
+        SectionCard {
+            RichSettingsItem(
+                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
+                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
+                title = stringResource(R.string.settings_system_custom_file_picker),
+                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
+                trailingContent = {
+                    MorpheSwitch(
+                        checked = useCustomFilePicker,
+                        onCheckedChange = null,
+                        modifier = Modifier.semantics {
+                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
+                        }
+                    )
+                }
             )
         }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
@@ -31,7 +31,7 @@ import app.morphe.manager.util.isAndroidTv
  * Storage management section.
  */
 @Composable
-fun StorageManagementSection(
+fun FilesAndStorageSection(
     settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel
 ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -162,10 +162,11 @@ private fun PatchSelectionManagementDialogContent(
     onShowPatchDetails: (PatchDetailsTarget) -> Unit
 ) {
     val openImportAllSelectionsPicker = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE)
-    ) { uri ->
-        uri?.let { importExportViewModel.importAllSelections(it) }
-    }
+        mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
+        onResult = { uri ->
+            uri?.let { importExportViewModel.importAllSelections(it) }
+        }
+    )
 
     val exportAllSelectionsLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument(JSON_MIMETYPE)

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -24,6 +25,7 @@ import app.morphe.manager.R
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.ImportExportViewModel
 import app.morphe.manager.ui.viewmodel.SettingsViewModel
+import app.morphe.manager.util.isAndroidTv
 
 /**
  * Storage management section.
@@ -33,6 +35,8 @@ fun StorageManagementSection(
     settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel
 ) {
+    val context = LocalContext.current
+    val isTV = remember { context.isAndroidTv() }
     val useExpertMode by settingsViewModel.prefs.useExpertMode.getAsState()
     val useCustomFilePicker by settingsViewModel.prefs.useCustomFilePicker.getAsState()
     val enabledState = stringResource(R.string.enabled)
@@ -154,22 +158,25 @@ fun StorageManagementSection(
             }
         }
 
-        SectionCard {
-            RichSettingsItem(
-                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
-                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
-                title = stringResource(R.string.settings_system_custom_file_picker),
-                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
-                trailingContent = {
-                    MorpheSwitch(
-                        checked = useCustomFilePicker,
-                        onCheckedChange = null,
-                        modifier = androidx.compose.ui.Modifier.semantics {
-                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
-                        }
-                    )
-                }
-            )
+        // TV always uses the custom picker regardless of this toggle, so hide it to avoid confusion
+        if (!isTV) {
+            SectionCard {
+                RichSettingsItem(
+                    onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
+                    leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
+                    title = stringResource(R.string.settings_system_custom_file_picker),
+                    subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
+                    trailingContent = {
+                        MorpheSwitch(
+                            checked = useCustomFilePicker,
+                            onCheckedChange = null,
+                            modifier = androidx.compose.ui.Modifier.semantics {
+                                stateDescription = if (useCustomFilePicker) enabledState else disabledState
+                            }
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
@@ -9,16 +9,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Apps
-import androidx.compose.material.icons.outlined.ChevronRight
-import androidx.compose.material.icons.outlined.Storage
-import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
@@ -35,6 +34,9 @@ fun StorageManagementSection(
     importExportViewModel: ImportExportViewModel
 ) {
     val useExpertMode by settingsViewModel.prefs.useExpertMode.getAsState()
+    val useCustomFilePicker by settingsViewModel.prefs.useCustomFilePicker.getAsState()
+    val enabledState = stringResource(R.string.enabled)
+    val disabledState = stringResource(R.string.disabled)
 
     // Storage counts
     val originalApkCount by settingsViewModel.originalApkCount.collectAsStateWithLifecycle()
@@ -63,7 +65,7 @@ fun StorageManagementSection(
 
     Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
         SectionTitle(
-            text = stringResource(R.string.settings_system_storage_management),
+            text = stringResource(R.string.settings_system_files),
             icon = Icons.Outlined.Storage
         )
 
@@ -150,6 +152,24 @@ fun StorageManagementSection(
                     )
                 }
             }
+        }
+
+        SectionCard {
+            RichSettingsItem(
+                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
+                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
+                title = stringResource(R.string.settings_system_custom_file_picker),
+                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
+                trailingContent = {
+                    MorpheSwitch(
+                        checked = useCustomFilePicker,
+                        onCheckedChange = null,
+                        modifier = androidx.compose.ui.Modifier.semantics {
+                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
@@ -154,24 +154,22 @@ fun StorageManagementSection(
             }
         }
 
-        if (useExpertMode) {
-            SectionCard {
-                RichSettingsItem(
-                    onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
-                    leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
-                    title = stringResource(R.string.settings_system_custom_file_picker),
-                    subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
-                    trailingContent = {
-                        MorpheSwitch(
-                            checked = useCustomFilePicker,
-                            onCheckedChange = null,
-                            modifier = androidx.compose.ui.Modifier.semantics {
-                                stateDescription = if (useCustomFilePicker) enabledState else disabledState
-                            }
-                        )
-                    }
-                )
-            }
+        SectionCard {
+            RichSettingsItem(
+                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
+                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
+                title = stringResource(R.string.settings_system_custom_file_picker),
+                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
+                trailingContent = {
+                    MorpheSwitch(
+                        checked = useCustomFilePicker,
+                        onCheckedChange = null,
+                        modifier = androidx.compose.ui.Modifier.semantics {
+                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementSection.kt
@@ -154,22 +154,24 @@ fun StorageManagementSection(
             }
         }
 
-        SectionCard {
-            RichSettingsItem(
-                onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
-                leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
-                title = stringResource(R.string.settings_system_custom_file_picker),
-                subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
-                trailingContent = {
-                    MorpheSwitch(
-                        checked = useCustomFilePicker,
-                        onCheckedChange = null,
-                        modifier = androidx.compose.ui.Modifier.semantics {
-                            stateDescription = if (useCustomFilePicker) enabledState else disabledState
-                        }
-                    )
-                }
-            )
+        if (useExpertMode) {
+            SectionCard {
+                RichSettingsItem(
+                    onClick = { settingsViewModel.setUseCustomFilePicker(!useCustomFilePicker) },
+                    leadingContent = { MorpheIcon(icon = Icons.Outlined.FolderOpen) },
+                    title = stringResource(R.string.settings_system_custom_file_picker),
+                    subtitle = stringResource(R.string.settings_system_custom_file_picker_description),
+                    trailingContent = {
+                        MorpheSwitch(
+                            checked = useCustomFilePicker,
+                            onCheckedChange = null,
+                            modifier = androidx.compose.ui.Modifier.semantics {
+                                stateDescription = if (useCustomFilePicker) enabledState else disabledState
+                            }
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -158,29 +158,32 @@ fun AdaptiveIconCreatorDialog(
     val context = LocalContext.current
 
     // Foreground image picker, resets all transforms when a new image is loaded
-    val openForegroundPicker = rememberAdaptiveFilePicker(mimeTypes = arrayOf("image/*")) { uri ->
-        uri?.let {
-            foregroundUri = it
-            showTransparencyWarning = false
-            scope.launch(Dispatchers.IO) {
-                try {
-                    val inputStream = context.contentResolver.openInputStream(it)
-                    val bitmap = BitmapFactory.decodeStream(inputStream)
-                    inputStream?.close()
-                    foregroundBitmap = bitmap
-                    val hasTransparency = bitmap?.hasTransparentPixels() == true
-                    // Reset transform when new image is loaded
-                    withContext(Dispatchers.Main) {
-                        scale = 1f; offsetX = 0f; offsetY = 0f
-                        notificationScale = 1f
-                        showTransparencyWarning = !hasTransparency
+    val openForegroundPicker = rememberAdaptiveFilePicker(
+        mimeTypes = arrayOf("image/*"),
+        onResult = { uri ->
+            uri?.let {
+                foregroundUri = it
+                showTransparencyWarning = false
+                scope.launch(Dispatchers.IO) {
+                    try {
+                        val inputStream = context.contentResolver.openInputStream(it)
+                        val bitmap = BitmapFactory.decodeStream(inputStream)
+                        inputStream?.close()
+                        foregroundBitmap = bitmap
+                        val hasTransparency = bitmap?.hasTransparentPixels() == true
+                        // Reset transform when new image is loaded
+                        withContext(Dispatchers.Main) {
+                            scale = 1f; offsetX = 0f; offsetY = 0f
+                            notificationScale = 1f
+                            showTransparencyWarning = !hasTransparency
+                        }
+                    } catch (e: Exception) {
+                        withContext(Dispatchers.Main) { context.toast("Failed to load image: ${e.message}") }
                     }
-                } catch (e: Exception) {
-                    withContext(Dispatchers.Main) { context.toast("Failed to load image: ${e.message}") }
                 }
             }
         }
-    }
+    )
 
     val successMessage = stringResource(R.string.adaptive_icon_created_success)
     val failureMessage = stringResource(R.string.adaptive_icon_creation_failed)

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import android.os.Environment
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import app.morphe.manager.util.APK_EXTENSIONS
+import app.morphe.manager.util.formatBytes
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.*
+
+private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
+    "application/vnd.android.package-archive" to setOf("apk", "apks", "xapk", "apkm"),
+    "application/json" to setOf("json"),
+    "text/plain" to setOf("txt", "log"),
+    "application/vnd.ms-project" to setOf("mpp"),
+    "image/png" to setOf("png"),
+    "image/jpeg" to setOf("jpg", "jpeg"),
+    "image/gif" to setOf("gif"),
+    "image/webp" to setOf("webp"),
+)
+
+// Returns null when the types are too broad to filter (wildcards like *\/*, application\/*)
+internal fun resolveAllowedExtensions(mimeTypes: Array<String>): Set<String>? {
+    if (mimeTypes.any { it == "*/*" || it.endsWith("/*") }) return null
+    val extensions = mutableSetOf<String>()
+    for (mime in mimeTypes) {
+        extensions += MIME_EXTENSION_MAP[mime] ?: return null
+    }
+    return extensions.ifEmpty { null }
+}
+
+private fun storageRoots(): List<Pair<String, File>> {
+    val roots = mutableListOf<Pair<String, File>>()
+    val primary = Environment.getExternalStorageDirectory()
+    if (primary.exists()) roots += "Internal storage" to primary
+    File("/storage").listFiles()?.forEach { dir ->
+        if (!dir.isDirectory || dir.name == "emulated" || dir.name == "self") return@forEach
+        if (dir.canRead()) roots += "SD card" to dir
+    }
+    return roots
+}
+
+private fun listDir(dir: File, allowedExtensions: Set<String>?): List<File> =
+    dir.listFiles()
+        ?.filter { it.isDirectory || allowedExtensions == null || it.extension.lowercase() in allowedExtensions }
+        ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+        ?: emptyList()
+
+private fun formatModDate(timestamp: Long): String =
+    SimpleDateFormat("dd.MM.yyyy, HH:mm", Locale.getDefault()).format(Date(timestamp))
+
+/**
+ * Fullscreen file browser dialog styled to match the Morphe design system.
+ * Navigates storage roots and subdirectories; shows file size and modification time.
+ * Filters visible files to [mimeTypes] when a precise mapping exists.
+ */
+@Composable
+fun FilePicker(
+    mimeTypes: Array<String>,
+    onDismiss: () -> Unit,
+    onFilePicked: (File) -> Unit
+) {
+    val allowedExtensions = remember(mimeTypes) { resolveAllowedExtensions(mimeTypes) }
+    val roots = remember { storageRoots() }
+
+    var currentDir by remember { mutableStateOf<File?>(null) }
+    var dirContents by remember { mutableStateOf<List<File>>(emptyList()) }
+    var selectedFile by remember { mutableStateOf<File?>(null) }
+    var refreshKey by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(currentDir, refreshKey) {
+        dirContents = currentDir?.let { listDir(it, allowedExtensions) } ?: emptyList()
+        if (selectedFile?.parentFile != currentDir) selectedFile = null
+    }
+
+    val navigateBack = {
+        val atStorageRoot = roots.any { (_, root) -> root == currentDir }
+        currentDir = if (atStorageRoot) null else currentDir?.parentFile
+    }
+
+    BackHandler(enabled = currentDir != null, onBack = navigateBack)
+
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = null,
+        noPadding = true,
+        scrollable = false,
+        footer = null
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .statusBarsPadding()
+                    .padding(start = 4.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(android.R.string.cancel),
+                        tint = LocalDialogTextColor.current
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.file_picker_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = LocalDialogTextColor.current,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(onClick = { refreshKey++ }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Refresh,
+                        contentDescription = null,
+                        tint = LocalDialogTextColor.current
+                    )
+                }
+            }
+
+            HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.08f))
+
+            if (currentDir != null) {
+                Text(
+                    text = currentDir!!.absolutePath,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = LocalDialogSecondaryTextColor.current,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 6.dp)
+                )
+                HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.06f))
+            }
+
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                if (currentDir == null) {
+                    items(roots, key = { it.second.absolutePath }) { (label, root) ->
+                        FilePickerRow(
+                            icon = Icons.Outlined.Storage,
+                            name = label,
+                            detail = null,
+                            onClick = { currentDir = root }
+                        )
+                        HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.06f))
+                    }
+                } else {
+                    item(key = "__back__") {
+                        FilePickerRow(
+                            icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                            name = stringResource(R.string.file_picker_previous_directory),
+                            detail = null,
+                            onClick = navigateBack
+                        )
+                        HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.06f))
+                    }
+
+                    if (dirContents.isEmpty()) {
+                        item(key = "__empty__") {
+                            EmptyState(
+                                message = stringResource(R.string.file_picker_no_files),
+                                icon = Icons.Outlined.FolderOff
+                            )
+                        }
+                    } else {
+                        items(dirContents, key = { it.absolutePath }) { file ->
+                            val isSelected = selectedFile == file
+                            val isDir = file.isDirectory
+                            val icon = when {
+                                isDir -> Icons.Outlined.Folder
+                                file.extension.lowercase() in APK_EXTENSIONS -> Icons.Outlined.Android
+                                else -> Icons.AutoMirrored.Outlined.InsertDriveFile
+                            }
+                            val detail = if (!isDir) {
+                                "${formatBytes(file.length())} · ${formatModDate(file.lastModified())}"
+                            } else null
+
+                            FilePickerRow(
+                                icon = icon,
+                                name = file.name,
+                                detail = detail,
+                                isSelected = isSelected,
+                                onClick = {
+                                    if (isDir) currentDir = file
+                                    else selectedFile = if (isSelected) null else file
+                                }
+                            )
+                            HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.06f))
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.08f))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(24.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = LocalDialogTextColor.current
+                    ),
+                    border = BorderStroke(1.dp, LocalDialogTextColor.current.copy(alpha = 0.3f))
+                ) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                Button(
+                    onClick = { selectedFile?.let { onFilePicked(it) } },
+                    enabled = selectedFile != null,
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(24.dp)
+                ) {
+                    Text(stringResource(R.string.file_picker_select))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilePickerRow(
+    icon: ImageVector,
+    name: String,
+    detail: String?,
+    isSelected: Boolean = false,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .background(
+                if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.18f)
+                else Color.Transparent
+            )
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = if (isSelected) MaterialTheme.colorScheme.primary
+                   else LocalDialogTextColor.current.copy(alpha = 0.75f),
+            modifier = Modifier.size(22.dp)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (isSelected) MaterialTheme.colorScheme.primary
+                        else LocalDialogTextColor.current,
+                fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+            )
+            if (detail != null) {
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = LocalDialogSecondaryTextColor.current
+                )
+            }
+        }
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Outlined.CheckCircle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -102,6 +102,7 @@ fun FilePicker(
     var dirContents by remember { mutableStateOf<List<File>>(emptyList()) }
     var selectedFile by remember { mutableStateOf<File?>(null) }
     var refreshKey by remember { mutableIntStateOf(0) }
+    var showStorageMenu by remember { mutableStateOf(false) }
 
     // Restore the last visited directory on open; Downloads stays as fallback until then
     LaunchedEffect(Unit) {
@@ -167,16 +168,39 @@ fun FilePicker(
             HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.08f))
 
             if (currentDir != null) {
-                Text(
-                    text = currentDir!!.absolutePath,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = LocalDialogSecondaryTextColor.current,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 6.dp)
-                )
+                Box {
+                    Text(
+                        text = currentDir!!.absolutePath,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = LocalDialogSecondaryTextColor.current,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable(enabled = roots.size > 1) { showStorageMenu = true }
+                            .padding(horizontal = 16.dp, vertical = 6.dp)
+                    )
+                    DropdownMenu(
+                        expanded = showStorageMenu,
+                        onDismissRequest = { showStorageMenu = false }
+                    ) {
+                        roots.forEach { (label, root) ->
+                            DropdownMenuItem(
+                                text = { Text(label) },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Outlined.Storage,
+                                        contentDescription = null
+                                    )
+                                },
+                                onClick = {
+                                    currentDir = root
+                                    showStorageMenu = false
+                                }
+                            )
+                        }
+                    }
+                }
                 HorizontalDivider(color = LocalDialogTextColor.current.copy(alpha = 0.06f))
             }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -8,7 +8,6 @@ package app.morphe.manager.ui.screen.shared
 import android.content.pm.PackageInfo
 import android.os.Environment
 import android.util.LruCache
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -168,10 +167,8 @@ fun FilePicker(
         currentDir = if (atStorageRoot) null else currentDir?.parentFile
     }
 
-    BackHandler(enabled = currentDir != null, onBack = navigateBack)
-
     MorpheDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { if (currentDir != null) navigateBack() else onDismiss() },
         title = null,
         noPadding = true,
         scrollable = false,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -201,19 +201,17 @@ fun FilePicker(
                     .padding(start = 4.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = onDismiss) {
-                    Icon(
-                        imageVector = Icons.Outlined.Close,
-                        contentDescription = stringResource(android.R.string.cancel),
-                        tint = LocalDialogTextColor.current
-                    )
-                }
                 Text(
-                    text = stringResource(R.string.file_picker_title),
+                    text = stringResource(
+                        if (allowFolderSelection) R.string.file_picker_title_folder
+                        else R.string.file_picker_title
+                    ),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = LocalDialogTextColor.current,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 16.dp)
                 )
                 Box {
                     IconButton(onClick = { showSortMenu = true }) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -49,6 +49,9 @@ private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
     "application/json" to setOf("json"),
     "text/plain" to setOf("txt", "log"),
     "application/vnd.ms-project" to setOf("mpp"), // Morphe patch bundle format
+    "application/x-pkcs12" to setOf("p12", "pfx"),
+    "application/x-java-keystore" to setOf("jks"),
+    "application/vnd.morphe.keystore" to setOf("keystore", "bks"), // BKS keystores, no standard MIME
     "image/png" to setOf("png"),
     "image/jpeg" to setOf("jpg", "jpeg"),
     "image/gif" to setOf("gif"),

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.APK_EXTENSIONS
 import app.morphe.manager.util.formatBytes
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
+import org.koin.compose.koinInject
 
 private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
     "application/vnd.android.package-archive" to setOf("apk", "apks", "xapk", "apkm"),
@@ -87,17 +89,34 @@ fun FilePicker(
     onDismiss: () -> Unit,
     onFilePicked: (File) -> Unit
 ) {
+    val prefs: PreferencesManager = koinInject()
     val allowedExtensions = remember(mimeTypes) { resolveAllowedExtensions(mimeTypes) }
     val roots = remember { storageRoots() }
 
-    var currentDir by remember { mutableStateOf<File?>(null) }
+    val downloadsDir = remember {
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            .takeIf { it.isDirectory }
+    }
+
+    var currentDir by remember { mutableStateOf(downloadsDir) }
     var dirContents by remember { mutableStateOf<List<File>>(emptyList()) }
     var selectedFile by remember { mutableStateOf<File?>(null) }
     var refreshKey by remember { mutableIntStateOf(0) }
 
+    // Restore the last visited directory on open; Downloads stays as fallback until then
+    LaunchedEffect(Unit) {
+        val savedPath = prefs.lastFilePickerPath.get()
+        if (savedPath.isNotEmpty()) {
+            val savedDir = File(savedPath)
+            if (savedDir.isDirectory) currentDir = savedDir
+        }
+    }
+
+    // Reload contents and persist the current directory on every navigation
     LaunchedEffect(currentDir, refreshKey) {
         dirContents = currentDir?.let { listDir(it, allowedExtensions) } ?: emptyList()
         if (selectedFile?.parentFile != currentDir) selectedFile = null
+        currentDir?.absolutePath?.let { prefs.lastFilePickerPath.update(it) }
     }
 
     val navigateBack = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -323,6 +323,7 @@ fun FilePicker(
 
                             val icon = when {
                                 isDir -> Icons.Outlined.Folder
+                                canLoadIcon && packageInfo == null -> Icons.Outlined.Android
                                 canLoadIcon -> null
                                 isApk -> Icons.Outlined.Android
                                 else -> Icons.AutoMirrored.Outlined.InsertDriveFile

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -5,15 +5,15 @@
 
 package app.morphe.manager.ui.screen.shared
 
+import android.content.pm.PackageInfo
 import android.os.Environment
+import android.util.LruCache
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
@@ -29,20 +29,19 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import android.content.pm.PackageInfo
-import android.util.LruCache
 import app.morphe.manager.R
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.APK_EXTENSIONS
 import app.morphe.manager.util.PM
 import app.morphe.manager.util.formatBytes
-import java.io.File
-import java.text.SimpleDateFormat
-import java.util.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
     "application/vnd.android.package-archive" to setOf("apk", "apks", "xapk", "apkm"),
@@ -360,25 +359,17 @@ fun FilePicker(
                     .padding(horizontal = 16.dp, vertical = 12.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                OutlinedButton(
+                MorpheDialogOutlinedButton(
+                    text = stringResource(android.R.string.cancel),
                     onClick = onDismiss,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(24.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = LocalDialogTextColor.current
-                    ),
-                    border = BorderStroke(1.dp, LocalDialogTextColor.current.copy(alpha = 0.3f))
-                ) {
-                    Text(stringResource(android.R.string.cancel))
-                }
-                Button(
+                    modifier = Modifier.weight(1f)
+                )
+                MorpheDialogButton(
+                    text = stringResource(R.string.file_picker_select),
                     onClick = { selectedFile?.let { onFilePicked(it) } },
                     enabled = selectedFile != null,
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(24.dp)
-                ) {
-                    Text(stringResource(R.string.file_picker_select))
-                }
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -73,6 +73,8 @@ private fun storageRoots(): List<Pair<String, File>> {
     return roots
 }
 
+private val iconLoadDispatcher = Dispatchers.IO.limitedParallelism(2)
+
 private fun listDir(dir: File, allowedExtensions: Set<String>?): List<File> =
     dir.listFiles()
         ?.filter { it.isDirectory || allowedExtensions == null || it.extension.lowercase() in allowedExtensions }
@@ -243,14 +245,17 @@ fun FilePicker(
                             val isSelected = selectedFile == file
                             val isDir = file.isDirectory
                             val isApk = !isDir && file.extension.lowercase() in APK_EXTENSIONS
+                            // Only standard .apk supports getPackageArchiveInfo; bundles (.apkm/.apks/.xapk) are ZIPs
+                            val canLoadIcon = !isDir && file.extension.lowercase() == "apk"
 
                             val packageInfo by produceState<PackageInfo?>(null, file) {
-                                if (isApk) value = withContext(Dispatchers.IO) { pm.getPackageInfo(file) }
+                                if (canLoadIcon) value = withContext(iconLoadDispatcher) { pm.getPackageInfo(file) }
                             }
 
                             val icon = when {
                                 isDir -> Icons.Outlined.Folder
-                                isApk -> null
+                                canLoadIcon -> null
+                                isApk -> Icons.Outlined.Android
                                 else -> Icons.AutoMirrored.Outlined.InsertDriveFile
                             }
                             val detail = if (!isDir) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -121,7 +121,8 @@ private fun formatModDate(timestamp: Long): String =
 fun FilePicker(
     mimeTypes: Array<String>,
     onDismiss: () -> Unit,
-    onFilePicked: (File) -> Unit
+    onFilePicked: (File) -> Unit,
+    allowFolderSelection: Boolean = false
 ) {
     val prefs: PreferencesManager = koinInject()
     val pm: PM = koinInject()
@@ -366,8 +367,8 @@ fun FilePicker(
                 )
                 MorpheDialogButton(
                     text = stringResource(R.string.file_picker_select),
-                    onClick = { selectedFile?.let { onFilePicked(it) } },
-                    enabled = selectedFile != null,
+                    onClick = { (selectedFile ?: currentDir?.takeIf { allowFolderSelection })?.let { onFilePicked(it) } },
+                    enabled = selectedFile != null || (allowFolderSelection && currentDir != null),
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -6,13 +6,16 @@
 package app.morphe.manager.ui.screen.shared
 
 import android.content.pm.PackageInfo
+import android.graphics.BitmapFactory
 import android.os.Environment
 import android.util.LruCache
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
@@ -22,8 +25,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -96,8 +103,22 @@ private fun storageRoots(): List<Pair<String, File>> {
     return roots
 }
 
+private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp")
+
 private val iconLoadDispatcher = Dispatchers.IO.limitedParallelism(2)
 private val apkPackageInfoCache = LruCache<String, PackageInfo>(100)
+private val imageThumbnailCache = LruCache<String, ImageBitmap>(30)
+
+private fun decodeThumbnail(file: File): ImageBitmap? = runCatching {
+    val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(file.absolutePath, opts)
+    var sampleSize = 1
+    while (opts.outWidth / (sampleSize * 2) >= 128 && opts.outHeight / (sampleSize * 2) >= 128) {
+        sampleSize *= 2
+    }
+    BitmapFactory.decodeFile(file.absolutePath, BitmapFactory.Options().apply { inSampleSize = sampleSize })
+        ?.asImageBitmap()
+}.getOrNull()
 
 private enum class SortMode {
     NAME_ASC, NAME_DESC, SIZE_DESC, SIZE_ASC, DATE_DESC, DATE_ASC;
@@ -327,6 +348,7 @@ fun FilePicker(
                             val isApk = !isDir && file.extension.lowercase() in APK_EXTENSIONS
                             // Only standard .apk supports getPackageArchiveInfo; bundles (.apkm/.apks/.xapk) are ZIPs
                             val canLoadIcon = !isDir && file.extension.lowercase() == "apk"
+                            val isImage = !isDir && file.extension.lowercase() in IMAGE_EXTENSIONS
 
                             val packageInfo by produceState<PackageInfo?>(null, file) {
                                 if (canLoadIcon) {
@@ -341,6 +363,19 @@ fun FilePicker(
                                 }
                             }
 
+                            val thumbnail by produceState<ImageBitmap?>(null, file) {
+                                if (isImage) {
+                                    val cached = imageThumbnailCache.get(file.absolutePath)
+                                    if (cached != null) {
+                                        value = cached
+                                    } else {
+                                        val bmp = withContext(iconLoadDispatcher) { decodeThumbnail(file) }
+                                        if (bmp != null) imageThumbnailCache.put(file.absolutePath, bmp)
+                                        value = bmp
+                                    }
+                                }
+                            }
+
                             val isMpp = !isDir && file.extension.lowercase() == "mpp"
                             val icon = when {
                                 isDir -> Icons.Outlined.Folder
@@ -348,6 +383,8 @@ fun FilePicker(
                                 canLoadIcon -> null
                                 isApk -> Icons.Outlined.Android
                                 isMpp -> null
+                                isImage && thumbnail == null -> Icons.Outlined.Image
+                                isImage -> null
                                 else -> Icons.AutoMirrored.Outlined.InsertDriveFile
                             }
                             val iconRes = if (isMpp) R.drawable.ic_notification else null
@@ -358,6 +395,7 @@ fun FilePicker(
                             FilePickerRow(
                                 icon = icon,
                                 iconRes = iconRes,
+                                thumbnail = thumbnail,
                                 packageInfo = packageInfo,
                                 name = file.name,
                                 detail = detail,
@@ -405,6 +443,7 @@ private fun FilePickerRow(
     detail: String?,
     packageInfo: PackageInfo? = null,
     iconRes: Int? = null,
+    thumbnail: ImageBitmap? = null,
     isSelected: Boolean = false,
     onClick: () -> Unit
 ) {
@@ -427,6 +466,15 @@ private fun FilePickerRow(
                 packageInfo = packageInfo,
                 contentDescription = null,
                 modifier = Modifier.size(22.dp)
+            )
+        } else if (thumbnail != null) {
+            Image(
+                bitmap = thumbnail,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(22.dp)
+                    .clip(RoundedCornerShape(4.dp))
             )
         } else if (iconRes != null) {
             Icon(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.InsertDriveFile
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -39,6 +40,7 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
@@ -77,11 +79,36 @@ private fun storageRoots(): List<Pair<String, File>> {
 private val iconLoadDispatcher = Dispatchers.IO.limitedParallelism(2)
 private val apkPackageInfoCache = LruCache<String, PackageInfo>(100)
 
+private enum class SortMode {
+    NAME_ASC, NAME_DESC, SIZE_DESC, SIZE_ASC, DATE_DESC, DATE_ASC;
+
+    fun labelRes() = when (this) {
+        NAME_ASC  -> R.string.file_picker_sort_name_asc
+        NAME_DESC -> R.string.file_picker_sort_name_desc
+        SIZE_DESC -> R.string.file_picker_sort_size_desc
+        SIZE_ASC  -> R.string.file_picker_sort_size_asc
+        DATE_DESC -> R.string.file_picker_sort_date_desc
+        DATE_ASC  -> R.string.file_picker_sort_date_asc
+    }
+}
+
 private fun listDir(dir: File, allowedExtensions: Set<String>?): List<File> =
     dir.listFiles()
         ?.filter { it.isDirectory || allowedExtensions == null || it.extension.lowercase() in allowedExtensions }
-        ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
         ?: emptyList()
+
+private fun applySort(files: List<File>, mode: SortMode): List<File> {
+    val (dirs, nonDirs) = files.partition { it.isDirectory }
+    val sortedFiles = when (mode) {
+        SortMode.NAME_ASC  -> nonDirs.sortedBy { it.name.lowercase() }
+        SortMode.NAME_DESC -> nonDirs.sortedByDescending { it.name.lowercase() }
+        SortMode.SIZE_DESC -> nonDirs.sortedByDescending { it.length() }
+        SortMode.SIZE_ASC  -> nonDirs.sortedBy { it.length() }
+        SortMode.DATE_DESC -> nonDirs.sortedByDescending { it.lastModified() }
+        SortMode.DATE_ASC  -> nonDirs.sortedBy { it.lastModified() }
+    }
+    return dirs.sortedBy { it.name.lowercase() } + sortedFiles
+}
 
 private fun formatModDate(timestamp: Long): String =
     SimpleDateFormat("dd.MM.yyyy, HH:mm", Locale.getDefault()).format(Date(timestamp))
@@ -99,6 +126,7 @@ fun FilePicker(
 ) {
     val prefs: PreferencesManager = koinInject()
     val pm: PM = koinInject()
+    val coroutineScope = rememberCoroutineScope()
     val allowedExtensions = remember(mimeTypes) { resolveAllowedExtensions(mimeTypes) }
     val roots = remember { storageRoots() }
 
@@ -112,6 +140,12 @@ fun FilePicker(
     var selectedFile by remember { mutableStateOf<File?>(null) }
     var refreshKey by remember { mutableIntStateOf(0) }
     var showStorageMenu by remember { mutableStateOf(false) }
+    var sortMode by remember {
+        mutableStateOf(runCatching { SortMode.valueOf(prefs.filePickerSortMode.getBlocking()) }.getOrDefault(SortMode.NAME_ASC))
+    }
+    var showSortMenu by remember { mutableStateOf(false) }
+
+    val sortedContents = remember(dirContents, sortMode) { applySort(dirContents, sortMode) }
 
     // Restore the last visited directory on open; Downloads stays as fallback until then
     LaunchedEffect(Unit) {
@@ -165,6 +199,33 @@ fun FilePicker(
                     color = LocalDialogTextColor.current,
                     modifier = Modifier.weight(1f)
                 )
+                Box {
+                    IconButton(onClick = { showSortMenu = true }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.Sort,
+                            contentDescription = null,
+                            tint = LocalDialogTextColor.current
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = showSortMenu,
+                        onDismissRequest = { showSortMenu = false }
+                    ) {
+                        SortMode.entries.forEach { mode ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(mode.labelRes())) },
+                                trailingIcon = if (sortMode == mode) {
+                                    { Icon(Icons.Outlined.Check, contentDescription = null) }
+                                } else null,
+                                onClick = {
+                                    sortMode = mode
+                                    showSortMenu = false
+                                    coroutineScope.launch { prefs.filePickerSortMode.update(mode.name) }
+                                }
+                            )
+                        }
+                    }
+                }
                 IconButton(onClick = { refreshKey++ }) {
                     Icon(
                         imageVector = Icons.Outlined.Refresh,
@@ -243,7 +304,7 @@ fun FilePicker(
                             )
                         }
                     } else {
-                        items(dirContents, key = { it.absolutePath }) { file ->
+                        items(sortedContents, key = { it.absolutePath }) { file ->
                             val isSelected = selectedFile == file
                             val isDir = file.isDirectory
                             val isApk = !isDir && file.extension.lowercase() in APK_EXTENSIONS

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -339,19 +340,23 @@ fun FilePicker(
                                 }
                             }
 
+                            val isMpp = !isDir && file.extension.lowercase() == "mpp"
                             val icon = when {
                                 isDir -> Icons.Outlined.Folder
                                 canLoadIcon && packageInfo == null -> Icons.Outlined.Android
                                 canLoadIcon -> null
                                 isApk -> Icons.Outlined.Android
+                                isMpp -> null
                                 else -> Icons.AutoMirrored.Outlined.InsertDriveFile
                             }
+                            val iconRes = if (isMpp) R.drawable.ic_notification else null
                             val detail = if (!isDir) {
                                 "${formatBytes(file.length())} · ${formatModDate(file.lastModified())}"
                             } else null
 
                             FilePickerRow(
                                 icon = icon,
+                                iconRes = iconRes,
                                 packageInfo = packageInfo,
                                 name = file.name,
                                 detail = detail,
@@ -398,9 +403,12 @@ private fun FilePickerRow(
     name: String,
     detail: String?,
     packageInfo: PackageInfo? = null,
+    iconRes: Int? = null,
     isSelected: Boolean = false,
     onClick: () -> Unit
 ) {
+    val iconTint = if (isSelected) MaterialTheme.colorScheme.primary
+                   else LocalDialogTextColor.current.copy(alpha = 0.75f)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -419,12 +427,18 @@ private fun FilePickerRow(
                 contentDescription = null,
                 modifier = Modifier.size(22.dp)
             )
+        } else if (iconRes != null) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(22.dp)
+            )
         } else if (icon != null) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = if (isSelected) MaterialTheme.colorScheme.primary
-                       else LocalDialogTextColor.current.copy(alpha = 0.75f),
+                tint = iconTint,
                 modifier = Modifier.size(22.dp)
             )
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -28,13 +28,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import android.content.pm.PackageInfo
 import app.morphe.manager.R
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.APK_EXTENSIONS
+import app.morphe.manager.util.PM
 import app.morphe.manager.util.formatBytes
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
 private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
@@ -90,6 +94,7 @@ fun FilePicker(
     onFilePicked: (File) -> Unit
 ) {
     val prefs: PreferencesManager = koinInject()
+    val pm: PM = koinInject()
     val allowedExtensions = remember(mimeTypes) { resolveAllowedExtensions(mimeTypes) }
     val roots = remember { storageRoots() }
 
@@ -237,9 +242,15 @@ fun FilePicker(
                         items(dirContents, key = { it.absolutePath }) { file ->
                             val isSelected = selectedFile == file
                             val isDir = file.isDirectory
+                            val isApk = !isDir && file.extension.lowercase() in APK_EXTENSIONS
+
+                            val packageInfo by produceState<PackageInfo?>(null, file) {
+                                if (isApk) value = withContext(Dispatchers.IO) { pm.getPackageInfo(file) }
+                            }
+
                             val icon = when {
                                 isDir -> Icons.Outlined.Folder
-                                file.extension.lowercase() in APK_EXTENSIONS -> Icons.Outlined.Android
+                                isApk -> null
                                 else -> Icons.AutoMirrored.Outlined.InsertDriveFile
                             }
                             val detail = if (!isDir) {
@@ -248,6 +259,7 @@ fun FilePicker(
 
                             FilePickerRow(
                                 icon = icon,
+                                packageInfo = packageInfo,
                                 name = file.name,
                                 detail = detail,
                                 isSelected = isSelected,
@@ -297,9 +309,10 @@ fun FilePicker(
 
 @Composable
 private fun FilePickerRow(
-    icon: ImageVector,
+    icon: ImageVector?,
     name: String,
     detail: String?,
+    packageInfo: PackageInfo? = null,
     isSelected: Boolean = false,
     onClick: () -> Unit
 ) {
@@ -315,13 +328,21 @@ private fun FilePickerRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = if (isSelected) MaterialTheme.colorScheme.primary
-                   else LocalDialogTextColor.current.copy(alpha = 0.75f),
-            modifier = Modifier.size(22.dp)
-        )
+        if (packageInfo != null) {
+            AppIcon(
+                packageInfo = packageInfo,
+                contentDescription = null,
+                modifier = Modifier.size(22.dp)
+            )
+        } else if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (isSelected) MaterialTheme.colorScheme.primary
+                       else LocalDialogTextColor.current.copy(alpha = 0.75f),
+                modifier = Modifier.size(22.dp)
+            )
+        }
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = name,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import android.content.pm.PackageInfo
+import android.util.LruCache
 import app.morphe.manager.R
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.APK_EXTENSIONS
@@ -74,6 +75,7 @@ private fun storageRoots(): List<Pair<String, File>> {
 }
 
 private val iconLoadDispatcher = Dispatchers.IO.limitedParallelism(2)
+private val apkPackageInfoCache = LruCache<String, PackageInfo>(100)
 
 private fun listDir(dir: File, allowedExtensions: Set<String>?): List<File> =
     dir.listFiles()
@@ -249,7 +251,16 @@ fun FilePicker(
                             val canLoadIcon = !isDir && file.extension.lowercase() == "apk"
 
                             val packageInfo by produceState<PackageInfo?>(null, file) {
-                                if (canLoadIcon) value = withContext(iconLoadDispatcher) { pm.getPackageInfo(file) }
+                                if (canLoadIcon) {
+                                    val cached = apkPackageInfoCache.get(file.absolutePath)
+                                    if (cached != null) {
+                                        value = cached
+                                    } else {
+                                        val info = withContext(iconLoadDispatcher) { pm.getPackageInfo(file) }
+                                        if (info != null) apkPackageInfoCache.put(file.absolutePath, info)
+                                        value = info
+                                    }
+                                }
                             }
 
                             val icon = when {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -383,7 +383,7 @@ fun FilePicker(
                 horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 MorpheDialogOutlinedButton(
-                    text = stringResource(android.R.string.cancel),
+                    text = stringResource(R.string.close),
                     onClick = onDismiss,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/FilePicker.kt
@@ -42,23 +42,41 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+// Exact MIME type → extensions
 private val MIME_EXTENSION_MAP: Map<String, Set<String>> = mapOf(
     "application/vnd.android.package-archive" to setOf("apk", "apks", "xapk", "apkm"),
     "application/json" to setOf("json"),
     "text/plain" to setOf("txt", "log"),
-    "application/vnd.ms-project" to setOf("mpp"),
+    "application/vnd.ms-project" to setOf("mpp"), // Morphe patch bundle format
     "image/png" to setOf("png"),
     "image/jpeg" to setOf("jpg", "jpeg"),
     "image/gif" to setOf("gif"),
     "image/webp" to setOf("webp"),
 )
 
-// Returns null when the types are too broad to filter (wildcards like *\/*, application\/*)
+// Category wildcard MIME type → extensions
+private val MIME_WILDCARD_MAP: Map<String, Set<String>> = mapOf(
+    "image/*" to setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "heic", "heif", "svg", "ico"),
+    "video/*" to setOf("mp4", "mkv", "avi", "mov", "webm", "3gp", "ts", "flv"),
+    "audio/*" to setOf("mp3", "wav", "ogg", "flac", "aac", "m4a", "opus", "wma"),
+    "text/*" to setOf("txt", "log", "csv", "xml", "html", "htm", "md", "json"),
+)
+
+// Broad/generic MIME types added as system-picker fallbacks - skipped during resolution
+// so they don't suppress filtering when specific types are also present in the array
+private val MIME_PASSTHROUGH: Set<String> = setOf(
+    "*/*",
+    "application/octet-stream",
+    "application/*",
+)
+
+// Skips passthrough types; returns null only when no specific type could be resolved
 internal fun resolveAllowedExtensions(mimeTypes: Array<String>): Set<String>? {
-    if (mimeTypes.any { it == "*/*" || it.endsWith("/*") }) return null
+    val specific = mimeTypes.filter { it !in MIME_PASSTHROUGH }
+    if (specific.isEmpty()) return null
     val extensions = mutableSetOf<String>()
-    for (mime in mimeTypes) {
-        extensions += MIME_EXTENSION_MAP[mime] ?: return null
+    for (mime in specific) {
+        extensions += MIME_EXTENSION_MAP[mime] ?: MIME_WILDCARD_MAP[mime] ?: return null
     }
     return extensions.ifEmpty { null }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -120,57 +120,59 @@ fun HeaderCreatorDialog(
 
     // Light header image picker
     val openLightHeaderPicker = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf("image/*")
-    ) { uri ->
-        uri?.let {
-            lightHeaderUri = it
-            scope.launch(Dispatchers.IO) {
-                try {
-                    val inputStream = context.contentResolver.openInputStream(it)
-                    val bitmap = BitmapFactory.decodeStream(inputStream)
-                    inputStream?.close()
-                    lightHeaderBitmap = bitmap
-                    // Reset transform when new image is loaded
-                    withContext(Dispatchers.Main) {
-                        lightScale = 1f
-                        lightOffsetX = 0f
-                        lightOffsetY = 0f
-                    }
-                } catch (e: Exception) {
-                    withContext(Dispatchers.Main) {
-                        context.toast("Failed to load image: ${e.message}")
+        mimeTypes = arrayOf("image/*"),
+        onResult = { uri ->
+            uri?.let {
+                lightHeaderUri = it
+                scope.launch(Dispatchers.IO) {
+                    try {
+                        val inputStream = context.contentResolver.openInputStream(it)
+                        val bitmap = BitmapFactory.decodeStream(inputStream)
+                        inputStream?.close()
+                        lightHeaderBitmap = bitmap
+                        // Reset transform when new image is loaded
+                        withContext(Dispatchers.Main) {
+                            lightScale = 1f
+                            lightOffsetX = 0f
+                            lightOffsetY = 0f
+                        }
+                    } catch (e: Exception) {
+                        withContext(Dispatchers.Main) {
+                            context.toast("Failed to load image: ${e.message}")
+                        }
                     }
                 }
             }
         }
-    }
+    )
 
     // Dark header image picker
     val openDarkHeaderPicker = rememberAdaptiveFilePicker(
-        mimeTypes = arrayOf("image/*")
-    ) { uri ->
-        uri?.let {
-            darkHeaderUri = it
-            scope.launch(Dispatchers.IO) {
-                try {
-                    val inputStream = context.contentResolver.openInputStream(it)
-                    val bitmap = BitmapFactory.decodeStream(inputStream)
-                    inputStream?.close()
-                    darkHeaderBitmap = bitmap
-                    // Reset transform when new image is loaded
-                    withContext(Dispatchers.Main) {
-                        darkScale = 1f
-                        darkOffsetX = 0f
-                        darkOffsetY = 0f
-                    }
-                } catch (e: Exception) {
-                    withContext(Dispatchers.Main) {
-                        context.toast("Failed to load image: ${e.message}")
+        mimeTypes = arrayOf("image/*"),
+        onResult = { uri ->
+            uri?.let {
+                darkHeaderUri = it
+                scope.launch(Dispatchers.IO) {
+                    try {
+                        val inputStream = context.contentResolver.openInputStream(it)
+                        val bitmap = BitmapFactory.decodeStream(inputStream)
+                        inputStream?.close()
+                        darkHeaderBitmap = bitmap
+                        // Reset transform when new image is loaded
+                        withContext(Dispatchers.Main) {
+                            darkScale = 1f
+                            darkOffsetX = 0f
+                            darkOffsetY = 0f
+                        }
+                    } catch (e: Exception) {
+                        withContext(Dispatchers.Main) {
+                            context.toast("Failed to load image: ${e.message}")
+                        }
                     }
                 }
             }
         }
-    }
+    )
 
     // Folder picker for saving
     val successMessage = stringResource(R.string.header_creator_success)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -208,6 +208,10 @@ class SettingsViewModel(
         prefs.promptInstallerOnInstall.update(enabled)
     }
 
+    fun setUseCustomFilePicker(enabled: Boolean) = viewModelScope.launch {
+        prefs.useCustomFilePicker.update(enabled)
+    }
+
     /**
      * Requests root access when the AutoSaved (root-mount) installer is chosen,
      * then persists the selection.

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -180,6 +180,9 @@ class SettingsViewModel(
 
     fun setExpertMode(enabled: Boolean) = viewModelScope.launch {
         prefs.useExpertMode.update(enabled)
+        if (enabled && !prefs.customFilePickerUserConfigured.get()) {
+            prefs.useCustomFilePicker.update(true)
+        }
     }
 
     fun setProcessRuntime(enabled: Boolean) = viewModelScope.launch {
@@ -210,6 +213,7 @@ class SettingsViewModel(
 
     fun setUseCustomFilePicker(enabled: Boolean) = viewModelScope.launch {
         prefs.useCustomFilePicker.update(enabled)
+        prefs.customFilePickerUserConfigured.update(true)
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -259,10 +259,9 @@ fun Context.isAndroidTv(): Boolean {
 }
 
 /**
- * On Android TV uses [ActivityResultContracts.OpenDocument] which routes through
- * DocumentsUI and shows registered storage providers (file managers).
- * On phones/tablets: uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker]
- * is enabled, falling back to [ActivityResultContracts.GetContent] otherwise.
+ * Uses Morphe's built-in [FilePicker] on all devices when [PreferencesManager.useCustomFilePicker]
+ * is enabled. Falls back to [ActivityResultContracts.OpenDocument] on TV and
+ * [ActivityResultContracts.GetContent] on phones/tablets.
  * Storage permission is requested automatically before showing the custom picker.
  */
 @Composable
@@ -308,11 +307,11 @@ fun rememberAdaptiveFilePicker(
     return remember(isTV, useCustomPicker) {
         {
             when {
-                isTV -> tvLauncher.launch(mimeTypes)
                 useCustomPicker -> {
                     if (fs.hasStoragePermission()) showPickerState.value = true
                     else permissionLauncher.launch(permissionName)
                 }
+                isTV -> tvLauncher.launch(mimeTypes)
                 else -> phoneLauncher.launch(if (mimeTypes.size == 1) mimeTypes[0] else "*/*")
             }
         }

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -14,10 +14,11 @@ import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import app.morphe.manager.data.platform.Filesystem
+import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.ui.screen.shared.FilePicker
 import org.koin.compose.koinInject
 import java.io.File
 
@@ -39,6 +40,9 @@ data class MppManifest(
  * Prefer using Uri directly with ContentResolver where possible.
  */
 fun Uri.toFilePath(): String {
+    // file:// URIs from the custom file picker — extract the path directly
+    if (scheme == "file") return path ?: Uri.decode(toString())
+
     val docId: String? = when {
         DocumentsContract.isTreeUri(this) ->
             // Child document URI contains the full path; root tree URI contains only the root
@@ -234,8 +238,9 @@ fun Context.isAndroidTv(): Boolean {
 /**
  * On Android TV uses [ActivityResultContracts.OpenDocument] which routes through
  * DocumentsUI and shows registered storage providers (file managers).
- * On phones/tablets uses [ActivityResultContracts.GetContent]: a single MIME type is passed
- * as-is; multiple types collapse to a wildcard with extension validation on the result.
+ * On phones/tablets: uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker]
+ * is enabled, falling back to [ActivityResultContracts.GetContent] otherwise.
+ * Storage permission is requested automatically before showing the custom picker.
  */
 @Composable
 fun rememberAdaptiveFilePicker(
@@ -244,7 +249,11 @@ fun rememberAdaptiveFilePicker(
 ): () -> Unit {
     val context = LocalContext.current
     val isTV = remember { context.isAndroidTv() }
+    val prefs: PreferencesManager = koinInject()
+    val fs: Filesystem = koinInject()
+    val useCustomPicker by prefs.useCustomFilePicker.getAsState()
 
+    // System launchers — always registered so the composable graph stays stable
     val tvLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri -> onResult(uri) }
@@ -253,10 +262,34 @@ fun rememberAdaptiveFilePicker(
         contract = ActivityResultContracts.GetContent()
     ) { uri -> onResult(uri) }
 
-    return remember(isTV) {
+    val (permissionContract, permissionName) = remember { fs.permissionContract() }
+    val showPickerState = remember { mutableStateOf(false) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(contract = permissionContract) { granted ->
+        if (granted) showPickerState.value = true
+    }
+
+    if (showPickerState.value) {
+        FilePicker(
+            mimeTypes = mimeTypes,
+            onDismiss = { showPickerState.value = false },
+            onFilePicked = { file ->
+                showPickerState.value = false
+                onResult(Uri.fromFile(file))
+            }
+        )
+    }
+
+    return remember(isTV, useCustomPicker) {
         {
-            if (isTV) tvLauncher.launch(mimeTypes)
-            else phoneLauncher.launch(if (mimeTypes.size == 1) mimeTypes[0] else "*/*")
+            when {
+                isTV -> tvLauncher.launch(mimeTypes)
+                useCustomPicker -> {
+                    if (fs.hasStoragePermission()) showPickerState.value = true
+                    else permissionLauncher.launch(permissionName)
+                }
+                else -> phoneLauncher.launch(if (mimeTypes.size == 1) mimeTypes[0] else "*/*")
+            }
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -190,8 +190,6 @@ fun rememberFolderPickerWithPermission(
         if (granted) {
             if (useCustomPicker || isTV) showPickerState.value = true
             else folderPickerLauncher.launch(null)
-        } else if (isTV) {
-            folderPickerLauncher.launch(null)
         }
     }
 
@@ -263,9 +261,8 @@ fun Context.isAndroidTv(): Boolean {
 }
 
 /**
- * Uses Morphe's built-in [FilePicker] on TV and on any device when [PreferencesManager.useCustomFilePicker] is enabled.
- * Falls back to [ActivityResultContracts.OpenDocument] on TV if permission is denied,
- * or [ActivityResultContracts.GetContent] on phones/tablets.
+ * Uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker] is enabled.
+ * Falls back to [ActivityResultContracts.GetContent] on phones/tablets.
  * Storage permission is requested automatically before showing the custom picker.
  */
 @Composable
@@ -280,11 +277,7 @@ fun rememberAdaptiveFilePicker(
     val fs: Filesystem = koinInject()
     val useCustomPicker by prefs.useCustomFilePicker.getAsState()
 
-    // System launchers - always registered so the composable graph stays stable
-    val tvLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocument()
-    ) { uri -> onResult(uri) }
-
+    // SAF launcher for phones/tablets - always registered so the composable graph stays stable
     val phoneLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri -> onResult(uri) }
@@ -294,7 +287,6 @@ fun rememberAdaptiveFilePicker(
 
     val permissionLauncher = rememberLauncherForActivityResult(contract = permissionContract) { granted ->
         if (granted) showPickerState.value = true
-        else if (isTV) tvLauncher.launch(mimeTypes)
     }
 
     if (showPickerState.value) {

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -21,6 +21,7 @@ import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.ui.screen.shared.FilePicker
 import org.koin.compose.koinInject
 import java.io.File
+import java.util.zip.ZipInputStream
 
 /** Parsed metadata from a .mpp patch bundle's META-INF/MANIFEST.MF entry. */
 data class MppManifest(
@@ -40,7 +41,7 @@ data class MppManifest(
  * Prefer using Uri directly with ContentResolver where possible.
  */
 fun Uri.toFilePath(): String {
-    // file:// URIs from the custom file picker — extract the path directly
+    // file:// URIs from the custom file picker - extract the path directly
     if (scheme == "file") return path ?: Uri.decode(toString())
 
     val docId: String? = when {
@@ -102,7 +103,7 @@ fun Uri.hasApkExtension(contentResolver: ContentResolver): Boolean =
 fun Uri.readMppManifest(contentResolver: ContentResolver): MppManifest? =
     runCatching {
         contentResolver.openInputStream(this)?.use { stream ->
-            java.util.zip.ZipInputStream(stream).use { zip ->
+            ZipInputStream(stream).use { zip ->
                 var manifest: MppManifest? = null
                 var entry = zip.nextEntry
                 while (entry != null && manifest == null) {
@@ -148,13 +149,31 @@ fun rememberFolderPicker(onFolderPicked: (Uri) -> Unit): () -> Unit {
  * Folder picker launcher with automatic permission handling.
  * Use this when storing the picked folder PATH as a patch option value (the patcher will
  * later read files from it via the File API, which requires MANAGE_EXTERNAL_STORAGE).
+ * Uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker] is enabled,
+ * falling back to [ActivityResultContracts.OpenDocumentTree] otherwise.
  */
 @Composable
 fun rememberFolderPickerWithPermission(
     onFolderPicked: (Uri) -> Unit
 ): () -> Unit {
     val fs: Filesystem = koinInject()
+    val prefs: PreferencesManager = koinInject()
+    val useCustomPicker by prefs.useCustomFilePicker.getAsState()
+    val showPickerState = remember { mutableStateOf(false) }
 
+    if (showPickerState.value) {
+        FilePicker(
+            mimeTypes = arrayOf("*/*"),
+            allowFolderSelection = true,
+            onDismiss = { showPickerState.value = false },
+            onFilePicked = { file ->
+                showPickerState.value = false
+                onFolderPicked(Uri.fromFile(file))
+            }
+        )
+    }
+
+    // SAF launcher - always registered so the composable graph stays stable
     val folderPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree()
     ) { uri: Uri? ->
@@ -167,16 +186,20 @@ fun rememberFolderPickerWithPermission(
         contract = permissionContract
     ) { granted ->
         if (granted) {
-            folderPickerLauncher.launch(null)
+            if (useCustomPicker) showPickerState.value = true
+            else folderPickerLauncher.launch(null)
         }
     }
 
-    return remember {
+    return remember(useCustomPicker) {
         {
-            if (fs.hasStoragePermission()) {
-                folderPickerLauncher.launch(null)
-            } else {
-                permissionLauncher.launch(permissionName)
+            when {
+                useCustomPicker -> {
+                    if (fs.hasStoragePermission()) showPickerState.value = true
+                    else permissionLauncher.launch(permissionName)
+                }
+                fs.hasStoragePermission() -> folderPickerLauncher.launch(null)
+                else -> permissionLauncher.launch(permissionName)
             }
         }
     }
@@ -246,6 +269,7 @@ fun Context.isAndroidTv(): Boolean {
 fun rememberAdaptiveFilePicker(
     mimeTypes: Array<String>,
     onResult: (Uri?) -> Unit,
+    allowFolderSelection: Boolean = false
 ): () -> Unit {
     val context = LocalContext.current
     val isTV = remember { context.isAndroidTv() }
@@ -253,7 +277,7 @@ fun rememberAdaptiveFilePicker(
     val fs: Filesystem = koinInject()
     val useCustomPicker by prefs.useCustomFilePicker.getAsState()
 
-    // System launchers — always registered so the composable graph stays stable
+    // System launchers - always registered so the composable graph stays stable
     val tvLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri -> onResult(uri) }
@@ -272,6 +296,7 @@ fun rememberAdaptiveFilePicker(
     if (showPickerState.value) {
         FilePicker(
             mimeTypes = mimeTypes,
+            allowFolderSelection = allowFolderSelection,
             onDismiss = { showPickerState.value = false },
             onFilePicked = { file ->
                 showPickerState.value = false

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -264,10 +264,15 @@ fun Context.isAndroidTv(): Boolean {
  * Uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker] is enabled.
  * Falls back to [ActivityResultContracts.GetContent] on phones/tablets.
  * Storage permission is requested automatically before showing the custom picker.
+ *
+ * [customPickerMimeTypes] overrides the MIME types passed to the custom picker only,
+ * allowing tighter extension filtering without affecting the system picker.
+ * Defaults to [mimeTypes] when not specified.
  */
 @Composable
 fun rememberAdaptiveFilePicker(
     mimeTypes: Array<String>,
+    customPickerMimeTypes: Array<String> = mimeTypes,
     onResult: (Uri?) -> Unit,
     allowFolderSelection: Boolean = false
 ): () -> Unit {
@@ -291,7 +296,7 @@ fun rememberAdaptiveFilePicker(
 
     if (showPickerState.value) {
         FilePicker(
-            mimeTypes = mimeTypes,
+            mimeTypes = customPickerMimeTypes,
             allowFolderSelection = allowFolderSelection,
             onDismiss = { showPickerState.value = false },
             onFilePicked = { file ->

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -94,7 +94,6 @@ fun Uri.hasMppExtension(contentResolver: ContentResolver): Boolean =
 fun Uri.hasApkExtension(contentResolver: ContentResolver): Boolean =
     displayName(contentResolver)?.substringAfterLast('.', "")?.lowercase() in APK_EXTENSIONS
 
-
 /**
  * Reads and parses the META-INF/MANIFEST.MF entry from a .mpp patch bundle URI.
  * Returns null if the entry is missing, the URI is unreadable, or any IO error occurs.

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -149,13 +149,15 @@ fun rememberFolderPicker(onFolderPicked: (Uri) -> Unit): () -> Unit {
  * Folder picker launcher with automatic permission handling.
  * Use this when storing the picked folder PATH as a patch option value (the patcher will
  * later read files from it via the File API, which requires MANAGE_EXTERNAL_STORAGE).
- * Uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker] is enabled,
- * falling back to [ActivityResultContracts.OpenDocumentTree] otherwise.
+ * Uses Morphe's built-in [FilePicker] on TV and when [PreferencesManager.useCustomFilePicker]
+ * is enabled, falling back to [ActivityResultContracts.OpenDocumentTree] otherwise.
  */
 @Composable
 fun rememberFolderPickerWithPermission(
     onFolderPicked: (Uri) -> Unit
 ): () -> Unit {
+    val context = LocalContext.current
+    val isTV = remember { context.isAndroidTv() }
     val fs: Filesystem = koinInject()
     val prefs: PreferencesManager = koinInject()
     val useCustomPicker by prefs.useCustomFilePicker.getAsState()
@@ -186,15 +188,17 @@ fun rememberFolderPickerWithPermission(
         contract = permissionContract
     ) { granted ->
         if (granted) {
-            if (useCustomPicker) showPickerState.value = true
+            if (useCustomPicker || isTV) showPickerState.value = true
             else folderPickerLauncher.launch(null)
+        } else if (isTV) {
+            folderPickerLauncher.launch(null)
         }
     }
 
-    return remember(useCustomPicker) {
+    return remember(isTV, useCustomPicker) {
         {
             when {
-                useCustomPicker -> {
+                useCustomPicker || isTV -> {
                     if (fs.hasStoragePermission()) showPickerState.value = true
                     else permissionLauncher.launch(permissionName)
                 }
@@ -259,9 +263,9 @@ fun Context.isAndroidTv(): Boolean {
 }
 
 /**
- * Uses Morphe's built-in [FilePicker] on all devices when [PreferencesManager.useCustomFilePicker]
- * is enabled. Falls back to [ActivityResultContracts.OpenDocument] on TV and
- * [ActivityResultContracts.GetContent] on phones/tablets.
+ * Uses Morphe's built-in [FilePicker] on TV and on any device when [PreferencesManager.useCustomFilePicker] is enabled.
+ * Falls back to [ActivityResultContracts.OpenDocument] on TV if permission is denied,
+ * or [ActivityResultContracts.GetContent] on phones/tablets.
  * Storage permission is requested automatically before showing the custom picker.
  */
 @Composable
@@ -290,6 +294,7 @@ fun rememberAdaptiveFilePicker(
 
     val permissionLauncher = rememberLauncherForActivityResult(contract = permissionContract) { granted ->
         if (granted) showPickerState.value = true
+        else if (isTV) tvLauncher.launch(mimeTypes)
     }
 
     if (showPickerState.value) {
@@ -307,11 +312,10 @@ fun rememberAdaptiveFilePicker(
     return remember(isTV, useCustomPicker) {
         {
             when {
-                useCustomPicker -> {
+                useCustomPicker || isTV -> {
                     if (fs.hasStoragePermission()) showPickerState.value = true
                     else permissionLauncher.launch(permissionName)
                 }
-                isTV -> tvLauncher.launch(mimeTypes)
                 else -> phoneLauncher.launch(if (mimeTypes.size == 1) mimeTypes[0] else "*/*")
             }
         }

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -14,7 +14,10 @@ import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.domain.manager.PreferencesManager
@@ -148,8 +151,9 @@ fun rememberFolderPicker(onFolderPicked: (Uri) -> Unit): () -> Unit {
  * Folder picker launcher with automatic permission handling.
  * Use this when storing the picked folder PATH as a patch option value (the patcher will
  * later read files from it via the File API, which requires MANAGE_EXTERNAL_STORAGE).
- * Uses Morphe's built-in [FilePicker] on TV and when [PreferencesManager.useCustomFilePicker]
- * is enabled, falling back to [ActivityResultContracts.OpenDocumentTree] otherwise.
+ * Uses Morphe's built-in [FilePicker] on TV and when [PreferencesManager.useCustomFilePicker] is enabled.
+ * On phones/tablets without the custom picker, falls back to [ActivityResultContracts.OpenDocumentTree].
+ * Storage permission is always required first; if denied, the picker is not shown.
  */
 @Composable
 fun rememberFolderPickerWithPermission(
@@ -260,7 +264,7 @@ fun Context.isAndroidTv(): Boolean {
 }
 
 /**
- * Uses Morphe's built-in [FilePicker] when [PreferencesManager.useCustomFilePicker] is enabled.
+ * Uses Morphe's built-in [FilePicker] on TV and when [PreferencesManager.useCustomFilePicker] is enabled.
  * Falls back to [ActivityResultContracts.GetContent] on phones/tablets.
  * Storage permission is requested automatically before showing the custom picker.
  *

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,10 +672,8 @@ The image dimensions must be as follows:
     <string name="settings_system_export_debug_logs_export_failed">Failed to export logs</string>
     <string name="settings_system_export_debug_logs_export_success">Logs exported</string>
 
-    <!-- Settings - System Tab - Files Section -->
-    <string name="settings_system_files">Files</string>
-    <string name="settings_system_custom_file_picker">Custom file picker</string>
-    <string name="settings_system_custom_file_picker_description">Browse storage with Morphe\'s built-in file picker instead of the system default</string>
+    <!-- Settings - System Tab - Files & Storage Section -->
+
 
     <!-- File Picker -->
     <string name="file_picker_title">Select file</string>
@@ -691,8 +689,8 @@ The image dimensions must be as follows:
     <string name="file_picker_sort_date_desc">Date (newest first)</string>
     <string name="file_picker_sort_date_asc">Date (oldest first)</string>
 
-    <!-- Settings - System Tab - Storage Management Section -->
-    <string name="settings_system_storage_management">Storage management</string>
+    <!-- Settings - System Tab - Files & Storage Section -->
+    <string name="settings_system_files">Files &amp; storage</string>
     <string name="settings_system_apks_size">Total size: %s</string>
     <string name="settings_system_apk_item_info" translatable="false">v%s • %s</string>
 
@@ -734,6 +732,10 @@ The image dimensions must be as follows:
     <string name="settings_system_selected_patches_title">Selected patches (%s)</string>
     <string name="settings_system_patch_options_title">Patch options (%s)</string>
     <string name="settings_system_no_patches_or_options">No patches or options saved</string>
+
+    <!-- Settings - System Tab - Custom file picker -->
+    <string name="settings_system_custom_file_picker">Custom file picker</string>
+    <string name="settings_system_custom_file_picker_description">Browse storage with Morphe\'s built-in file picker instead of the system default</string>
 
     <!-- Settings - System Tab - About Section -->
     <string name="settings_system_about">About</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,6 +672,19 @@ The image dimensions must be as follows:
     <string name="settings_system_export_debug_logs_export_failed">Failed to export logs</string>
     <string name="settings_system_export_debug_logs_export_success">Logs exported</string>
 
+    <!-- Settings - System Tab - Files Section -->
+    <string name="settings_system_files">Files</string>
+    <string name="settings_system_custom_file_picker">Custom file picker</string>
+    <string name="settings_system_custom_file_picker_description">Browse storage with Morphe\'s built-in file picker instead of the system default</string>
+
+    <!-- File Picker -->
+    <string name="file_picker_title">Select file</string>
+    <string name="file_picker_previous_directory">Previous directory</string>
+    <string name="file_picker_select">Select</string>
+    <string name="file_picker_no_files">No files here</string>
+    <string name="file_picker_internal_storage">Internal storage</string>
+    <string name="file_picker_sd_card">SD card</string>
+
     <!-- Settings - System Tab - Storage Management Section -->
     <string name="settings_system_storage_management">Storage management</string>
     <string name="settings_system_apks_size">Total size: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -684,6 +684,12 @@ The image dimensions must be as follows:
     <string name="file_picker_no_files">No files here</string>
     <string name="file_picker_internal_storage">Internal storage</string>
     <string name="file_picker_sd_card">SD card</string>
+    <string name="file_picker_sort_name_asc">Name (A–Z)</string>
+    <string name="file_picker_sort_name_desc">Name (Z–A)</string>
+    <string name="file_picker_sort_size_desc">Size (largest first)</string>
+    <string name="file_picker_sort_size_asc">Size (smallest first)</string>
+    <string name="file_picker_sort_date_desc">Date (newest first)</string>
+    <string name="file_picker_sort_date_asc">Date (oldest first)</string>
 
     <!-- Settings - System Tab - Storage Management Section -->
     <string name="settings_system_storage_management">Storage management</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,23 +673,6 @@ The image dimensions must be as follows:
     <string name="settings_system_export_debug_logs_export_success">Logs exported</string>
 
     <!-- Settings - System Tab - Files & Storage Section -->
-
-
-    <!-- File Picker -->
-    <string name="file_picker_title">Select file</string>
-    <string name="file_picker_previous_directory">Previous directory</string>
-    <string name="file_picker_select">Select</string>
-    <string name="file_picker_no_files">No files here</string>
-    <string name="file_picker_internal_storage">Internal storage</string>
-    <string name="file_picker_sd_card">SD card</string>
-    <string name="file_picker_sort_name_asc">Name (A–Z)</string>
-    <string name="file_picker_sort_name_desc">Name (Z–A)</string>
-    <string name="file_picker_sort_size_desc">Size (largest first)</string>
-    <string name="file_picker_sort_size_asc">Size (smallest first)</string>
-    <string name="file_picker_sort_date_desc">Date (newest first)</string>
-    <string name="file_picker_sort_date_asc">Date (oldest first)</string>
-
-    <!-- Settings - System Tab - Files & Storage Section -->
     <string name="settings_system_files">Files &amp; storage</string>
     <string name="settings_system_apks_size">Total size: %s</string>
     <string name="settings_system_apk_item_info" translatable="false">v%s • %s</string>
@@ -736,6 +719,21 @@ The image dimensions must be as follows:
     <!-- Settings - System Tab - Custom file picker -->
     <string name="settings_system_custom_file_picker">Custom file picker</string>
     <string name="settings_system_custom_file_picker_description">Browse storage with Morphe\'s built-in file picker instead of the system default</string>
+
+    <!-- File Picker -->
+    <string name="file_picker_title">Select file</string>
+    <string name="file_picker_title_folder">Select folder</string>
+    <string name="file_picker_previous_directory">Previous directory</string>
+    <string name="file_picker_select">Select</string>
+    <string name="file_picker_no_files">No files here</string>
+    <string name="file_picker_internal_storage">Internal storage</string>
+    <string name="file_picker_sd_card">SD card</string>
+    <string name="file_picker_sort_name_asc">Name (A–Z)</string>
+    <string name="file_picker_sort_name_desc">Name (Z–A)</string>
+    <string name="file_picker_sort_size_desc">Size (largest first)</string>
+    <string name="file_picker_sort_size_asc">Size (smallest first)</string>
+    <string name="file_picker_sort_date_desc">Date (newest first)</string>
+    <string name="file_picker_sort_date_asc">Date (oldest first)</string>
 
     <!-- Settings - System Tab - About Section -->
     <string name="settings_system_about">About</string>


### PR DESCRIPTION
Built-in file browser replaces the system picker:
- Filters files by type (APK, images, JSON, MPP bundles, etc.)
- APK icon previews with placeholder while loading
- Custom app icon for `.mpp` patch bundle files
- Folder selection support
- Storage root switcher (internal storage / SD card)
- Sort by `name`, `size`, or `date` (ascending/descending), persisted across sessions
- Remembers last visited directory, defaults to `Downloads`
- Toggle in `Settings - Files & storage`
___
![Screenshot_2026-05-23-10-52-15-039_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/eba85e38-d9b7-4747-a7dc-29baa00a11e0)

