### PR TITLE
fix: Improve source import and installer reliability

### DIFF
--- a/app/src/main/assets/root/module.prop
+++ b/app/src/main/assets/root/module.prop
@@ -1,6 +1,6 @@
-id=__PKG_NAME__-Morphe
-name=__LABEL__ Morphe
-version=__VERSION__
+id=__PKG_NAME_PROP__-Morphe
+name=__LABEL_PROP__ Morphe
+version=__VERSION_PROP__
 versionCode=0
 author=Morphe
 description=Mounts the patched APK on top of the original one

--- a/app/src/main/assets/root/service.sh
+++ b/app/src/main/assets/root/service.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
-package_name="__PKG_NAME__"
-version="__VERSION__"
+package_name=__PKG_NAME_SH__
+version=__VERSION_SH__
 
 # Resolve the module directory from the script's own path.
 # Falls back to the standard Magisk modules path if readlink is unavailable

--- a/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
@@ -169,21 +169,14 @@ sealed class RemotePatchBundle(
         }
     }
 
-    fun clearChangelogCache() {
+    suspend fun clearChangelogCache() {
         val assetKey = "$uid|$endpoint"
-        changelogCacheMutex.tryLock()
-        try {
+        changelogCacheMutex.withLock {
             changelogCache.remove(assetKey)
-        } finally {
-            changelogCacheMutex.unlock()
         }
 
-        entriesCacheMutex.tryLock()
-
-        try {
+        entriesCacheMutex.withLock {
             entriesCache.keys.removeAll { it.startsWith("$uid|") }
-        } finally {
-            entriesCacheMutex.unlock()
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/domain/installer/InstallerManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/InstallerManager.kt
@@ -199,6 +199,9 @@ class InstallerManager(
         runCatching {
             app.revokeUriPermission(plan.uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
         }
+        runCatching {
+            plan.sharedFile.takeIf { it.exists() }?.delete()
+        }
     }
 
     private fun readCustomInstallerTokens(): List<Token.Component> =

--- a/app/src/main/java/app/morphe/manager/domain/installer/RootInstaller.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/RootInstaller.kt
@@ -181,9 +181,11 @@ class RootInstaller(
                         val content = String(inputStream.readBytes())
                             .replace("\r\n", "\n")
                             .replace("\r", "\n")
-                            .replace("__PKG_NAME__", packageName)
-                            .replace("__VERSION__", version)
-                            .replace("__LABEL__", label)
+                            .replace("__PKG_NAME_SH__", shellLiteral(packageName))
+                            .replace("__VERSION_SH__", shellLiteral(version))
+                            .replace("__PKG_NAME_PROP__", modulePropValue(packageName))
+                            .replace("__VERSION_PROP__", modulePropValue(version))
+                            .replace("__LABEL_PROP__", modulePropValue(label))
                             .toByteArray()
 
                         outputStream.write(content)
@@ -240,6 +242,12 @@ class RootInstaller(
 
     companion object {
         const val MODULES_PATH = "/data/adb/modules"
+
+        private fun shellLiteral(value: String): String =
+            "'" + value.replace("'", "'\"'\"'") + "'"
+
+        private fun modulePropValue(value: String): String =
+            value.replace(Regex("[\\r\\n\\u0000]"), " ").trim()
 
         private fun Shell.Result.assertSuccess(errorMessage: String) {
             if (!isSuccess) throw Exception(errorMessage)

--- a/app/src/main/java/app/morphe/manager/domain/installer/SessionInstaller.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/SessionInstaller.kt
@@ -83,6 +83,14 @@ class SessionInstaller(private val app: Application) {
 
             val sessionId = installer.createSession(params)
             Log.d(TAG, "Created session $sessionId for ${apkFile.name}")
+            var registeredReceiver: BroadcastReceiver? = null
+
+            fun unregisterRegisteredReceiver() {
+                registeredReceiver?.let { receiver ->
+                    runCatching { app.unregisterReceiver(receiver) }
+                    registeredReceiver = null
+                }
+            }
 
             try {
                 installer.openSession(sessionId).use { session ->
@@ -114,7 +122,7 @@ class SessionInstaller(private val app: Application) {
 
                             when (status) {
                                 PackageInstaller.STATUS_SUCCESS -> {
-                                    app.unregisterReceiver(this)
+                                    unregisterRegisteredReceiver()
                                     cont.resume(InstallResult.Success)
                                 }
 
@@ -134,17 +142,17 @@ class SessionInstaller(private val app: Application) {
                                 }
 
                                 PackageInstaller.STATUS_FAILURE_ABORTED -> {
-                                    app.unregisterReceiver(this)
+                                    unregisterRegisteredReceiver()
                                     cont.resumeWithException(InstallCancelledException())
                                 }
 
                                 PackageInstaller.STATUS_FAILURE_CONFLICT -> {
-                                    app.unregisterReceiver(this)
+                                    unregisterRegisteredReceiver()
                                     cont.resume(InstallResult.Conflict(message))
                                 }
 
                                 else -> {
-                                    app.unregisterReceiver(this)
+                                    unregisterRegisteredReceiver()
                                     if (message?.contains("dead", ignoreCase = true) == true ||
                                         message?.contains("abandoned", ignoreCase = true) == true
                                     ) {
@@ -158,15 +166,17 @@ class SessionInstaller(private val app: Application) {
                     }
 
                     registerReceiverCompat(receiver, IntentFilter(ACTION_INSTALL_STATUS))
+                    registeredReceiver = receiver
 
                     cont.invokeOnCancellation {
-                        runCatching { app.unregisterReceiver(receiver) }
+                        unregisterRegisteredReceiver()
                         runCatching { installer.abandonSession(sessionId) }
                     }
 
                     session.commit(pi.intentSender)
                 }
             } catch (e: Exception) {
+                unregisterRegisteredReceiver()
                 runCatching { installer.abandonSession(sessionId) }
                 throw e
             }

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -206,7 +206,7 @@ class PreferencesManager(
         installerCustomComponents = installerCustomComponents.get(),
         installerHiddenComponents = installerHiddenComponents.get(),
         keystoreAlias = keystoreAlias.get(),
-        keystorePass = keystorePass.get(),
+        keystorePass = null,
         firstLaunch = firstLaunch.get(),
         useManagerPrereleases = useManagerPrereleases.get(),
         bundlePrereleasesEnabled = bundlePrereleasesEnabled.get(),

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
+import java.io.IOException
 import java.net.URI
 import java.net.URISyntaxException
 import java.nio.ByteBuffer
@@ -899,9 +900,9 @@ class PatchBundleRepository(
                         copyTotal = copyRead
                     }
 
-                    val manifestName = runCatching {
-                        PatchBundle(tempFile.absolutePath).manifestAttributes?.name
-                    }.getOrNull()?.takeUnless { it.isBlank() }
+                    val manifestAttributes = PatchBundle(tempFile.absolutePath).manifestAttributes
+                        ?: throw IOException("Invalid patch bundle manifest")
+                    val manifestName = manifestAttributes.name?.takeUnless { it.isBlank() }
 
                     // Block importing official Morphe source
 //                    if (manifestName?.equals(SOURCE_NAME, ignoreCase = true) == true) {
@@ -978,6 +979,9 @@ class PatchBundleRepository(
                             runCatching {
                                 localBundle.patchesJarFile.delete()
                             }
+                            runCatching {
+                                dao.remove(entity.uid)
+                            }
                         }
                     }
                 } finally {
@@ -1038,6 +1042,7 @@ class PatchBundleRepository(
     suspend fun createRemote(
         url: String,
         autoUpdate: Boolean,
+        displayName: String? = null,
         createdAt: Long? = null,
         updatedAt: Long? = null,
         onProgress: PatchBundleDownloadProgress? = null,
@@ -1082,6 +1087,7 @@ class PatchBundleRepository(
                 "",
                 SourceInfo.from(normalizedUrl),
                 autoUpdate,
+                displayName = displayName,
                 createdAt = createdAt,
                 updatedAt = updatedAt
             ).load() as RemotePatchBundle
@@ -1142,13 +1148,23 @@ class PatchBundleRepository(
 
     fun normalizeRemoteBundleUrl(input: String): String {
         val trimmed = input.trim()
+        val normalizedInput = if (trimmed.contains("://")) trimmed else "https://$trimmed"
         val parsed = try {
-            Url(trimmed)
+            Url(normalizedInput)
         } catch (e: Exception) {
+            throw IllegalArgumentException("Invalid bundle URL: ${e.message ?: trimmed}")
+        }
+        val uri = try {
+            URI(normalizedInput)
+        } catch (e: URISyntaxException) {
             throw IllegalArgumentException("Invalid bundle URL: ${e.message ?: trimmed}")
         }
 
         val host = parsed.host
+        val scheme = parsed.protocol.name.lowercase(Locale.US)
+        if (scheme != "http" && scheme != "https") {
+            throw IllegalArgumentException("Unsupported bundle URL scheme: $scheme")
+        }
         val pathSegments = parsed.encodedPath.trim('/').split('/').filter { it.isNotBlank() }
 
         // Handle GitHub repository URLs
@@ -1173,9 +1189,7 @@ class PatchBundleRepository(
             val branch = when {
                 // URL format: github.com/owner/repo/tree/branch/path...
                 pathSegments.size >= 4 && pathSegments[2] == "tree" -> {
-                    val branchSegments = pathSegments.drop(3)
-                    // Find where the branch name ends (could be multi-segment like "refs/heads/main")
-                    branchSegments.takeWhile { !it.endsWith(".json") }.joinToString("/")
+                    pathSegments[3]
                 }
                 // URL format: github.com/owner/repo/blob/branch/path...
                 pathSegments.size >= 4 && pathSegments[2] == "blob" -> {
@@ -1188,9 +1202,8 @@ class PatchBundleRepository(
             // Get the remaining path after branch (if any)
             val remainingPath = when {
                 pathSegments.size >= 4 && pathSegments[2] == "tree" -> {
-                    // For tree URLs, get everything after the branch
-                    val branchSegmentCount = branch.split("/").size
-                    pathSegments.drop(3 + branchSegmentCount).joinToString("/")
+                    // For tree URLs, get everything after the branch.
+                    pathSegments.drop(4).joinToString("/")
                 }
                 pathSegments.size >= 5 && pathSegments[2] == "blob" -> {
                     // For blob URLs, get everything after the branch
@@ -1255,7 +1268,21 @@ class PatchBundleRepository(
                 else -> "main"
             }
 
-            return "https://gitlab.com/$owner/$repo/-/raw/$branch/patches-bundle.json"
+            val remainingPath = when {
+                treeIndex >= 2 && pathSegments.getOrNull(treeIndex - 1) == "-" ->
+                    pathSegments.drop(treeIndex + 2).joinToString("/")
+                blobIndex >= 2 && pathSegments.getOrNull(blobIndex - 1) == "-" ->
+                    pathSegments.drop(blobIndex + 2).joinToString("/")
+                else -> ""
+            }
+            val finalPath = if (remainingPath.isNotEmpty()) {
+                if (remainingPath.endsWith(".json", ignoreCase = true)) remainingPath
+                else "$remainingPath/patches-bundle.json"
+            } else {
+                "patches-bundle.json"
+            }
+
+            return "https://gitlab.com/$owner/$repo/-/raw/$branch/$finalPath"
         }
 
         // Handle raw.githubusercontent.com URLs (legacy support)
@@ -1284,7 +1311,11 @@ class PatchBundleRepository(
         }
 
         val query = parsed.encodedQuery.takeIf { it.isNotEmpty() }?.let { "?$it" }.orEmpty()
-        return "https://$host$normalizedPath$query"
+        val authority = uri.rawAuthority?.substringAfterLast('@') ?: buildString {
+            append(host)
+            if (uri.port != -1) append(":${uri.port}")
+        }
+        return "$scheme://$authority$normalizedPath$query"
     }
 
     /** Returns true if [uid] corresponds to a currently loaded bundle. */
@@ -1911,6 +1942,7 @@ class PatchBundleRepository(
                 .filterIsInstance<RemotePatchBundle>()
                 .map { it.endpoint.lowercase(Locale.US) }
                 .toSet()
+                .toMutableSet()
 
             var addedAny = false
             snapshots.forEach { snapshot ->
@@ -1918,7 +1950,9 @@ class PatchBundleRepository(
                     normalizeRemoteBundleUrl(snapshot.source)
                 }.getOrNull() ?: return@forEach
 
-                if (normalizedUrl.lowercase(Locale.US) in existingEndpoints) return@forEach
+                val normalizedKey = normalizedUrl.lowercase(Locale.US)
+                if (normalizedKey in existingEndpoints) return@forEach
+                existingEndpoints += normalizedKey
 
                 createEntity(
                     name = snapshot.name,

--- a/app/src/main/java/app/morphe/manager/network/service/HttpService.kt
+++ b/app/src/main/java/app/morphe/manager/network/service/HttpService.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
@@ -147,10 +148,11 @@ class HttpService(
     suspend fun download(
         saveLocation: File,
         resumeFrom: Long = 0,
-        builder: HttpRequestBuilder.() -> Unit
-    ) {
+        builder: HttpRequestBuilder.() -> Unit,
+        onProgress: ((bytesRead: Long, contentLength: Long?, resumed: Boolean) -> Unit)? = null
+    ): Boolean {
         try {
-            runWith429Retry("download") {
+            return runWith429Retry("download") {
                 http.prepareGet {
                     if (resumeFrom > 0) header(HttpHeaders.Range, "bytes=$resumeFrom-")
                     builder()
@@ -162,6 +164,8 @@ class HttpService(
 
                         response.status.isSuccess() -> {
                             val channel: ByteReadChannel = response.body()
+                            val contentLength =
+                                response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
                             // Append only when the server confirmed partial content (HTTP 206)
                             val append =
                                 resumeFrom > 0 && response.status == HttpStatusCode.PartialContent
@@ -170,9 +174,17 @@ class HttpService(
                             }
                             withContext(Dispatchers.IO) {
                                 FileOutputStream(saveLocation, append).use { out ->
-                                    channel.copyToStream(out)
+                                    val base = if (append) resumeFrom else 0L
+                                    channel.copyToStream(out, contentLength) { bytesRead, length ->
+                                        onProgress?.invoke(
+                                            base + bytesRead,
+                                            length?.let { base + it },
+                                            append
+                                        )
+                                    }
                                 }
                             }
+                            append
                         }
 
                         else -> throw HttpException(response.status)
@@ -302,6 +314,10 @@ class HttpService(
                                         position += read
                                         totalRead.addAndGet(read.toLong())
                                         reportProgress()
+                                    }
+
+                                    if (position != end + 1) {
+                                        throw IOException("Range $start-$end ended at ${position - 1}")
                                     }
                                 }
 
@@ -494,17 +510,25 @@ class HttpService(
                 followRedirects = false
             }
 
-            noRedirectClient.request {
-                method = HttpMethod.Head
-                url(url)
-            }.headers[HttpHeaders.Location]?.let { location ->
-                if (location.startsWith("http://") || location.startsWith("https://")) {
-                    location
-                } else {
-                    val uri = java.net.URI(url)
-                    val prefix = "${uri.scheme}://${uri.host}"
-                    if (location.startsWith("/")) "$prefix$location" else "$prefix/$location"
+            try {
+                noRedirectClient.request {
+                    method = HttpMethod.Head
+                    url(url)
+                }.headers[HttpHeaders.Location]?.let { location ->
+                    if (location.startsWith("http://") || location.startsWith("https://")) {
+                        location
+                    } else {
+                        val uri = java.net.URI(url)
+                        val authority = uri.rawAuthority?.substringAfterLast('@') ?: buildString {
+                            append(uri.host)
+                            if (uri.port != -1) append(":${uri.port}")
+                        }
+                        val prefix = "${uri.scheme}://$authority"
+                        if (location.startsWith("/")) "$prefix$location" else "$prefix/$location"
+                    }
                 }
+            } finally {
+                noRedirectClient.close()
             }
         }.getOrNull()
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -248,8 +248,10 @@ fun BundleManagementSheet(
                                     if (bundle.uid == bundleToShowChangelogUid) {
                                         bundleToShowChangelogUid = null
                                     }
-                                    bundle.clearChangelogCache()
-                                    scope.launch { patchBundleRepository.setUsePrerelease(bundle.uid, usePrerelease) }
+                                    scope.launch {
+                                        bundle.clearChangelogCache()
+                                        patchBundleRepository.setUsePrerelease(bundle.uid, usePrerelease)
+                                    }
                                 }
                                 else -> null
                             },

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1028,9 +1028,9 @@ class HomeViewModel(
         }
     }
 
-    fun createRemoteSource(apiUrl: String, autoUpdate: Boolean) = viewModelScope.launch {
+    fun createRemoteSource(apiUrl: String, autoUpdate: Boolean, displayName: String? = null) = viewModelScope.launch {
         withContext(NonCancellable) {
-            patchBundleRepository.createRemote(apiUrl, autoUpdate)
+            patchBundleRepository.createRemote(apiUrl, autoUpdate, displayName = displayName)
         }
         patchBundleRepository.bundleUpdateProgress
             .dropWhile { it == null }
@@ -1052,7 +1052,7 @@ class HomeViewModel(
     fun confirmDeepLinkBundle() {
         val bundle = deepLinkPendingBundle ?: return
         deepLinkPendingBundle = null
-        createRemoteSource(bundle.url, autoUpdate = true)
+        createRemoteSource(bundle.url, autoUpdate = true, displayName = bundle.name)
     }
 
     /** User dismissed the deep link confirmation dialog. */
@@ -2144,6 +2144,12 @@ class HomeViewModel(
         patches: PatchSelection,
         options: Options
     ) {
+        if (patches.values.sumOf { it.size } == 0) {
+            app.toast(app.getString(R.string.home_no_patches_available))
+            cleanupPendingData()
+            return
+        }
+
         // Dismiss InstalledAppInfoDialog here, right before navigating to PatcherScreen.
         // This ensures there is never a gap between the info dialog closing and the next screen appearing
         dismissInstalledAppInfo()
@@ -2543,6 +2549,8 @@ class HomeViewModel(
         context: Context,
         uri: Uri
     ): ApkLoadResult = withContext(Dispatchers.IO) {
+        var tempFile: File? = null
+        var keepTempFile = false
         try {
             // Copy file to uiTempDir with original extension detection
             val fileName = context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
@@ -2551,27 +2559,28 @@ class HomeViewModel(
             } ?: "temp_${System.currentTimeMillis()}"
 
             val extension = fileName.substringAfterLast('.', "apk").lowercase()
-            val tempFile = filesystem.uiTempDir.resolve("temp_apk_${System.currentTimeMillis()}.$extension")
+            val copiedTempFile = filesystem.uiTempDir.resolve("temp_apk_${System.currentTimeMillis()}.$extension")
+            tempFile = copiedTempFile
 
             // openInputStream can return null when the provider is unavailable
             // e.g. Samsung External Storage restricted by Battery Optimization
             val bytesCopied = context.contentResolver.openInputStream(uri)?.use { input ->
-                tempFile.outputStream().use { output -> input.copyTo(output) }
+                copiedTempFile.outputStream().use { output -> input.copyTo(output) }
             }
             if (bytesCopied == null || bytesCopied == 0L) {
-                tempFile.delete()
+                copiedTempFile.delete()
                 return@withContext ApkLoadResult.Unreadable
             }
 
             // Check if it's a split APK archive
-            val isSplitArchive = SplitApkPreparer.isSplitArchive(tempFile)
+            val isSplitArchive = SplitApkPreparer.isSplitArchive(copiedTempFile)
 
             val packageInfo = if (isSplitArchive) {
                 // Extract the representative base APK and read package info from it.
                 // SplitApkInspector uses a smarter entry-selection algorithm than a naive
                 // name search: base.apk → main/master → largest non-config → fallback.
                 val extracted = SplitApkInspector.extractRepresentativeApk(
-                    source = tempFile,
+                    source = copiedTempFile,
                     workspace = filesystem.uiTempDir
                 )
                 try {
@@ -2581,24 +2590,28 @@ class HomeViewModel(
                 }
             } else {
                 // Regular APK - parse directly
-                pm.getPackageInfo(tempFile)
+                pm.getPackageInfo(copiedTempFile)
             }
 
             if (packageInfo == null) {
-                tempFile.delete()
+                copiedTempFile.delete()
                 return@withContext ApkLoadResult.NotAnApk
             }
 
+            keepTempFile = true
             ApkLoadResult.Success(
                 SelectedApp.Local(
                     packageName = packageInfo.packageName,
                     version = packageInfo.versionName ?: "unknown",
-                    file = tempFile,
+                    file = copiedTempFile,
                     temporary = true
                 )
             )
         } catch (e: Exception) {
             Log.e(tag, "Failed to load APK", e)
+            if (!keepTempFile) {
+                tempFile?.takeIf { it.exists() }?.delete()
+            }
             ApkLoadResult.IoError
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -314,7 +314,11 @@ class PatcherViewModel(
             } else {
                 0.0
             }
-        } + ((completedPatchCount / patchCount.toDouble()) * patchesPercentage)
+        } + if (patchCount > 0) {
+            (completedPatchCount / patchCount.toDouble()) * patchesPercentage
+        } else {
+            0.0
+        }
 
         min(1.0, currentProgress).toFloat()
     }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/UpdateViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/UpdateViewModel.kt
@@ -133,13 +133,16 @@ class UpdateViewModel(
                             }
                         )
                     } else {
-                        http.download(location, resumeOffset) {
-                            url(release.downloadUrl)
-                            onDownload { bytesSentTotal, contentLength ->
-                                downloadedSize = resumeOffset + bytesSentTotal
-                                totalSize = resumeOffset + (contentLength ?: totalSize)
+                        http.download(
+                            saveLocation = location,
+                            resumeFrom = resumeOffset,
+                            builder = { url(release.downloadUrl) },
+                            onProgress = { bytesRead, contentLength, resumed ->
+                                downloadedSize = bytesRead
+                                totalSize = contentLength ?: totalSize
+                                if (!resumed) canResumeDownload = false
                             }
-                        }
+                        )
                     }
                 }
                 canResumeDownload = false

--- a/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilePickerUtils.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.platform.LocalContext
 import app.morphe.manager.data.platform.Filesystem
 import org.koin.compose.koinInject
 import java.io.File
+import java.io.IOException
+import java.nio.charset.StandardCharsets
 
 /** Parsed metadata from a .mpp patch bundle's META-INF/MANIFEST.MF entry. */
 data class MppManifest(
@@ -103,7 +105,10 @@ fun Uri.readMppManifest(contentResolver: ContentResolver): MppManifest? =
                 var entry = zip.nextEntry
                 while (entry != null && manifest == null) {
                     if (entry.name == "META-INF/MANIFEST.MF") {
-                        val attrs = zip.bufferedReader().readText()
+                        if (entry.size > MAX_MPP_MANIFEST_BYTES) {
+                            throw IOException("Manifest is too large")
+                        }
+                        val attrs = zip.readLimitedText(MAX_MPP_MANIFEST_BYTES)
                             .lineSequence()
                             .filter { ":" in it }
                             .associate { line ->
@@ -127,6 +132,23 @@ fun Uri.readMppManifest(contentResolver: ContentResolver): MppManifest? =
             }
         }
     }.getOrNull()
+
+private const val MAX_MPP_MANIFEST_BYTES = 64 * 1024
+
+private fun java.io.InputStream.readLimitedText(maxBytes: Int): String {
+    val output = java.io.ByteArrayOutputStream()
+    val buffer = ByteArray(4096)
+    var total = 0
+    while (true) {
+        val remaining = maxBytes + 1 - total
+        val read = read(buffer, 0, minOf(buffer.size, remaining))
+        if (read == -1) break
+        output.write(buffer, 0, read)
+        total += read
+        if (total > maxBytes) throw IOException("Input exceeds $maxBytes bytes")
+    }
+    return output.toString(StandardCharsets.UTF_8.name())
+}
 
 /**
  * Plain SAF folder picker. Use this when writing files via [androidx.documentfile.provider.DocumentFile]/[ContentResolver].

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,6 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="root" path="app_signing/" />
+    <exclude domain="file" path="datastore/settings.preferences_pb" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,11 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="root" path="app_signing/" />
+        <exclude domain="file" path="datastore/settings.preferences_pb" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="root" path="app_signing/" />
+        <exclude domain="file" path="datastore/settings.preferences_pb" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## Changes

This PR tightens up a few related edge cases around adding patch sources, patching in mount mode, and cleaning up installer state.

- Source URLs now keep custom ports and nested GitHub/GitLab paths instead of being rewritten incorrectly.
- Failed local `.mpp` imports clean up after themselves, and settings import skips duplicate custom sources.
- Mount patching now stops early if filtering removes every selected patch.
- Manager update progress handles servers that ignore resume requests, and multipart bundle downloads fail if a range ends early.
- Temporary APK files, shared installer files, and PackageInstaller receivers are cleaned up in failure paths.
- Root mount metadata is written safely, signing files are excluded from backup, and settings exports no longer include the keystore password.

## Testing

- `git diff --check`
- `xmllint --noout app/src/main/res/xml/backup_rules.xml app/src/main/res/xml/data_extraction_rules.xml app/src/main/AndroidManifest.xml`
- `bash -n app/src/main/assets/root/service.sh`

I also set up local JDK 17 and tried `:app:compileDebugKotlin`, but this environment cannot access the Morphe GitHub Packages dependencies with the available token.
