### PR TITLE
fix: Cancelled install callbacks on some OEM systems

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
@@ -17,6 +17,7 @@ import app.morphe.manager.domain.installer.*
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.AppDataResolver
 import app.morphe.manager.util.PM
+import app.morphe.manager.util.sha256OrNull
 import app.morphe.manager.util.simpleMessage
 import app.morphe.manager.util.toast
 import kotlinx.coroutines.*
@@ -374,9 +375,14 @@ class InstallViewModel : ViewModel(), KoinComponent {
         val result = try {
             sessionInstaller.installInternal(outputFile)
         } catch (_: InstallCancelledException) {
-            // User dismissed the dialog - go back to Ready immediately, no error shown
-            installState = InstallState.Ready
-            return
+            if (confirmInstallCompleted(outputFile, targetPackageName)) {
+                Log.w(TAG, "Install callback reported cancelled but APK SHA-256 verification succeeded for $targetPackageName")
+                InstallResult.Success
+            } else {
+                // User dismissed the dialog and the installed APK does not match the patched APK.
+                installState = InstallState.Ready
+                return
+            }
         } catch (_: SessionDeadException) {
             Log.w(TAG, "Session dead, falling back to intent-based install")
             launchIntentBasedFallback(outputFile, targetPackageName, onPersistApp)
@@ -396,6 +402,18 @@ class InstallViewModel : ViewModel(), KoinComponent {
                 app.getString(R.string.install_app_fail, result.message ?: "Unknown error")
             )
         }
+    }
+
+    private suspend fun confirmInstallCompleted(
+        outputFile: File,
+        targetPackageName: String
+    ): Boolean = withContext(Dispatchers.IO) {
+        val installedFile = pm.getPackageInfo(targetPackageName)?.applicationInfo?.sourceDir
+            ?.takeIf { it.isNotEmpty() }
+            ?.let(::File) ?: return@withContext false
+        val installedHash = installedFile.sha256OrNull() ?: return@withContext false
+        val expectedHash = outputFile.sha256OrNull() ?: return@withContext false
+        installedHash == expectedHash
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
@@ -408,7 +408,7 @@ class InstallViewModel : ViewModel(), KoinComponent {
         outputFile: File,
         targetPackageName: String
     ): Boolean = withContext(Dispatchers.IO) {
-        val installedFile = pm.getPackageInfo(targetPackageName)?.applicationInfo?.sourceDir
+        val installedFile = pm.getApplicationInfo(targetPackageName)?.sourceDir
             ?.takeIf { it.isNotEmpty() }
             ?.let(::File) ?: return@withContext false
         val installedHash = installedFile.sha256OrNull() ?: return@withContext false

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -212,6 +212,21 @@ class PM(
     }
 }
 
+fun File.sha256OrNull(): String? = runCatching {
+    if (!isFile) return@runCatching null
+    val digest = MessageDigest.getInstance("SHA-256")
+    inputStream().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (!Thread.currentThread().isInterrupted) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    if (Thread.currentThread().isInterrupted) return@runCatching null
+    digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+}.getOrNull()
+
 /** Opens the system screen that lets the user grant the "install unknown apps" permission. */
 object RequestInstallAppsContract : ActivityResultContract<String, Boolean>(), KoinComponent {
     private val pm: PM by inject()

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -4,8 +4,10 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.ApplicationInfoFlags
 import android.content.pm.PackageManager.NameNotFoundException
 import android.content.pm.PackageManager.PackageInfoFlags
 import android.content.pm.Signature
@@ -41,12 +43,24 @@ class PM(
 
     val application: Application get() = app
 
+    @Suppress("DEPRECATION")
     fun getPackageInfo(packageName: String, flags: Int = 0): PackageInfo? =
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 app.packageManager.getPackageInfo(packageName, PackageInfoFlags.of(flags.toLong()))
             else
                 app.packageManager.getPackageInfo(packageName, flags)
+        } catch (_: NameNotFoundException) {
+            null
+        }
+
+    @Suppress("DEPRECATION")
+    fun getApplicationInfo(packageName: String, flags: Int = 0): ApplicationInfo? =
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                app.packageManager.getApplicationInfo(packageName, ApplicationInfoFlags.of(flags.toLong()))
+            else
+                app.packageManager.getApplicationInfo(packageName, flags)
         } catch (_: NameNotFoundException) {
             null
         }

--- a/app/src/main/java/app/morphe/manager/util/Util.kt
+++ b/app/src/main/java/app/morphe/manager/util/Util.kt
@@ -26,8 +26,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import java.io.File
-import java.security.MessageDigest
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -171,17 +169,3 @@ fun <T : Any> SavedStateHandle.saveableVar(init: () -> T): PropertyDelegateProvi
                 set(name, value)
         }
     }
-
-fun File.sha256OrNull(): String? = runCatching {
-    if (!isFile) return@runCatching null
-    val digest = MessageDigest.getInstance("SHA-256")
-    inputStream().use { input ->
-        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        while (true) {
-            val read = input.read(buffer)
-            if (read < 0) break
-            digest.update(buffer, 0, read)
-        }
-    }
-    digest.digest().joinToString("") { byte -> "%02x".format(byte) }
-}.getOrNull()

--- a/app/src/main/java/app/morphe/manager/util/Util.kt
+++ b/app/src/main/java/app/morphe/manager/util/Util.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import java.io.File
+import java.security.MessageDigest
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -169,3 +171,17 @@ fun <T : Any> SavedStateHandle.saveableVar(init: () -> T): PropertyDelegateProvi
                 set(name, value)
         }
     }
+
+fun File.sha256OrNull(): String? = runCatching {
+    if (!isFile) return@runCatching null
+    val digest = MessageDigest.getInstance("SHA-256")
+    inputStream().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    digest.digest().joinToString("") { byte -> "%02x".format(byte) }
+}.getOrNull()


### PR DESCRIPTION
On some OEM Android builds, such as ColorOS, PackageInstaller may report a cancelled result even after the installation has completed successfully.

This PR handles that compatibility case by checking the SHA-256 hash of the installed APK source after a cancelled callback. If the installed package body matches the APK that was just submitted for installation, the flow treats the install as successful; otherwise it preserves the existing cancel behavior.

Verification:
- ./gradlew :app:assembleDebug