### PR TITLE
fix: Escape root module metadata

### DIFF
--- a/app/src/main/assets/root/module.prop
+++ b/app/src/main/assets/root/module.prop
@@ -1,6 +1,6 @@
-id=__PKG_NAME__-Morphe
-name=__LABEL__ Morphe
-version=__VERSION__
+id=__PKG_NAME_PROP__-Morphe
+name=__LABEL_PROP__ Morphe
+version=__VERSION_PROP__
 versionCode=0
 author=Morphe
 description=Mounts the patched APK on top of the original one

--- a/app/src/main/assets/root/service.sh
+++ b/app/src/main/assets/root/service.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
-package_name="__PKG_NAME__"
-version="__VERSION__"
+package_name=__PKG_NAME_SH__
+version=__VERSION_SH__
 
 # Resolve the module directory from the script's own path.
 # Falls back to the standard Magisk modules path if readlink is unavailable

--- a/app/src/main/java/app/morphe/manager/domain/installer/RootInstaller.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/RootInstaller.kt
@@ -181,9 +181,11 @@ class RootInstaller(
                         val content = String(inputStream.readBytes())
                             .replace("\r\n", "\n")
                             .replace("\r", "\n")
-                            .replace("__PKG_NAME__", packageName)
-                            .replace("__VERSION__", version)
-                            .replace("__LABEL__", label)
+                            .replace("__PKG_NAME_SH__", shellLiteral(packageName))
+                            .replace("__VERSION_SH__", shellLiteral(version))
+                            .replace("__PKG_NAME_PROP__", modulePropValue(packageName))
+                            .replace("__VERSION_PROP__", modulePropValue(version))
+                            .replace("__LABEL_PROP__", modulePropValue(label))
                             .toByteArray()
 
                         outputStream.write(content)
@@ -240,6 +242,12 @@ class RootInstaller(
 
     companion object {
         const val MODULES_PATH = "/data/adb/modules"
+
+        private fun shellLiteral(value: String): String =
+            "'" + value.replace("'", "'\"'\"'") + "'"
+
+        private fun modulePropValue(value: String): String =
+            value.replace(Regex("[\\r\\n\\u0000]"), " ").trim()
 
         private fun Shell.Result.assertSuccess(errorMessage: String) {
             if (!isSuccess) throw Exception(errorMessage)


### PR DESCRIPTION
## Summary

Mount install writes APK metadata into the Magisk module files. The shell script template was using raw string replacement, so values like the APK version name could break out of the assignment in `service.sh`.

This escapes values based on where they are written: shell literals for `service.sh`, and newline/NUL-stripped values for `module.prop`.

## Changes

- Use shell-safe placeholders for `service.sh`.
- Sanitize `module.prop` values separately.
- Keep the change scoped to root module file generation.

## Testing

- `git diff --check`
- `bash -n app/src/main/assets/root/service.sh`
- Checked that a quoted version string with shell metacharacters stays inert after escaping.