### PR TITLE
feat: Add app list reorder mode to home screen multiselect bar

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
@@ -7,18 +7,20 @@ package app.morphe.manager.domain.manager
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import androidx.core.content.edit
 
 /**
- * Manages user preferences for home screen app buttons.
+ * Manages user preferences for home screen app buttons: hidden packages and custom sort order.
  *
- * Ordering is handled automatically:
+ * Default ordering (applied when no custom order is set):
  * 1. Patched (installed) apps first
  * 2. Apps with isPinnedByDefault = true
- * 3. All other apps — alphabetical
+ * 3. All other apps, alphabetical
+ *
+ * A custom order overrides the default sort and is persisted across sessions.
  */
 class HomeAppButtonPreferences(context: Context) {
 
@@ -28,12 +30,17 @@ class HomeAppButtonPreferences(context: Context) {
     private val _hiddenPackages = MutableStateFlow(loadHiddenPackages())
     val hiddenPackages: StateFlow<Set<String>> = _hiddenPackages.asStateFlow()
 
+    private val _customOrder = MutableStateFlow(loadCustomOrder())
+    val customOrder: StateFlow<List<String>> = _customOrder.asStateFlow()
+
     private fun loadHiddenPackages(): Set<String> {
         return prefs.getStringSet(KEY_HIDDEN, null) ?: emptySet()
     }
 
-    fun isHidden(packageName: String): Boolean =
-        _hiddenPackages.value.contains(packageName)
+    private fun loadCustomOrder(): List<String> {
+        val raw = prefs.getString(KEY_CUSTOM_ORDER, null) ?: return emptyList()
+        return raw.split("\n").filter { it.isNotEmpty() }
+    }
 
     fun hide(packageName: String) {
         val current = _hiddenPackages.value.toMutableSet()
@@ -47,10 +54,15 @@ class HomeAppButtonPreferences(context: Context) {
         saveHiddenPackages(current)
     }
 
-    /**
-     * Get all currently hidden packages (for "show hidden" UI).
-     */
-    fun getHiddenPackages(): Set<String> = _hiddenPackages.value
+    fun saveOrder(packageNames: List<String>) {
+        prefs.edit { putString(KEY_CUSTOM_ORDER, packageNames.joinToString("\n")) }
+        _customOrder.value = packageNames
+    }
+
+    fun resetOrder() {
+        prefs.edit { remove(KEY_CUSTOM_ORDER) }
+        _customOrder.value = emptyList()
+    }
 
     private fun saveHiddenPackages(packages: Set<String>) {
         prefs.edit {
@@ -62,5 +74,6 @@ class HomeAppButtonPreferences(context: Context) {
     companion object {
         private const val PREFS_NAME = "home_app_buttons"
         private const val KEY_HIDDEN = "hidden_packages"
+        private const val KEY_CUSTOM_ORDER = "custom_order"
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -225,6 +225,8 @@ fun HomeScreen(
                 onHideApp = { packageName -> homeViewModel.hideApp(packageName) },
                 onHideMultiple = { packageNames -> packageNames.forEach { homeViewModel.hideApp(it) } },
                 onUnhideApp = { packageName -> homeViewModel.unhideApp(packageName) },
+                onSaveOrder = { packageNames -> homeViewModel.saveAppOrder(packageNames) },
+                onResetOrder = { homeViewModel.resetAppOrder() },
                 onShowPatches = { item -> patchesSheetItem.value = item },
                 showGestureHint = showGestureHint,
                 onGestureHintShown = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -43,13 +43,11 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.*
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.*
@@ -70,6 +68,8 @@ import app.morphe.manager.util.KnownApps
 import app.morphe.manager.util.toast
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 import kotlin.time.Duration.Companion.milliseconds
 
 /** Data describing one side of a swipe action - icon, label, and colors. */
@@ -127,7 +127,11 @@ fun SectionsLayout(
     isExpertModeEnabled: Boolean = false,
 
     // Onboarding
-    onboardingState: OnboardingState? = null
+    onboardingState: OnboardingState? = null,
+
+    // Reorder
+    onSaveOrder: (List<String>) -> Unit = {},
+    onResetOrder: () -> Unit = {}
 ) {
     val windowSize = rememberWindowSize()
 
@@ -177,7 +181,9 @@ fun SectionsLayout(
                     onBundlesClick = onBundlesClick,
                     onSettingsClick = onSettingsClick,
                     isExpertModeEnabled = isExpertModeEnabled,
-                    onboardingState = onboardingState
+                    onboardingState = onboardingState,
+                    onSaveOrder = onSaveOrder,
+                    onResetOrder = onResetOrder
                 )
             }
 
@@ -238,7 +244,9 @@ private fun AdaptiveContent(
     onBundlesClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     isExpertModeEnabled: Boolean = false,
-    onboardingState: OnboardingState? = null
+    onboardingState: OnboardingState? = null,
+    onSaveOrder: (List<String>) -> Unit = {},
+    onResetOrder: () -> Unit = {}
 ) {
     val contentPadding = windowSize.contentPadding
     val itemSpacing = windowSize.itemSpacing
@@ -314,6 +322,8 @@ private fun AdaptiveContent(
                         onBundlesClick = onBundlesClick,
                         onboardingState = onboardingState,
                         showFadeOverlay = false,
+                        onSaveOrder = onSaveOrder,
+                        onResetOrder = onResetOrder,
                         modifier = Modifier.weight(1f)
                     )
 
@@ -368,6 +378,8 @@ private fun AdaptiveContent(
                         onSearchQueryChange = onSearchQueryChange,
                         onBundlesClick = onBundlesClick,
                         onboardingState = onboardingState,
+                        onSaveOrder = onSaveOrder,
+                        onResetOrder = onResetOrder,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
@@ -770,11 +782,18 @@ fun MainAppsSection(
     onSearchQueryChange: (String) -> Unit = {},
     onBundlesClick: () -> Unit = {},
     onboardingState: OnboardingState? = null,
-    showFadeOverlay: Boolean = true
+    showFadeOverlay: Boolean = true,
+    onSaveOrder: (List<String>) -> Unit = {},
+    onResetOrder: () -> Unit = {}
 ) {
     // Multi-select state - set of packageNames chosen for bulk hide
     val isMultiSelectMode = remember { mutableStateOf(false) }
     val selectedPackages = remember { mutableStateOf(emptySet<String>()) }
+
+    // Reorder state
+    val isReorderMode = remember { mutableStateOf(false) }
+    var localOrder by remember { mutableStateOf(homeAppItems.map { it.packageName }) }
+    val haptic = LocalHapticFeedback.current
 
     // Back gesture/button cancels multi-select instead of navigating back
     BackHandler(enabled = isMultiSelectMode.value) {
@@ -782,13 +801,29 @@ fun MainAppsSection(
         selectedPackages.value = emptySet()
     }
 
-    // Sync selection with current item list; exit mode if no items remain
+    // Back gesture/button exits reorder mode without saving
+    BackHandler(enabled = isReorderMode.value) {
+        isReorderMode.value = false
+        localOrder = homeAppItems.map { it.packageName }
+    }
+
+    // Sync selection and local order with current item list
     LaunchedEffect(homeAppItems) {
         val filtered = selectedPackages.value.filter { pkg ->
             homeAppItems.any { it.packageName == pkg }
         }.toSet()
         selectedPackages.value = filtered
         if (filtered.isEmpty()) isMultiSelectMode.value = false
+
+        if (!isReorderMode.value) {
+            localOrder = homeAppItems.map { it.packageName }
+        } else {
+            val pkgSet = homeAppItems.map { it.packageName }.toSet()
+            val kept = localOrder.filter { it in pkgSet }
+            val keptSet = kept.toSet()
+            val added = pkgSet.filter { it !in keptSet }
+            localOrder = kept + added
+        }
     }
 
     // Track if real content has ever arrived so we never re-show the shimmer on resume
@@ -853,6 +888,16 @@ fun MainAppsSection(
     }
 
     val listState = rememberLazyListState()
+    val reorderableState = rememberReorderableLazyListState(listState) { from, to ->
+        val newOrder = localOrder.toMutableList()
+        val moved = newOrder.removeAt(from.index)
+        newOrder.add(to.index, moved)
+        localOrder = newOrder
+    }
+    val orderedItems = remember(localOrder, homeAppItems) {
+        val byPackage = homeAppItems.associateBy { it.packageName }
+        localOrder.mapNotNull { byPackage[it] }
+    }
 
     // True empty state: loaded, no apps from any bundle (no sources / all disabled)
     val isNoSourcesState = !stableLoadingState.value && homeAppItems.isEmpty() && hiddenAppItems.isEmpty()
@@ -926,8 +971,14 @@ fun MainAppsSection(
                                 contentPadding = PaddingValues(
                                     start = horizontalPadding,
                                     end = horizontalPadding,
-                                    // Extra bottom padding so cards aren't hidden behind the multi-select bar
-                                    bottom = if (isMultiSelectMode.value) 120.dp else 0.dp
+                                    // Extra bottom padding so cards aren't hidden behind the action bar
+                                    // MultiSelectBar surface heights (144dp / 100dp) minus bar's own
+                                    // 8dp top padding, plus itemSpacing for consistent card gap
+                                    bottom = when {
+                                        isMultiSelectMode.value -> 136.dp + itemSpacing
+                                        isReorderMode.value -> 92.dp + itemSpacing
+                                        else -> 0.dp
+                                    }
                                 )
                             ) {
                                 // Cold start: homeAppItems still empty - show placeholder shimmer cards
@@ -937,6 +988,33 @@ fun MainAppsSection(
                                             gradientColors = placeholderGradients[index % placeholderGradients.size],
                                             modifier = Modifier.animateItem()
                                         )
+                                    }
+                                } else if (isReorderMode.value) {
+                                    itemsIndexed(
+                                        items = orderedItems,
+                                        key = { _, item -> item.packageName }
+                                    ) { _, item ->
+                                        ReorderableItem(reorderableState, key = item.packageName) { _ ->
+                                            DynamicAppCard(
+                                                item = item,
+                                                isLoading = false,
+                                                hasUpdate = item.hasUpdate,
+                                                onAppClick = {},
+                                                onHide = {},
+                                                onShowPatches = {},
+                                                showGestureHint = false,
+                                                onGestureHintShown = {},
+                                                isSelected = false,
+                                                isMultiSelectMode = true,
+                                                onLongPress = {},
+                                                dragHandleModifier = Modifier.draggableHandle(
+                                                    onDragStarted = {
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                    }
+                                                ),
+                                                modifier = Modifier.animateItem()
+                                            )
+                                        }
                                     }
                                 } else {
                                     itemsIndexed(
@@ -1112,11 +1190,12 @@ fun MainAppsSection(
                         }
                     }
 
-                    // Multi-select confirmation bar - slides up from bottom
+                    // Multi-select / reorder bar - slides up from bottom
                     MultiSelectBar(
                         selectedCount = selectedPackages.value.size,
                         totalCount = homeAppItems.size,
-                        visible = isMultiSelectMode.value,
+                        visible = isMultiSelectMode.value || isReorderMode.value,
+                        isReorderMode = isReorderMode.value,
                         onSelectAll = {
                             selectedPackages.value = homeAppItems.map { it.packageName }.toSet()
                         },
@@ -1128,9 +1207,28 @@ fun MainAppsSection(
                         },
                         actionIcon = Icons.Outlined.VisibilityOff,
                         actionContentDescription = stringResource(R.string.hide),
+                        actionDoneMessage = stringResource(R.string.hidden),
                         onCancel = {
                             isMultiSelectMode.value = false
                             selectedPackages.value = emptySet()
+                        },
+                        onEnterReorder = {
+                            isMultiSelectMode.value = false
+                            selectedPackages.value = emptySet()
+                            isReorderMode.value = true
+                        },
+                        onSaveOrder = {
+                            onSaveOrder(localOrder)
+                            isReorderMode.value = false
+                        },
+                        onResetOrder = {
+                            onResetOrder()
+                            localOrder = homeAppItems.map { it.packageName }
+                            isReorderMode.value = false
+                        },
+                        onCancelReorder = {
+                            isReorderMode.value = false
+                            localOrder = homeAppItems.map { it.packageName }
                         },
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
@@ -1334,7 +1432,8 @@ private fun DynamicAppCard(
     onGestureHintShown: () -> Unit,
     isSelected: Boolean = false,
     isMultiSelectMode: Boolean = false,
-    onLongPress: () -> Unit = {}
+    onLongPress: () -> Unit = {},
+    dragHandleModifier: Modifier? = null
 ) {
     val showHideDialog = remember { mutableStateOf(false) }
     val density = LocalDensity.current
@@ -1451,6 +1550,23 @@ private fun DynamicAppCard(
             }
         }
 
+        if (dragHandleModifier != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .size(48.dp)
+                    .then(dragHandleModifier),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.DragHandle,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+            }
+        }
+
         if (showHideDialog.value) {
             HideAppDialog(
                 item = item,
@@ -1478,13 +1594,22 @@ private fun MultiSelectBar(
     onAction: () -> Unit,
     actionIcon: ImageVector,
     actionContentDescription: String,
+    actionDoneMessage: String,
     onCancel: () -> Unit,
+    onEnterReorder: () -> Unit,
+    onSaveOrder: () -> Unit,
+    onResetOrder: () -> Unit,
+    onCancelReorder: () -> Unit,
     modifier: Modifier = Modifier,
+    isReorderMode: Boolean = false,
+    showReorderButton: Boolean = true,
     actionColors: IconButtonColors = IconButtonDefaults.filledTonalIconButtonColors(
         containerColor = MaterialTheme.colorScheme.errorContainer,
         contentColor = MaterialTheme.colorScheme.onErrorContainer
     )
 ) {
+    val effectiveReorderMode = isReorderMode && showReorderButton
+
     val context = LocalContext.current
     fun withToast(doneMessage: String, action: () -> Unit): () -> Unit = {
         context.toast(doneMessage)
@@ -1496,6 +1621,12 @@ private fun MultiSelectBar(
     val deselectAllLabel = stringResource(R.string.deselect_all)
     val deselectAllDone = stringResource(R.string.deselect_all_done)
     val cancelLabel = stringResource(android.R.string.cancel)
+    val reorderListLabel = stringResource(R.string.reorder_list)
+    val reorderListHint = stringResource(R.string.reorder_list_hint)
+    val reorderDone = stringResource(R.string.reorder_done)
+    val resetOrderLabel = stringResource(R.string.reset_order)
+    val resetOrderDone = stringResource(R.string.reset_order_done)
+    val doneLabel = stringResource(R.string.done)
 
     AnimatedVisibility(
         visible = visible,
@@ -1512,58 +1643,113 @@ private fun MultiSelectBar(
             shadowElevation = 8.dp,
             tonalElevation = 4.dp
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                AnimatedContent(
-                    targetState = selectedCount,
-                    transitionSpec = MorpheAnimations.compactCounterTransitionSpec,
-                    label = "selected_count"
-                ) { count ->
-                    Text(
-                        text = "$count ${stringResource(R.string.selected).lowercase()}",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+            AnimatedContent(
+                targetState = effectiveReorderMode,
+                transitionSpec = MorpheAnimations.fadeCrossfade(200),
+                label = "multibar_mode"
+            ) { inReorder ->
+                if (inReorder) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = reorderListHint,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            ActionPillButton(
+                                onClick = withToast(resetOrderDone, onResetOrder),
+                                icon = Icons.Outlined.Restore,
+                                contentDescription = resetOrderLabel,
+                                tooltip = resetOrderLabel
+                            )
+                            ActionPillButton(
+                                onClick = onCancelReorder,
+                                icon = Icons.Outlined.Close,
+                                contentDescription = cancelLabel,
+                                tooltip = cancelLabel
+                            )
+                            ActionPillButton(
+                                onClick = withToast(reorderDone, onSaveOrder),
+                                icon = Icons.Outlined.Check,
+                                contentDescription = doneLabel,
+                                tooltip = doneLabel
+                            )
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        AnimatedContent(
+                            targetState = selectedCount,
+                            transitionSpec = MorpheAnimations.compactCounterTransitionSpec,
+                            label = "selected_count"
+                        ) { count ->
+                            Text(
+                                text = "$count ${stringResource(R.string.selected).lowercase()}",
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
 
-                Row(
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        ActionPillButton(
-                            onClick = withToast(selectAllDone, onSelectAll),
-                            icon = Icons.Outlined.DoneAll,
-                            contentDescription = selectAllLabel,
-                            tooltip = selectAllLabel,
-                            enabled = selectedCount < totalCount
-                        )
-                        ActionPillButton(
-                            onClick = withToast(deselectAllDone, onDeselectAll),
-                            icon = Icons.Outlined.RemoveDone,
-                            contentDescription = deselectAllLabel,
-                            tooltip = deselectAllLabel,
-                            enabled = selectedCount > 0
-                        )
-                        ActionPillButton(
-                            onClick = onCancel,
-                            icon = Icons.Outlined.Close,
-                            contentDescription = cancelLabel,
-                            tooltip = cancelLabel
-                        )
-                        ActionPillButton(
-                            onClick = withToast(actionContentDescription, onAction),
-                            icon = actionIcon,
-                            contentDescription = actionContentDescription,
-                            tooltip = actionContentDescription,
-                            enabled = selectedCount > 0,
-                            colors = actionColors
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            ActionPillButton(
+                                onClick = withToast(selectAllDone, onSelectAll),
+                                icon = Icons.Outlined.DoneAll,
+                                contentDescription = selectAllLabel,
+                                tooltip = selectAllLabel,
+                                enabled = selectedCount < totalCount,
+                                modifier = Modifier.weight(1f)
+                            )
+                            ActionPillButton(
+                                onClick = withToast(deselectAllDone, onDeselectAll),
+                                icon = Icons.Outlined.RemoveDone,
+                                contentDescription = deselectAllLabel,
+                                tooltip = deselectAllLabel,
+                                enabled = selectedCount > 0,
+                                modifier = Modifier.weight(1f)
+                            )
+                            ActionPillButton(
+                                onClick = onCancel,
+                                icon = Icons.Outlined.Close,
+                                contentDescription = cancelLabel,
+                                tooltip = cancelLabel,
+                                modifier = Modifier.weight(1f)
+                            )
+                            ActionPillButton(
+                                onClick = withToast(actionDoneMessage, onAction),
+                                icon = actionIcon,
+                                contentDescription = actionContentDescription,
+                                tooltip = actionContentDescription,
+                                enabled = selectedCount > 0,
+                                colors = actionColors,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+
+                        if (showReorderButton) {
+                            ActionPillButton(
+                                onClick = onEnterReorder,
+                                icon = Icons.Outlined.Reorder,
+                                contentDescription = reorderListLabel,
+                                tooltip = reorderListLabel,
+                                label = reorderListLabel,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
                     }
                 }
             }
@@ -2330,6 +2516,7 @@ internal fun HiddenAppsDialog(
     onShowPatches: (HomeAppItem) -> Unit,
     onDismiss: () -> Unit
 ) {
+    val itemSpacing = rememberWindowSize().itemSpacing
     val isMultiSelectMode = remember { mutableStateOf(false) }
     val selectedPackages = remember { mutableStateOf(emptySet<String>()) }
 
@@ -2387,6 +2574,7 @@ internal fun HiddenAppsDialog(
                     selectedCount = selectedPackages.value.size,
                     totalCount = hiddenAppItems.size,
                     visible = true,
+                    showReorderButton = false,
                     onSelectAll = {
                         selectedPackages.value = hiddenAppItems.map { it.packageName }.toSet()
                     },
@@ -2398,6 +2586,7 @@ internal fun HiddenAppsDialog(
                     },
                     actionIcon = Icons.Outlined.Visibility,
                     actionContentDescription = stringResource(R.string.unhide),
+                    actionDoneMessage = stringResource(R.string.unhide_done),
                     actionColors = IconButtonDefaults.filledTonalIconButtonColors(
                         containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                         contentColor = MaterialTheme.colorScheme.onTertiaryContainer
@@ -2405,7 +2594,11 @@ internal fun HiddenAppsDialog(
                     onCancel = {
                         isMultiSelectMode.value = false
                         selectedPackages.value = emptySet()
-                    }
+                    },
+                    onEnterReorder = {},
+                    onSaveOrder = {},
+                    onResetOrder = {},
+                    onCancelReorder = {}
                 )
             } else {
                 MorpheDialogOutlinedButton(
@@ -2426,7 +2619,7 @@ internal fun HiddenAppsDialog(
         } else {
             LazyColumn(
                 modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(itemSpacing)
             ) {
                 items(
                     items = hiddenAppItems,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/ActionPillButton.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/ActionPillButton.kt
@@ -29,15 +29,17 @@ fun ActionPillButton(
     val iconSize = if (large) 20.dp else 18.dp
     val textStyle = if (large) MaterialTheme.typography.labelLarge else MaterialTheme.typography.labelSmall
 
-    val button: @Composable () -> Unit = {
+    val buttonModifier = Modifier
+        .height(height)
+        .widthIn(min = minWidth)
+
+    val button: @Composable (Modifier) -> Unit = { outerModifier ->
         FilledTonalIconButton(
             onClick = onClick,
             enabled = enabled,
             colors = colors,
             shape = RoundedCornerShape(50),
-            modifier = modifier
-                .height(height)
-                .widthIn(min = minWidth)
+            modifier = outerModifier.then(buttonModifier)
         ) {
             if (label != null) {
                 Row(
@@ -59,7 +61,7 @@ fun ActionPillButton(
                 Icon(
                     imageVector = icon,
                     contentDescription = contentDescription,
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier.size(iconSize)
                 )
             }
         }
@@ -69,11 +71,12 @@ fun ActionPillButton(
         TooltipBox(
             positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
             tooltip = { PlainTooltip { Text(tooltip) } },
-            state = rememberTooltipState()
+            state = rememberTooltipState(),
+            modifier = modifier
         ) {
-            button()
+            button(modifier)
         }
     } else {
-        button()
+        button(modifier)
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1100,17 +1100,25 @@ class HomeViewModel(
     val bundleAppMetadataFlow: StateFlow<Map<String, BundleAppMetadata>> =
         patchBundleRepository.appMetadata
 
+    private val _homePrefsFlow = combine(
+        homeAppButtonPrefs.hiddenPackages,
+        homeAppButtonPrefs.customOrder,
+    ) { hidden, order -> Pair(hidden, order) }
+
     /**
-     * Combined flow that produces the sorted list of home app items.
-     *
-     * Sorting order by display name:
-     * 1. Patched (installed) apps first
-     * 2. Non-patched apps
-     * Hidden apps are excluded.
-     */
+    * Sorted list of visible and hidden home app items.
+    *
+    * Default sort order:
+    * 1. Patched (installed) apps first
+    * 2. Apps with isPinnedByDefault = true
+    * 3. All other apps, alphabetical
+    *
+    * If the user has saved a custom order it is applied on top of the default sort.
+    * Hidden apps are excluded from [HomeAppState.visible].
+    */
     val homeAppState: StateFlow<HomeAppState?> = combine(
         patchBundleRepository.bundleState,
-        homeAppButtonPrefs.hiddenPackages,
+        _homePrefsFlow,
         installedAppRepository.getAll().onEach { apps ->
             apps.forEach { app ->
                 appDataResolver.invalidate(app.currentPackageName)
@@ -1121,7 +1129,7 @@ class HomeViewModel(
         },
         _appUpdatesAvailable,
         _appStateTicker,
-    ) { bundleState, hiddenPackages, installedApps, updatesMap, _ ->
+    ) { bundleState, (hiddenPackages, customOrder), installedApps, updatesMap, _ ->
         val ready = bundleState as? PatchBundleRepository.BundleState.Ready
             ?: return@combine null
 
@@ -1176,12 +1184,18 @@ class HomeViewModel(
         val visiblePackages = packages.filter { it !in hiddenPackages }
         val visibleItems = ArrayList<HomeAppItem>(visiblePackages.size)
         for (pkg in visiblePackages) visibleItems.add(buildItem(pkg))
-        val visible = visibleItems.sortedWith(
+        val defaultSorted = visibleItems.sortedWith(
             compareByDescending<HomeAppItem> { it.installedApp != null }
                 .thenByDescending { it.isPinnedByDefault }
                 .thenByDescending { it.packageInfo != null }
                 .thenBy(String.CASE_INSENSITIVE_ORDER) { it.displayName }
         )
+        val visible = if (customOrder.isEmpty()) {
+            defaultSorted
+        } else {
+            val indexMap = customOrder.mapIndexed { i, pkg -> pkg to i }.toMap()
+            defaultSorted.sortedBy { indexMap[it.packageName] ?: Int.MAX_VALUE }
+        }
 
         val hiddenItems = ArrayList<HomeAppItem>(activeHidden.size)
         for (pkg in activeHidden) hiddenItems.add(buildItem(pkg))
@@ -1244,6 +1258,14 @@ class HomeViewModel(
      */
     fun getBundleDisplayName(uid: Int): String? =
         allBundlesInfoState.value[uid]?.name
+
+    fun saveAppOrder(packageNames: List<String>) {
+        homeAppButtonPrefs.saveOrder(packageNames)
+    }
+
+    fun resetAppOrder() {
+        homeAppButtonPrefs.resetOrder()
+    }
 
     /**
      * Hide an app from the home screen.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -849,6 +849,11 @@ The image dimensions must be as follows:
     <string name="select_all_done">All selected</string>
     <string name="deselect_all">Deselect all</string>
     <string name="deselect_all_done">All deselected</string>
+    <string name="reorder_list">Reorder list</string>
+    <string name="reorder_list_hint">Drag to reorder</string>
+    <string name="reorder_done">Order saved</string>
+    <string name="reset_order">Reset order</string>
+    <string name="reset_order_done">Order reset</string>
     <string name="rename">Rename</string>
     <string name="import_">Import</string>
     <string name="export">Export</string>
@@ -883,6 +888,7 @@ The image dimensions must be as follows:
     <string name="hide">Hide</string>
     <string name="hidden">Hidden</string>
     <string name="unhide">Unhide</string>
+    <string name="unhide_done">Shown</string>
     <string name="logs">Logs</string>
     <string name="sources">Sources</string>
     <string name="installing_ellipsis">Installing…</string>


### PR DESCRIPTION
Adds a reorder mode accessible from the multiselect bar (long-press any app card) via a  `Reorder list` button. Users can drag app cards by their handle to set a custom order, which is persisted and applied on top of the default sort; the order can be reset to default at any time.
___
![Screenshot_2026-06-16-17-20-28-522_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/093a0cfe-5b10-4b45-a0e5-e1931a88a469)

