### PR TITLE
fix: Use existing credential helpers for gpr in settings.gradle.kts

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,13 +41,8 @@ dependencyResolutionManagement {
             // A repository must be specified for some reason. "registry" is a dummy.
             url = uri("https://maven.pkg.github.com/MorpheApp/registry")
             credentials {
-                val hardcodedUser = ""
-                val hardcodedToken = ""
-                val gprUser: String? = providers.gradleProperty("gpr.user").orNull
-                val gprKey: String? = providers.gradleProperty("gpr.key").orNull
-
-                username = (hardcodedUser.ifBlank { System.getenv("GITHUB_ACTOR") ?: gprUser })
-                password = (hardcodedToken.ifBlank { System.getenv("GITHUB_TOKEN") ?: gprKey })
+                username = githubUser()
+                password = githubToken()
             }
         }
     }


### PR DESCRIPTION
Fixes #612

Maven credentials block for maven.pkg.github.com was bypassing local.properties, only checking gradle properties and environment variables. Helper fucntions githubUser() and githubToken() are defined at the top of the file already handle all three credential sources in the correct priority order: local.properties -> gradle property -> environment variable

Replaced the inline credential resolution with calls to the helpers functions, and removed the unused hardcodedUser/hardcodedToken variables.