### PR TITLE
feat: Check `versionCode` when resolving patch compatibility

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -82,12 +82,9 @@ class PatchBundleRepository(
             .map { BundleAppMetadata.buildFrom(it) }
             .stateIn(scope, SharingStarted.Eagerly, emptyMap())
 
-    fun scopedBundleInfoFlow(packageName: String, version: String?) = enabledBundlesInfoFlow.map {
+    fun scopedBundleInfoFlow(packageName: String, version: String?, versionCode: Long? = null) = enabledBundlesInfoFlow.map {
         it.map { (_, bundleInfo) ->
-            bundleInfo.forPackage(
-                packageName,
-                version
-            )
+            bundleInfo.forPackage(packageName, version, versionCode)
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -43,6 +43,7 @@ import java.nio.ByteOrder
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
 import app.morphe.manager.data.room.bundles.Source as SourceInfo
 
 class PatchBundleRepository(
@@ -137,7 +138,7 @@ class PatchBundleRepository(
         if (!isDone) return
 
         bundleImportAutoClearJob = scope.launch {
-            delay(8_000)
+            delay(8.seconds)
             val current = bundleImportProgressFlow.value ?: return@launch
             val currentDownloadComplete = current.bytesTotal?.takeIf { it > 0L }?.let { total ->
                 current.bytesRead >= total
@@ -1532,7 +1533,7 @@ class PatchBundleRepository(
                 bundleUpdateProgressFlow.value = noInternetProgress
 
                 scope.launch {
-                    delay(3500)
+                    delay(3.5.seconds)
                     if (bundleUpdateProgressFlow.value == noInternetProgress) {
                         bundleUpdateProgressFlow.value = null
                     }
@@ -1551,7 +1552,7 @@ class PatchBundleRepository(
                 )
                 bundleUpdateProgressFlow.value = skippedProgress
                 scope.launch {
-                    delay(3500)
+                    delay(3.5.seconds)
                     if (bundleUpdateProgressFlow.value == skippedProgress) {
                         bundleUpdateProgressFlow.value = null
                     }
@@ -1673,7 +1674,7 @@ class PatchBundleRepository(
                 bundleUpdateProgressFlow.value = errorProgress
 
                 scope.launch {
-                    delay(3500)
+                    delay(3.5.seconds)
                     if (bundleUpdateProgressFlow.value == errorProgress) {
                         bundleUpdateProgressFlow.value = null
                     }
@@ -1696,7 +1697,7 @@ class PatchBundleRepository(
                 bundleUpdateProgressFlow.value = noUpdatesProgress
 
                 scope.launch {
-                    delay(3500)
+                    delay(3.5.seconds)
                     if (bundleUpdateProgressFlow.value == noUpdatesProgress) {
                         bundleUpdateProgressFlow.value = null
                     }
@@ -1740,7 +1741,7 @@ class PatchBundleRepository(
             bundleUpdateProgressFlow.value = successProgress
 
             scope.launch {
-                delay(3500)
+                delay(3.5.seconds)
                 if (bundleUpdateProgressFlow.value == successProgress) {
                     bundleUpdateProgressFlow.value = null
                 }

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchBundleInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchBundleInfo.kt
@@ -148,28 +148,5 @@ sealed class PatchBundleInfo {
 
             bundle.uid to patches
         }
-
-        /**
-         * Algorithm for determining whether all required options have been set.
-         */
-        inline fun Iterable<Scoped>.requiredOptionsSet(
-            allowIncompatible: Boolean,
-            crossinline isSelected: (Scoped, PatchInfo) -> Boolean,
-            crossinline optionsForPatch: (Scoped, PatchInfo) -> Map<String, Any?>?
-        ) = all bundle@{ bundle ->
-            bundle
-                .patchSequence(allowIncompatible)
-                .filter { isSelected(bundle, it) }
-                .all patch@{
-                    if (it.options.isNullOrEmpty()) return@patch true
-                    val opts by lazy { optionsForPatch(bundle, it).orEmpty() }
-
-                    it.options.all option@{ option ->
-                        if (!option.required || option.default != null) return@option true
-
-                        option.key in opts
-                    }
-                }
-        }
     }
 }

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchBundleInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchBundleInfo.kt
@@ -39,7 +39,7 @@ sealed class PatchBundleInfo {
         /**
          * Create a [PatchBundleInfo.Scoped] that only contains information about patches that are relevant for a specific [packageName].
          */
-        fun forPackage(packageName: String, version: String?): Scoped {
+        fun forPackage(packageName: String, version: String?, versionCode: Long? = null): Scoped {
             val relevantPatches = patches.filter { it.compatibleWith(packageName) }
             val compatible = mutableListOf<PatchInfo>()
             val incompatible = mutableListOf<PatchInfo>()
@@ -56,7 +56,7 @@ sealed class PatchBundleInfo {
                 // Categorise into compatible / incompatible / universal
                 val targetList = when {
                     patch.compatiblePackages == null -> universal
-                    patch.supports(packageName, version) -> compatible
+                    patch.supports(packageName, version, versionCode) -> compatible
                     else -> incompatible
                 }
                 targetList.add(patch)

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -1,6 +1,7 @@
 package app.morphe.manager.patcher.patch
 
 import androidx.compose.runtime.Immutable
+import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Patch
 import app.morphe.patcher.patch.ApkFileType
 import kotlinx.collections.immutable.ImmutableList
@@ -62,8 +63,7 @@ data class PatchInfo(
                     versionCodes = compatibility.targets
                         .mapNotNull { target ->
                             val v = target.version ?: return@mapNotNull null
-                            val codes = target.versionCodes?.values?.toImmutableSet()?.takeIf { it.isNotEmpty() }
-                                ?: return@mapNotNull null
+                            val codes = target.buildCodesOrNull()?.toImmutableSet() ?: return@mapNotNull null
                             v to codes
                         }
                         .toMap()
@@ -96,7 +96,7 @@ data class PatchInfo(
             if (pkg.versions == null) return@any true
             if (versionName == null || versionName !in pkg.versions) return@any false
             val allowedCodes = pkg.versionCodes?.get(versionName) ?: return@any true
-            versionCode == null || allowedCodes.any { it.toLong() == versionCode }
+            versionCode == null || versionCode.toInt() in allowedCodes
         }
     }
 
@@ -156,6 +156,9 @@ data class CompatiblePackage(
     /** Per-version allowed version codes (union of all declared ABI codes). Null means no constraint. */
     val versionCodes: ImmutableMap<String, ImmutableSet<Int>>? = null,
 )
+
+/** Returns the union of all ABI-specific version codes, or null if none are declared. */
+fun AppTarget.buildCodesOrNull(): Set<Int>? = versionCodes?.values?.toSet()?.ifEmpty { null }
 
 @Immutable
 data class Option<T>(

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -59,6 +59,16 @@ data class PatchInfo(
                         .toMap()
                         .toImmutableMap()
                         .takeIf { it.isNotEmpty() },
+                    versionCodes = compatibility.targets
+                        .mapNotNull { target ->
+                            val v = target.version ?: return@mapNotNull null
+                            val codes = target.versionCodes?.values?.toImmutableSet()?.takeIf { it.isNotEmpty() }
+                                ?: return@mapNotNull null
+                            v to codes
+                        }
+                        .toMap()
+                        .toImmutableMap()
+                        .takeIf { it.isNotEmpty() },
                 )
             }
             ?.toImmutableList()
@@ -76,7 +86,7 @@ data class PatchInfo(
         compatiblePackages == null ||
                 compatiblePackages.any { it.packageName == null || it.packageName == packageName }
 
-    fun supports(packageName: String, versionName: String?): Boolean {
+    fun supports(packageName: String, versionName: String?, versionCode: Long? = null): Boolean {
         val packages = compatiblePackages ?: return true // Universal patch
 
         return packages.any { pkg ->
@@ -84,8 +94,9 @@ data class PatchInfo(
             if (pkg.packageName == null) return@any true
             if (pkg.packageName != packageName) return@any false
             if (pkg.versions == null) return@any true
-
-            versionName != null && versionName in pkg.versions
+            if (versionName == null || versionName !in pkg.versions) return@any false
+            val allowedCodes = pkg.versionCodes?.get(versionName) ?: return@any true
+            versionCode == null || allowedCodes.any { it.toLong() == versionCode }
         }
     }
 
@@ -142,6 +153,8 @@ data class CompatiblePackage(
     val versionDescriptions: ImmutableMap<String, String>? = null,
     /** Minimum Android SDK version required per app version. */
     val versionMinSdks: ImmutableMap<String, Int>? = null,
+    /** Per-version allowed version codes (union of all declared ABI codes). Null means no constraint. */
+    val versionCodes: ImmutableMap<String, ImmutableSet<Int>>? = null,
 )
 
 @Immutable

--- a/app/src/main/java/app/morphe/manager/ui/model/SelectedApp.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/SelectedApp.kt
@@ -7,11 +7,13 @@ import java.io.File
 sealed interface SelectedApp : Parcelable {
     val packageName: String
     val version: String?
+    val versionCode: Long?
 
     @Parcelize
     data class Local(
         override val packageName: String,
         override val version: String,
+        override val versionCode: Long? = null,
         val file: File,
         val temporary: Boolean,
         val resolved: Boolean = true,
@@ -21,6 +23,7 @@ sealed interface SelectedApp : Parcelable {
     @Parcelize
     data class Installed(
         override val packageName: String,
-        override val version: String
+        override val version: String,
+        override val versionCode: Long? = null
     ) : SelectedApp
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Home Screen with 5-section layout.
@@ -230,7 +231,7 @@ fun HomeScreen(
                     homeViewModel.markSwipeGestureHintShown()
                     if (onboardingState != null && onboardingState.swipeActive) {
                         scope.launch {
-                            delay(600)
+                            delay(600.milliseconds)
                             if (onboardingState.swipeActive) homeViewModel.triggerSwipeGestureHint()
                         }
                     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -51,6 +51,7 @@ import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.*
 import app.morphe.manager.util.*
 import app.morphe.patcher.patch.AppTarget
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -115,7 +116,7 @@ fun HomeDialogs(
             onNeedApk = {
                 homeViewModel.showApkAvailabilityDialog = false
                 scope.launch {
-                    delay(50)
+                    delay(50.milliseconds)
                     homeViewModel.showDownloadInstructionsDialog = true
                     homeViewModel.resolveDownloadRedirect()
                 }
@@ -229,15 +230,11 @@ fun HomeDialogs(
 
         UnsupportedVersionWarningDialog(
             version = dialogState.version,
+            versionCode = dialogState.versionCode,
             recommendedVersion = dialogState.recommendedVersion?.version,
-            allCompatibleVersions = dialogState.allCompatibleVersions.map { it.version ?: "" }.filter { it.isNotEmpty() },
-            versionDescriptions = dialogState.allCompatibleVersions
-                .mapNotNull { target ->
-                    val v = target.version ?: return@mapNotNull null
-                    val d = target.description ?: return@mapNotNull null
-                    v to d
-                }
-                .toMap(),
+            allCompatibleVersions = dialogState.compatibleVersionNames,
+            versionDescriptions = dialogState.compatibleVersionDescriptions,
+            compatibleVersionCodes = dialogState.compatibleVersionCodes,
             experimentalVersions = homeViewModel.getExperimentalVersionsForPackage(dialogState.packageName),
             isExperimental = dialogState.isExperimental,
             isExpertMode = isExpertMode,
@@ -691,6 +688,13 @@ private fun ApkAvailabilityDialog(
                             .mapNotNull { b -> b.target.version?.let { v -> b.target.description?.let { d -> v to d } } }
                             .toMap(),
                         incompatibleSdkVersions = incompatibleSdkVersions,
+                        versionCodes = compatibleVersions
+                            .mapNotNull { b ->
+                                val v = b.target.version ?: return@mapNotNull null
+                                val codes = b.buildCodes ?: return@mapNotNull null
+                                v to codes
+                            }
+                            .toMap(),
                     )
                 }
             } else {
@@ -707,7 +711,11 @@ private fun ApkAvailabilityDialog(
 
                 VersionListCard(
                     versions = listOf(recommendedVersion?.version ?: anyString),
-                    showUnpatchedBadge = true
+                    showUnpatchedBadge = true,
+                    versionCodes = compatibleVersions
+                        .firstOrNull { it.target.version == recommendedVersion?.version }
+                        ?.let { b -> b.target.version?.let { v -> b.buildCodes?.let { mapOf(v to it) } } }
+                        ?: emptyMap()
                 )
             }
 
@@ -1178,15 +1186,18 @@ private fun InstalledAppPickerDialog(
 @Composable
 private fun UnsupportedVersionWarningDialog(
     version: String,
+    versionCode: Long? = null,
     recommendedVersion: String?,
     allCompatibleVersions: List<String>,
     versionDescriptions: Map<String, String> = emptyMap(),
+    compatibleVersionCodes: Map<String, Set<Int>> = emptyMap(),
     experimentalVersions: Set<String> = emptySet(),
     isExperimental: Boolean = false,
     isExpertMode: Boolean,
     onDismiss: () -> Unit,
     onProceed: () -> Unit
 ) {
+    val versionCodeMismatch = !isExperimental && versionCode != null && version == recommendedVersion
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.home_dialog_unsupported_version_dialog_title),
@@ -1210,10 +1221,11 @@ private fun UnsupportedVersionWarningDialog(
         ) {
             Text(
                 text = stringResource(
-                    if (isExperimental)
-                        R.string.home_dialog_unsupported_version_experimental_description
-                    else
-                        R.string.home_dialog_unsupported_version_dialog_description
+                    when {
+                        isExperimental -> R.string.home_dialog_unsupported_version_experimental_description
+                        versionCodeMismatch -> R.string.home_dialog_unsupported_version_build_mismatch_description
+                        else -> R.string.home_dialog_unsupported_version_dialog_description
+                    }
                 ),
                 style = MaterialTheme.typography.bodyLarge,
                 color = secondaryColor,
@@ -1248,16 +1260,26 @@ private fun UnsupportedVersionWarningDialog(
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                text = version,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontFamily = FontFamily.Monospace,
-                                fontWeight = FontWeight.Bold,
-                                color = if (isExperimental)
-                                    MaterialTheme.colorScheme.tertiary
-                                else
-                                    MaterialTheme.colorScheme.error
-                            )
+                            Column {
+                                Text(
+                                    text = version,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    fontFamily = FontFamily.Monospace,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (isExperimental)
+                                        MaterialTheme.colorScheme.tertiary
+                                    else
+                                        MaterialTheme.colorScheme.error
+                                )
+                                if (versionCode != null) {
+                                    Text(
+                                        text = stringResource(R.string.home_dialog_unsupported_version_build, versionCode),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        fontFamily = FontFamily.Monospace,
+                                        color = secondaryColor
+                                    )
+                                }
+                            }
 
                             if (isExperimental) {
                                 InfoBadge(
@@ -1293,7 +1315,8 @@ private fun UnsupportedVersionWarningDialog(
                                 .takeIf { it >= 0 } ?: 0,
                             isCompatible = true,
                             experimentalVersions = experimentalVersions,
-                            descriptions = versionDescriptions
+                            descriptions = versionDescriptions,
+                            versionCodes = compatibleVersionCodes
                         )
                     }
                 } else if (recommendedVersion != null) {
@@ -1309,7 +1332,8 @@ private fun UnsupportedVersionWarningDialog(
                             versions = listOf(recommendedVersion),
                             recommendedIndex = 0,
                             isCompatible = true,
-                            experimentalVersions = experimentalVersions
+                            experimentalVersions = experimentalVersions,
+                            versionCodes = compatibleVersionCodes
                         )
                     }
                 }
@@ -1813,6 +1837,7 @@ private fun VersionListCard(
     experimentalVersions: Set<String> = emptySet(),
     descriptions: Map<String, String> = emptyMap(),
     incompatibleSdkVersions: Set<String> = emptySet(),
+    versionCodes: Map<String, Set<Int>> = emptyMap()
 ) {
     if (versions.isEmpty()) return
 
@@ -1844,6 +1869,7 @@ private fun VersionListCard(
                 val isExperimentalVersion = version in experimentalVersions
                 val isIncompatibleSdk = version in incompatibleSdkVersions
                 val versionDescription = descriptions[version]
+                val buildCode = versionCodes[version]?.firstOrNull()
 
                 // Resolve badge once - drives both the badge composable and version text color
                 val badge: @Composable (() -> Unit)? = when {
@@ -1903,6 +1929,16 @@ private fun VersionListCard(
                             overflow = TextOverflow.Ellipsis
                         )
                         badge?.invoke()
+                    }
+
+                    // Build number
+                    if (buildCode != null) {
+                        Text(
+                            text = stringResource(R.string.home_dialog_unsupported_version_build, buildCode),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
                     }
 
                     // Optional per-version description

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -1161,7 +1161,11 @@ private fun InstalledAppPickerDialog(
                                     overflow = TextOverflow.Ellipsis
                                 )
                                 Text(
-                                    text = "v${item.info.version}",
+                                    text = if (item.info.versionCode != null) {
+                                        "v${item.info.version} (${item.info.versionCode})"
+                                    } else {
+                                        "v${item.info.version}"
+                                    },
                                     style = MaterialTheme.typography.bodySmall,
                                     color = secondaryColor.copy(alpha = 0.6f),
                                     maxLines = 1,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -623,10 +623,8 @@ private fun ApkAvailabilityDialog(
                 // Saved APK button - always shown when a saved APK exists
                 if (savedApkInfo != null) {
                     MorpheDialogOutlinedButton(
-                        text = stringResource(
-                            R.string.home_apk_use_saved_with_version,
-                            savedApkInfo.version
-                        ),
+                        text = stringResource(R.string.home_apk_use_saved),
+                        textSuffix = buildVersionSuffix(savedApkInfo.version, savedApkInfo.versionCode),
                         onClick = onUseSaved,
                         icon = Icons.Outlined.History,
                         modifier = Modifier.fillMaxWidth()
@@ -636,10 +634,8 @@ private fun ApkAvailabilityDialog(
                 // Installed APK button - hidden when saved mono-APK covers the same split version
                 if (installedApkInfo != null && !preferSavedOverInstalled) {
                     MorpheDialogOutlinedButton(
-                        text = stringResource(
-                            R.string.home_apk_use_installed_with_version,
-                            installedApkInfo.version
-                        ),
+                        text = stringResource(R.string.home_apk_use_installed),
+                        textSuffix = buildVersionSuffix(installedApkInfo.version, installedApkInfo.versionCode),
                         onClick = onUseInstalled,
                         icon = Icons.Outlined.PhoneAndroid,
                         modifier = Modifier.fillMaxWidth()
@@ -2485,3 +2481,6 @@ fun SimpleBundleSelectDialog(
         }
     }
 }
+
+private fun buildVersionSuffix(version: String, versionCode: Long?): String =
+    if (versionCode != null) "v$version ($versionCode)" else "v$version"

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint
 import android.os.Build
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -1795,9 +1796,10 @@ private fun SelectableVersionListCard(
                                     target.isExperimental -> MaterialTheme.colorScheme.tertiary
                                     else -> LocalDialogTextColor.current
                                 },
-                                modifier = Modifier.weight(1f),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .basicMarquee(iterations = Int.MAX_VALUE),
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
                             )
                             badge?.invoke()
                         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -70,6 +70,7 @@ import app.morphe.manager.util.KnownApps
 import app.morphe.manager.util.toast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Data describing one side of a swipe action - icon, label, and colors. */
 private data class SwipeActionConfig(
@@ -810,7 +811,7 @@ fun MainAppsSection(
         } else {
             // Small delay so Compose has one frame to lay out the real cards before the
             // shimmer fades out - prevents a single-frame empty gap.
-            if (stableLoadingState.value) delay(50)
+            if (stableLoadingState.value) delay(50.milliseconds)
             stableLoadingState.value = false
         }
     }
@@ -1353,11 +1354,11 @@ private fun DynamicAppCard(
             offsetX.snapTo(0f)
             return@LaunchedEffect
         }
-        delay(800)
+        delay(800.milliseconds)
         val nudge = with(density) { 72.dp.toPx() }
         offsetX.animateTo(nudge,  tween(500, easing = FastOutSlowInEasing))
         offsetX.animateTo(0f,     tween(400, easing = FastOutSlowInEasing))
-        delay(250)
+        delay(250.milliseconds)
         offsetX.animateTo(-nudge, tween(500, easing = FastOutSlowInEasing))
         offsetX.animateTo(0f,     tween(400, easing = FastOutSlowInEasing))
         onGestureHintShown()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialogButton.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialogButton.kt
@@ -6,6 +6,7 @@
 package app.morphe.manager.ui.screen.shared
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
@@ -113,7 +114,8 @@ fun MorpheDialogOutlinedButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     icon: ImageVector? = null,
-    isDestructive: Boolean = false
+    isDestructive: Boolean = false,
+    textSuffix: String? = null
 ) {
     val colors = resolveButtonColors(isDestructive, filled = false)
 
@@ -143,8 +145,21 @@ fun MorpheDialogOutlinedButton(
             text = text,
             style = MaterialTheme.typography.labelLarge,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            softWrap = false,
+            overflow = if (textSuffix == null) TextOverflow.Ellipsis else TextOverflow.Clip
         )
+        if (textSuffix != null) {
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = textSuffix,
+                style = MaterialTheme.typography.labelLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .basicMarquee()
+            )
+        }
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -80,8 +80,11 @@ enum class BundleUpdateStatus {
 data class UnsupportedVersionDialogState(
     val packageName: String,
     val version: String,
+    val versionCode: Long? = null,
     val recommendedVersion: AppTarget?,
-    val allCompatibleVersions: List<AppTarget> = emptyList(),
+    val compatibleVersionNames: List<String> = emptyList(),
+    val compatibleVersionDescriptions: Map<String, String> = emptyMap(),
+    val compatibleVersionCodes: Map<String, Set<Int>> = emptyMap(),
     /** True if the selected version is marked as experimental in the patch bundle. */
     val isExperimental: Boolean = false
 )
@@ -93,7 +96,9 @@ data class UnsupportedVersionDialogState(
 data class BundledAppTarget(
     val target: AppTarget,
     val bundleUid: Int,
-    val bundleName: String
+    val bundleName: String,
+    /** Allowed build codes for this version, sourced from the patch bundle. Null means no constraint. */
+    val buildCodes: Set<Int>? = null
 )
 
 /** Dialog state for wrong package warning. */
@@ -1977,13 +1982,24 @@ class HomeViewModel(
 
         if (versionMismatch && !allowIncompatible) {
             val recommendedVersion = recommendedVersions[selectedApp.packageName]
-            val allVersions = compatibleVersions[selectedApp.packageName]?.map { it.target } ?: emptyList()
+            val allBundled = compatibleVersions[selectedApp.packageName] ?: emptyList()
             pendingSelectedApp = selectedApp
             showUnsupportedVersionDialog = UnsupportedVersionDialogState(
                 packageName = selectedApp.packageName,
                 version = selectedApp.version ?: "unknown",
+                versionCode = selectedApp.versionCode,
                 recommendedVersion = recommendedVersion,
-                allCompatibleVersions = allVersions,
+                compatibleVersionNames = allBundled.mapNotNull { it.target.version },
+                compatibleVersionDescriptions = allBundled.mapNotNull { b ->
+                    val v = b.target.version ?: return@mapNotNull null
+                    val d = b.target.description ?: return@mapNotNull null
+                    v to d
+                }.toMap(),
+                compatibleVersionCodes = allBundled.mapNotNull { b ->
+                    val v = b.target.version ?: return@mapNotNull null
+                    val codes = b.buildCodes ?: return@mapNotNull null
+                    v to codes
+                }.toMap(),
                 isExperimental = isVersionExperimental
             )
             cleanupPendingData(keepSelectedApp = true, keepBundleUid = true)
@@ -1995,13 +2011,24 @@ class HomeViewModel(
         // - Experimental mode OFF → UnsupportedVersionWarningDialog
         if (isVersionExperimental && !allowIncompatible) {
             val recommendedVersion = recommendedVersions[selectedApp.packageName]
-            val allVersions = compatibleVersions[selectedApp.packageName]?.map { it.target } ?: emptyList()
+            val allBundled = compatibleVersions[selectedApp.packageName] ?: emptyList()
             pendingSelectedApp = selectedApp
             val state = UnsupportedVersionDialogState(
                 packageName = selectedApp.packageName,
                 version = selectedApp.version ?: "unknown",
+                versionCode = selectedApp.versionCode,
                 recommendedVersion = recommendedVersion,
-                allCompatibleVersions = allVersions,
+                compatibleVersionNames = allBundled.mapNotNull { it.target.version },
+                compatibleVersionDescriptions = allBundled.mapNotNull { b ->
+                    val v = b.target.version ?: return@mapNotNull null
+                    val d = b.target.description ?: return@mapNotNull null
+                    v to d
+                }.toMap(),
+                compatibleVersionCodes = allBundled.mapNotNull { b ->
+                    val v = b.target.version ?: return@mapNotNull null
+                    val codes = b.buildCodes ?: return@mapNotNull null
+                    v to codes
+                }.toMap(),
                 isExperimental = true
             )
             if (isExperimentalModeEnabled) {
@@ -2595,6 +2622,8 @@ class HomeViewModel(
     ): Map<String, List<BundledAppTarget>> {
         // packageName → bundleUid → version → AppTarget
         val targetsByPackage = mutableMapOf<String, MutableMap<Int, MutableMap<String, AppTarget>>>()
+        // packageName → bundleUid → version → build codes (parallel to targetsByPackage)
+        val codesByPackage = mutableMapOf<String, MutableMap<Int, MutableMap<String, Set<Int>>>>()
 
         bundleInfo.forEach { (bundleUid, info) ->
             if (enabledBundleUids.isNotEmpty() && bundleUid !in enabledBundleUids) return@forEach
@@ -2605,19 +2634,23 @@ class HomeViewModel(
                     val bundleMap = targetsByPackage
                         .getOrPut(packageName) { mutableMapOf() }
                         .getOrPut(bundleUid) { mutableMapOf() }
+                    val codesMap = codesByPackage
+                        .getOrPut(packageName) { mutableMapOf() }
+                        .getOrPut(bundleUid) { mutableMapOf() }
 
                     pkg.versions?.forEach { version ->
                         val isExperimental = pkg.experimentalVersions?.contains(version) == true
                         // If a version appears in multiple patches of the same bundle, prefer stable
                         if (version !in bundleMap || !isExperimental) {
-                            val description = pkg.versionDescriptions?.get(version)
-                            val minSdk = pkg.versionMinSdks?.get(version)
                             bundleMap[version] = AppTarget(
                                 version = version,
                                 isExperimental = isExperimental,
-                                description = description,
-                                minSdk = minSdk,
+                                description = pkg.versionDescriptions?.get(version),
+                                minSdk = pkg.versionMinSdks?.get(version),
                             )
+                            pkg.versionCodes?.get(version)?.takeIf { it.isNotEmpty() }?.let {
+                                codesMap[version] = it.toSet()
+                            }
                         }
                     }
                 }
@@ -2626,17 +2659,19 @@ class HomeViewModel(
 
         // Flatten: bundles ordered by display name, versions newest→oldest within each bundle
         return targetsByPackage
-            .mapValues { (_, byBundle) ->
+            .mapValues { (packageName, byBundle) ->
                 byBundle.entries
                     .sortedWith(compareBy({ it.key != DEFAULT_SOURCE_UID }, { bundleNames[it.key] ?: "" }))
                     .flatMap { (uid, versionMap) ->
+                        val codesForBundle = codesByPackage[packageName]?.get(uid)
                         versionMap.values
                             .sortedDescending()
                             .map { target ->
                                 BundledAppTarget(
                                     target = target,
                                     bundleUid = uid,
-                                    bundleName = bundleNames[uid] ?: "Bundle $uid"
+                                    bundleName = bundleNames[uid] ?: "Bundle $uid",
+                                    buildCodes = target.version?.let { codesForBundle?.get(it) }
                                 )
                             }
                     }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1446,7 +1446,7 @@ class HomeViewModel(
             savedJob?.await()?.let { pendingSavedApkInfo = it }
             installedJob?.await()?.let { (installed, info) ->
                 pendingTargetAppInstalled = installed
-                pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version) }
+                pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version, it.versionCode) }
             }
         }
 
@@ -1501,10 +1501,13 @@ class HomeViewModel(
      * Returns true if [installedVersion] is listed in [pendingCompatibleVersions],
      * or if the compatible list is empty / contains an "any version" target.
      */
-    private fun isInstalledVersionCompatible(installedVersion: String): Boolean {
+    private fun isInstalledVersionCompatible(installedVersion: String, installedVersionCode: Long?): Boolean {
         val compatible = pendingCompatibleVersions
         if (compatible.isEmpty() || compatible.any { it.target.version == null }) return true
-        return compatible.any { it.target.version == installedVersion }
+        return compatible.any { entry ->
+            entry.target.version == installedVersion &&
+                (entry.buildCodes == null || installedVersionCode == null || installedVersionCode.toInt() in entry.buildCodes)
+        }
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -65,6 +65,8 @@ import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /** Bundle update status for snackbar display. */
 enum class BundleUpdateStatus {
@@ -759,7 +761,7 @@ class HomeViewModel(
             try {
                 patchBundleRepository.updateCheck()
                 checkForManagerUpdates()
-                delay(500)
+                delay(500.milliseconds)
             } finally {
                 _isRefreshing.value = false
             }
@@ -874,7 +876,7 @@ class HomeViewModel(
             if (releaseAgeSeconds < MANAGER_UPDATE_SHOW_DELAY_SECONDS) {
                 val remainingMs = (MANAGER_UPDATE_SHOW_DELAY_SECONDS - releaseAgeSeconds) * 1_000L
                 Log.d(tag, "Manager update ${update.version} is ${releaseAgeSeconds}s old, waiting ${remainingMs / 1000}s before showing banner")
-                delay(remainingMs)
+                delay(remainingMs.milliseconds)
             }
 
             updatedManagerVersion = update.version
@@ -975,7 +977,7 @@ class HomeViewModel(
         val toastRepeater = launch(Dispatchers.Main) {
             try {
                 while (isActive) {
-                    delay(1_750)
+                    delay(1_750.milliseconds)
                     progressToast.show()
                 }
             } catch (_: CancellationException) {
@@ -1050,9 +1052,8 @@ class HomeViewModel(
         }
         patchBundleRepository.bundleUpdateProgress
             .dropWhile { it == null }
-            .filter { it == null }
-            .first()
-        delay(1_500)
+            .first { it == null }
+        delay(1.5.seconds)
         showSwipeGestureHint.value = true
     }
 
@@ -1765,7 +1766,7 @@ class HomeViewModel(
             }
             // Wait for patches to be ready. Cap at 30 s to avoid hanging forever when
             // no patch sources are configured (installedAppsLoading never clears in that case)
-            withTimeoutOrNull(30_000L) {
+            withTimeoutOrNull(30.seconds) {
                 snapshotFlow { installedAppsLoading }.first { !it }
             }
             handleApkSelection(uri)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1846,9 +1846,9 @@ class HomeViewModel(
             }
 
             if (selectedApp != null) {
-                // The saved file is a merged mono-APK signed with our keystore.
-                // Skip signature verification to avoid a false "invalid signature" dialog
-                processSelectedAppIgnoringSignature(selectedApp)
+                // Saved file may be signed with our keystore - skip signature check.
+                // Version/versionCode check still runs via processSelectedApp.
+                processSelectedApp(selectedApp, skipSplitCheck = true)
             } else {
                 cleanupPendingData()
             }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1721,7 +1721,9 @@ class HomeViewModel(
                 }
             }
             if (selectedApp != null) {
-                processSelectedAppIgnoringSignature(selectedApp)
+                // Installed APK may be signed with our keystore - skip signature check.
+                // Version/versionCode check still runs via processSelectedApp.
+                processSelectedApp(selectedApp, skipSplitCheck = true)
             } else {
                 app.toast(app.getString(R.string.home_invalid_apk_io_error))
                 cleanupPendingData()

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -121,12 +121,14 @@ data class QuickPatchParams(
 data class SavedApkInfo(
     val fileName: String,
     val filePath: String,
-    val version: String
+    val version: String,
+    val versionCode: Long? = null
 )
 
 /** Installed APK information for display in APK selection dialog. */
 data class InstalledApkInfo(
     val version: String,
+    val versionCode: Long? = null,
     val apkPath: String,
     val splitPaths: List<String> = emptyList()
 ) {
@@ -1480,7 +1482,8 @@ class HomeViewModel(
             return SavedApkInfo(
                 fileName = file.name,
                 filePath = file.absolutePath,
-                version = version
+                version = version,
+                versionCode = resolvedData.packageInfo?.let { pm.getVersionCode(it) }
             )
         } catch (e: Exception) {
             Log.e(tag, "Failed to load saved APK info", e)
@@ -1549,7 +1552,7 @@ class HomeViewModel(
             val splitPaths = appInfo.splitSourceDirs
                 ?.filter { File(it).exists() }
                 ?: emptyList()
-            true to InstalledApkInfo(version = version, apkPath = sourceDir, splitPaths = splitPaths)
+            true to InstalledApkInfo(version = version, versionCode = pm.getVersionCode(pkgInfo), apkPath = sourceDir, splitPaths = splitPaths)
         } catch (e: Exception) {
             Log.e(tag, "Failed to load installed app info", e)
             false to null
@@ -1581,6 +1584,7 @@ class HomeViewModel(
                         SelectedApp.Local(
                             packageName = packageName,
                             version = installedInfo.version,
+                            versionCode = installedInfo.versionCode,
                             file = archive,
                             temporary = true,
                             fromInstalledDevice = true
@@ -1593,6 +1597,7 @@ class HomeViewModel(
                         SelectedApp.Local(
                             packageName = packageName,
                             version = installedInfo.version,
+                            versionCode = installedInfo.versionCode,
                             file = tempFile,
                             temporary = true,
                             fromInstalledDevice = true
@@ -1647,6 +1652,7 @@ class HomeViewModel(
                                     isSystemApp = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0,
                                     info = InstalledApkInfo(
                                         version = version,
+                                        versionCode = pm.getVersionCode(pkgInfo),
                                         apkPath = sourceDir,
                                         splitPaths = splitPaths
                                     )
@@ -1681,6 +1687,7 @@ class HomeViewModel(
                         SelectedApp.Local(
                             packageName = item.packageName,
                             version = item.info.version,
+                            versionCode = item.info.versionCode,
                             file = archive,
                             temporary = true,
                             fromInstalledDevice = true
@@ -1693,6 +1700,7 @@ class HomeViewModel(
                         SelectedApp.Local(
                             packageName = item.packageName,
                             version = item.info.version,
+                            versionCode = item.info.versionCode,
                             file = tempFile,
                             temporary = true,
                             fromInstalledDevice = true
@@ -1818,6 +1826,7 @@ class HomeViewModel(
                     SelectedApp.Local(
                         packageName = packageName,
                         version = savedInfo.version,
+                        versionCode = savedInfo.versionCode,
                         file = file,
                         temporary = false // Don't delete saved APK files
                     )
@@ -1925,7 +1934,7 @@ class HomeViewModel(
         // Scoped.universal = compatiblePackages == null (applies to any package/version).
         val bundles = withContext(Dispatchers.IO) {
             patchBundleRepository
-                .scopedBundleInfoFlow(selectedApp.packageName, selectedApp.version)
+                .scopedBundleInfoFlow(selectedApp.packageName, selectedApp.version, selectedApp.versionCode)
                 .first()
         }
 
@@ -2034,7 +2043,7 @@ class HomeViewModel(
         allowIncompatible: Boolean
     ) {
         val allBundles = patchBundleRepository
-            .scopedBundleInfoFlow(selectedApp.packageName, selectedApp.version)
+            .scopedBundleInfoFlow(selectedApp.packageName, selectedApp.version, selectedApp.versionCode)
             .first()
 
         if (allBundles.isEmpty()) {
@@ -2711,6 +2720,7 @@ class HomeViewModel(
                 SelectedApp.Local(
                     packageName = packageInfo.packageName,
                     version = packageInfo.versionName ?: "unknown",
+                    versionCode = pm.getVersionCode(packageInfo),
                     file = tempFile,
                     temporary = true
                 )

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -186,7 +186,8 @@ class PatcherViewModel(
     private suspend fun gatherScopedBundles(): Map<Int, PatchBundleInfo.Scoped> =
         patchBundleRepository.scopedBundleInfoFlow(
             packageName,
-            input.selectedApp.version
+            input.selectedApp.version,
+            input.selectedApp.versionCode
         ).first().associateBy { it.uid }
 
     suspend fun collectSelectedBundleMetadata(): Pair<List<String>, List<String>> {
@@ -603,7 +604,8 @@ class PatcherViewModel(
         // This ensures all applied patches are correctly saved
         val scopedBundlesForSelection = patchBundleRepository.scopedBundleInfoFlow(
             packageName,
-            input.selectedApp.version
+            input.selectedApp.version,
+            input.selectedApp.versionCode
         ).first().associateBy { it.uid }
         val sanitizedSelection = sanitizeSelection(appliedSelection, scopedBundlesForSelection)
         val sanitizedOptions = sanitizeOptions(appliedOptions, scopedBundlesForSelection)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -55,6 +55,8 @@ import java.nio.file.Files
 import java.util.UUID
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(SavedStateHandleSaveableApi::class)
 class PatcherViewModel(
@@ -321,8 +323,8 @@ class PatcherViewModel(
     }
 
     private val workManager = WorkManager.getInstance(app)
-    private val _patcherSucceeded = MediatorLiveData<Boolean?>()
-    val patcherSucceeded: LiveData<Boolean?> get() = _patcherSucceeded
+    val patcherSucceeded: LiveData<Boolean?>
+        field: MediatorLiveData<Boolean?> = MediatorLiveData()
     private var currentWorkSource: LiveData<WorkInfo?>? = null
     private val handledFailureIds = mutableSetOf<UUID>()
     private var forceKeepLocalInput = false
@@ -681,7 +683,7 @@ class PatcherViewModel(
             app.toast(app.getString(R.string.patched_app_save_failed_toast))
         } else {
             app.toast(app.getString(R.string.save_apk_success))
-            delay(2000)
+            delay(2.seconds)
         }
 
         if (saved) triggerNotificationPromptIfNeeded()
@@ -776,7 +778,7 @@ class PatcherViewModel(
                 ) {
                     _showLongStepWarning.value = true
                 }
-                delay(250)
+                delay(250.milliseconds)
             }
             _showLongStepWarning.value = false
         }
@@ -883,9 +885,9 @@ class PatcherViewModel(
 
     private fun observeWorker(id: UUID) {
         val source = workManager.getWorkInfoByIdLiveData(id)
-        currentWorkSource?.let { _patcherSucceeded.removeSource(it) }
+        currentWorkSource?.let { patcherSucceeded.removeSource(it) }
         currentWorkSource = source
-        _patcherSucceeded.addSource(source) { workInfo ->
+        patcherSucceeded.addSource(source) { workInfo ->
             when (workInfo?.state) {
                 WorkInfo.State.SUCCEEDED -> {
                     forceKeepLocalInput = false
@@ -899,7 +901,7 @@ class PatcherViewModel(
                                 // Delete temporary input file after saving
                                 cleanupTemporaryInput()
                                 refreshExportMetadata()
-                                _patcherSucceeded.value = true
+                                patcherSucceeded.value = true
                             }
                         }
                     }
@@ -907,13 +909,13 @@ class PatcherViewModel(
 
                 WorkInfo.State.FAILED -> {
                     handleWorkerFailure(workInfo)
-                    _patcherSucceeded.value = false
+                    patcherSucceeded.value = false
                 }
 
                 WorkInfo.State.RUNNING,
                 WorkInfo.State.ENQUEUED,
-                WorkInfo.State.BLOCKED -> _patcherSucceeded.value = null
-                else -> _patcherSucceeded.value = null
+                WorkInfo.State.BLOCKED -> patcherSucceeded.value = null
+                else -> patcherSucceeded.value = null
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -194,6 +194,9 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
     <string name="home_dialog_unsupported_version_dialog_proceed">Proceed anyway</string>
     <string name="home_dialog_unsupported_version_compatible_versions">Compatible versions:</string>
     <string name="home_dialog_unsupported_version_unsupported_label">Unsupported</string>
+    <!-- "Build" here refers to a specific compiled version of the app (versionCode) -->
+    <string name="home_dialog_unsupported_version_build">Build %d</string>
+    <string name="home_dialog_unsupported_version_build_mismatch_description">This is a different build of the same version. The patches require a specific build</string>
     <string name="home_dialog_wrong_package_title">Wrong package selected</string>
     <string name="home_dialog_wrong_package_description">The selected APK is not for the application you intended to patch</string>
     <string name="home_dialog_expected_package">Expected package:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,8 +112,8 @@
     <string name="home_apk_availability_incompatible_label">Incompatible</string>
     <string name="home_apk_availability_yes">Yes, help me find an APK</string>
     <string name="home_apk_availability_no">No, I already have an APK</string>
-    <string name="home_apk_use_saved_with_version">Use saved APK (v%s)</string>
-    <string name="home_apk_use_installed_with_version">Use installed APK (v%s)</string>
+    <string name="home_apk_use_saved">Use saved APK</string>
+    <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_app_info_no_saved_apk">No saved APK. Patching will require selecting the APK file again</string>
     <string name="home_version_requires_android">Requires Android %s+</string>
     <string name="home_apk_no_compatible_versions_title">Not supported on this device</string>


### PR DESCRIPTION
Honors the existing versionCodes field in AppTarget so patches can be pinned to a specific version code, while remaining fully backwards-compatible when the field is omitted.