### PR TITLE
fix: prefer saved APK when source versions match

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -590,15 +590,14 @@ private fun ApkAvailabilityDialog(
                     layout = DialogButtonLayout.Vertical
                 )
 
-                // When the installed app uses split APKs and the saved original covers the
-                // same version, prefer the saved merged mono-APK.
-                // Hide the installed button in that case
-                val preferSavedOverInstalled = installedApkInfo?.isSplit == true &&
-                    savedApkInfo != null && savedApkInfo.version == installedApkInfo.version
+                // When the saved original covers the same version as the installed APK,
+                // prefer it for repatching and hide the duplicate installed option.
+                val preferSavedOverInstalled = savedApkInfo != null &&
+                    installedApkInfo != null &&
+                    savedApkInfo.version == installedApkInfo.version
 
-                // Saved APK button - hidden when a single-APK install covers the same version
-                if (savedApkInfo != null &&
-                    (preferSavedOverInstalled || installedApkInfo == null || savedApkInfo.version != installedApkInfo.version)) {
+                // Saved APK button
+                if (savedApkInfo != null) {
                     MorpheDialogOutlinedButton(
                         text = stringResource(
                             R.string.home_apk_use_saved_with_version,
@@ -610,7 +609,7 @@ private fun ApkAvailabilityDialog(
                     )
                 }
 
-                // Installed APK button - hidden when saved mono-APK covers the same split version
+                // Installed APK button - hidden when a saved APK covers the same version
                 if (installedApkInfo != null && !preferSavedOverInstalled) {
                     MorpheDialogOutlinedButton(
                         text = stringResource(


### PR DESCRIPTION
This PR fixes a small source selection issue where the saved original APK option could be hidden when an installed APK with the same version was also detected.

When a saved APK exists, the dialog now keeps the saved APK option available. If the installed APK has the same version, the installed option is hidden to avoid showing two equivalent source choices.

Different-version saved and installed APKs are still shown separately.

Closes #582.

Testing:
- Ran `git diff --check`
- Could not complete local Gradle verification because this environment has no Android SDK configured:
  `SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or sdk.dir in local.properties.`