### PR TITLE
fix: Trigger Shizuku auto-install in the background without waiting for foreground

### DIFF
--- a/app/src/main/java/app/morphe/manager/patcher/runtime/process/PatcherProcess.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/runtime/process/PatcherProcess.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Looper
+import android.os.PowerManager
 import app.morphe.manager.BuildConfig
 import app.morphe.manager.patcher.Session
 import app.morphe.manager.patcher.logger.LogLevel
@@ -145,6 +146,14 @@ class PatcherProcess(private val context: Context) : IPatcherProcess.Stub() {
             // Abuse hidden APIs to get a context.
             val systemContext = ActivityThread.systemMain().systemContext as Context
             val appContext = systemContext.createPackageContext(managerPackageName, 0)
+
+            // Keep the CPU awake for the duration of patching. The child process does not
+            // inherit the parent's WakeLock, so it needs its own. Released automatically
+            // when the process exits via any exitProcess() call.
+            @Suppress("WakelockTimeout")
+            (appContext.getSystemService(Context.POWER_SERVICE) as PowerManager)
+                .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "PatcherProcess::Patcher")
+                .acquire()
 
             // Avoid annoying logs. See https://github.com/robolectric/robolectric/blob/ad0484c6b32c7d11176c711abeb3cb4a900f9258/robolectric/src/main/java/org/robolectric/android/internal/AndroidTestEnvironment.java#L376-L388
             Class.forName("android.app.AppCompatCallbacks").apply {

--- a/app/src/main/java/app/morphe/manager/patcher/worker/PatcherWorker.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/worker/PatcherWorker.kt
@@ -123,7 +123,7 @@ class PatcherWorker(
             applicationContext.getSystemService(NotificationManager::class.java)
         // Android won't visually switch from indeterminate → determinate on the same notification
         // ID unless we first post a brief non-indeterminate update. Post the real notification
-        // directly — the determinate bar replaces the spinning one cleanly this way
+        // directly - the determinate bar replaces the spinning one cleanly this way
         notificationManager.notify(NOTIFICATION_ID, createNotification(stepName, patchProgress, contentText))
     }
 
@@ -137,14 +137,19 @@ class PatcherWorker(
             // This does not always show up for some reason.
             setForeground(getForegroundInfo())
         } catch (e: Exception) {
-            Log.d(tag, "Failed to set foreground info:", e)
+            // Foreground promotion can fail on some devices or when notification permission is
+            // denied. Log it but continue - patching still works, just with less OS protection.
+            Log.w(tag, "Failed to promote worker to foreground service:".logFmt(), e)
         }
 
         val wakeLock: PowerManager.WakeLock =
             (applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager)
                 .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "$tag::Patcher")
                 .apply {
-                    acquire(10 * 60 * 1000L)
+                    // No timeout: the finally block below always releases this lock, so a cap
+                    // would only risk the CPU sleeping mid-patch on large or slow devices
+                    @Suppress("WakelockTimeout")
+                    acquire()
                     Log.d(tag, "Acquired wakelock.")
                 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
@@ -59,6 +59,7 @@ import org.koin.compose.koinInject
 import kotlin.math.exp
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Patcher screen with progress tracking.
@@ -100,7 +101,7 @@ fun PatcherScreen(
     // Animated progress with dual-mode animation
     var displayProgress by rememberSaveable { mutableFloatStateOf(patcherViewModel.progress) }
     val showLongStepWarning by patcherViewModel.showLongStepWarning.collectAsStateWithLifecycle()
-    var showSuccessScreen by rememberSaveable { mutableStateOf(false) }
+    val showSuccessScreen = patcherViewModel.showSuccessScreen
 
     LaunchedEffect(showSuccessScreen) {
         if (showSuccessScreen) miniGameState.pauseActiveGame()
@@ -125,13 +126,13 @@ fun PatcherScreen(
                 movingAverage = (1 - smoothingFactor) * movingAverage +
                         smoothingFactor * displayProgress
                 onBackgroundSpeedChange(1 + movingAverage)
-                delay(250)
+                delay(250.milliseconds)
             }
         } else {
             // Patching finished - reset speed then fire completion effect
             onBackgroundSpeedChange(1f)
-            if (patcherSucceeded == true) {
-                delay(300) // small pause so speed resets before effect fires
+            if (patcherSucceeded == true && patcherViewModel.patchingCompletedInForeground) {
+                delay(300.milliseconds) // small pause so speed resets before effect fires
                 onPatchingCompleted()
                 // Haptic feedback
                 view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
@@ -151,22 +152,18 @@ fun PatcherScreen(
     val primaryInstallerPref by prefs.installerPrimary.getAsState()
     val promptInstallerOnInstall by prefs.promptInstallerOnInstall.getAsState()
 
-    // Auto-install: triggers when success screen appears with Shizuku as primary installer.
-    // Skipped when promptInstallerOnInstall is enabled - user gets the manual Install button instead.
-    LaunchedEffect(showSuccessScreen) {
-        if (!showSuccessScreen) return@LaunchedEffect
-        if (!autoInstallWithShizuku) return@LaunchedEffect
-        if (usingMountInstall) return@LaunchedEffect
-        if (patcherSucceeded != true) return@LaunchedEffect
-        if (primaryInstallerPref != InstallerPreferenceTokens.SHIZUKU) return@LaunchedEffect
-        if (promptInstallerOnInstall) return@LaunchedEffect
-        if (installViewModel.installState !is InstallViewModel.InstallState.Ready) return@LaunchedEffect
-        delay(300)
-        installViewModel.install(
-            outputFile = outputFile,
-            originalPackageName = patcherViewModel.packageName,
-            onPersistApp = { pkg, type -> patcherViewModel.persistPatchedApp(pkg, type) }
-        )
+    // Auto-install: driven by ViewModel so it fires in the background even if the app is not
+    // in the foreground when patching completes. UI-only guards checked here.
+    LaunchedEffect(Unit) {
+        patcherViewModel.autoInstallEvent.collect {
+            if (usingMountInstall) return@collect
+            if (installViewModel.installState !is InstallViewModel.InstallState.Ready) return@collect
+            installViewModel.install(
+                outputFile = outputFile,
+                originalPackageName = patcherViewModel.packageName,
+                onPersistApp = { pkg, type -> patcherViewModel.persistPatchedApp(pkg, type) }
+            )
+        }
     }
 
     // Progress animation logic: drives displayProgress and showSuccessScreen
@@ -213,18 +210,12 @@ fun PatcherScreen(
             }
 
             // Update four times a second
-            delay(250)
+            delay(250.milliseconds)
         }
 
         // Patching completed - ensure progress reaches 100%
         if (patcherSucceeded == true) {
             displayProgress = 1.0f
-            // Wait for animation to complete and add extra delay
-            delay(2000) // Wait 2 seconds at 100% before showing success screen
-            showSuccessScreen = true
-        } else {
-            // Failed - show immediately
-            showSuccessScreen = true
         }
     }
 
@@ -244,7 +235,7 @@ fun PatcherScreen(
     }
 
     BackHandler {
-        if (patcherSucceeded == null) {
+        if (patcherViewModel.isPatching) {
             // Show cancel dialog if patching is in progress
             state.showCancelDialog = true
         } else {
@@ -254,7 +245,7 @@ fun PatcherScreen(
     }
 
     // Keep screen on during patching
-    if (patcherSucceeded == null) {
+    if (patcherViewModel.isPatching) {
         DisposableEffect(Unit) {
             val window = (context as Activity).window
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -477,7 +468,7 @@ fun PatcherScreen(
                     primaryToken,
                     installTarget
                 )
-                delay(1_500)
+                delay(1_500.milliseconds)
             }
         }
 
@@ -521,7 +512,7 @@ fun PatcherScreen(
                             patcherSucceeded = patcherSucceeded,
                             miniGameState = miniGameState,
                             onCancelClick = { state.showCancelDialog = true },
-                            onInstallClick = { showSuccessScreen = true },
+                            onInstallClick = { patcherViewModel.showSuccess() },
                             onHomeClick = onBackClick
                         )
                     } else {
@@ -560,7 +551,7 @@ fun PatcherScreen(
                         onDismissInstallerDialog = installViewModel::dismissInstallerUnavailableDialog,
                         usingMountInstall = usingMountInstall,
                         isExpertMode = useExpertMode,
-                        onLogsClick = { showSuccessScreen = false },
+                        onLogsClick = { patcherViewModel.hideSuccessScreen() },
                         onInstall = {
                             if (usingMountInstall) {
                                 // Mount install

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -21,6 +21,7 @@ import app.morphe.manager.BuildConfig
 import app.morphe.manager.R
 import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.room.apps.installed.InstallType
+import app.morphe.manager.domain.manager.InstallerPreferenceTokens
 import app.morphe.manager.domain.manager.PatchOptionsPreferencesManager
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.*
@@ -105,6 +106,24 @@ class PatcherViewModel(
     private var launchedActivity: CompletableDeferred<ActivityResult>? = null
     private val launchActivityChannel = Channel<Intent>()
     val launchActivityFlow = launchActivityChannel.receiveAsFlow()
+
+    private val _autoInstallChannel = Channel<Unit>(Channel.CONFLATED)
+    val autoInstallEvent: Flow<Unit> = _autoInstallChannel.receiveAsFlow()
+
+    var patchingCompletedAt: Long? = null
+        private set
+
+    var patchingCompletedInForeground: Boolean = false
+        private set
+
+    var showSuccessScreen: Boolean by mutableStateOf(false)
+        private set
+
+    fun showSuccess() { showSuccessScreen = true }
+    fun hideSuccessScreen() { showSuccessScreen = false }
+
+    var isPatching: Boolean by mutableStateOf(true)
+        private set
 
     private val selectedApp = input.selectedApp
     val packageName = selectedApp.packageName
@@ -324,8 +343,8 @@ class PatcherViewModel(
 
     private val workManager = WorkManager.getInstance(app)
     val patcherSucceeded: LiveData<Boolean?>
-        field: MediatorLiveData<Boolean?> = MediatorLiveData()
-    private var currentWorkSource: LiveData<WorkInfo?>? = null
+        field: MutableLiveData<Boolean?> = MutableLiveData()
+    private var observeWorkerJob: Job? = null
     private val handledFailureIds = mutableSetOf<UUID>()
     private var forceKeepLocalInput = false
 
@@ -884,40 +903,65 @@ class PatcherViewModel(
     }
 
     private fun observeWorker(id: UUID) {
-        val source = workManager.getWorkInfoByIdLiveData(id)
-        currentWorkSource?.let { patcherSucceeded.removeSource(it) }
-        currentWorkSource = source
-        patcherSucceeded.addSource(source) { workInfo ->
-            when (workInfo?.state) {
-                WorkInfo.State.SUCCEEDED -> {
-                    forceKeepLocalInput = false
+        observeWorkerJob?.cancel()
+        observeWorkerJob = viewModelScope.launch {
+            workManager.getWorkInfoByIdFlow(id).collect { workInfo ->
+                when (workInfo?.state) {
+                    WorkInfo.State.SUCCEEDED -> {
+                        forceKeepLocalInput = false
 
-                    // Save original APK before deleting temporary file (blocking)
-                    viewModelScope.launch(Dispatchers.IO) {
-                        try {
-                            saveOriginalApkIfNeeded()
-                        } finally {
-                            withContext(Dispatchers.Main) {
-                                // Delete temporary input file after saving
-                                cleanupTemporaryInput()
-                                refreshExportMetadata()
-                                patcherSucceeded.value = true
+                        // Save original APK before deleting temporary file (blocking).
+                        // Launched independently so cancelling observeWorkerJob (new patch run)
+                        // does not interrupt cleanup that is already in progress.
+                        viewModelScope.launch(Dispatchers.IO) {
+                            try {
+                                saveOriginalApkIfNeeded()
+                            } finally {
+                                withContext(Dispatchers.Main) {
+                                    // Delete temporary input file after saving
+                                    cleanupTemporaryInput()
+                                    refreshExportMetadata()
+                                    patchingCompletedAt = System.currentTimeMillis()
+                                    patchingCompletedInForeground = patcherSucceeded.hasActiveObservers()
+                                    isPatching = false
+                                    patcherSucceeded.value = true
+                                    scheduleAutoInstallIfNeeded()
+                                    scheduleSuccessScreen()
+                                }
                             }
                         }
                     }
-                }
 
-                WorkInfo.State.FAILED -> {
-                    handleWorkerFailure(workInfo)
-                    patcherSucceeded.value = false
-                }
+                    WorkInfo.State.FAILED -> {
+                        handleWorkerFailure(workInfo)
+                        isPatching = false
+                        patcherSucceeded.value = false
+                        showSuccessScreen = true
+                    }
 
-                WorkInfo.State.RUNNING,
-                WorkInfo.State.ENQUEUED,
-                WorkInfo.State.BLOCKED -> patcherSucceeded.value = null
-                else -> patcherSucceeded.value = null
+                    WorkInfo.State.RUNNING,
+                    WorkInfo.State.ENQUEUED,
+                    WorkInfo.State.BLOCKED -> {
+                        isPatching = true
+                        patcherSucceeded.value = null
+                    }
+                    else -> patcherSucceeded.value = null
+                }
             }
         }
+    }
+
+    private fun scheduleSuccessScreen() = viewModelScope.launch {
+        val elapsed = patchingCompletedAt?.let { System.currentTimeMillis() - it } ?: 0L
+        delay((2000L - elapsed).coerceAtLeast(0L).milliseconds)
+        showSuccessScreen = true
+    }
+
+    private fun scheduleAutoInstallIfNeeded() = viewModelScope.launch {
+        if (!prefs.autoInstallWithShizuku.get()) return@launch
+        if (prefs.installerPrimary.get() != InstallerPreferenceTokens.SHIZUKU) return@launch
+        if (prefs.promptInstallerOnInstall.get()) return@launch
+        _autoInstallChannel.trySend(Unit)
     }
 
     private fun handleWorkerFailure(workInfo: WorkInfo) {


### PR DESCRIPTION
Replaces `MediatorLiveData/LaunchedEffect` with `getWorkInfoByIdFlow()` in `viewModelScope` and a `Channel`-based event so Shizuku auto-install and all completion state updates fire immediately when patching finishes, regardless of whether
the app is in the foreground.