### PR TITLE
fix: Prevent text compression in headers on tablet portrait

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -326,7 +326,7 @@ fun InstalledAppInfoDialog(
                                 packageName = packageName,
                                 installedApp = installedApp,
                                 accentColor = appAccentColor,
-                                compact = true,
+                                compact = windowSize.widthSizeClass == WindowWidthSizeClass.Expanded,
                                 modifier = Modifier.clip(RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp))
                             )
                         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/patcher/ExpertPatchingProgress.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/patcher/ExpertPatchingProgress.kt
@@ -419,7 +419,10 @@ private fun ExpertProgressHeader(
                 text = stringResource(R.string.patching_app),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onBackground
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false)
             )
 
             PercentageBadge(progress = progress)


### PR DESCRIPTION
## Summary
Fixed layout issues where app name and step name text were being 
squeezed/compressed on tablet portrait (medium-width) screens.

The fix makes both layouts responsive: on wide screens (≥840dp) 
the original inline layout is preserved; on medium/narrow screens 
the secondary elements move below the primary text.

## Changes

### `app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt`
- Replaced hard-coded `compact = true` with `compact = windowSize.widthSizeClass == WindowWidthSizeClass.Expanded` when calling `AppHeroHeader` in the tablet (two-column) layout.
- **Effect:** the install-type chip and patch-date chip now move from the right side of the app name to a row below it on tablet portrait (600–840dp). The app name gets the full available width and is no longer compressed into a vertical letter-by-letter layout.

### `app/src/main/java/app/morphe/manager/ui/screen/patcher/ExpertPatchingProgress.kt`
- Added `maxLines = 1`, `overflow = TextOverflow.Ellipsis`, and `Modifier.weight(1f, fill = false)` to the "Patching app" title in `ExpertProgressHeader`.
- **Effect:** the percentage badge keeps its intrinsic width instead of being squeezed by the title text. Long localized titles are truncated with ellipsis rather than wrapping or breaking the layout.


<details>
  <summary>Screenshots before</summary>
  <img width="800" height="1280" alt="photo_2026-06-18 22 02 14" src="https://github.com/user-attachments/assets/5f3b12d2-0f8a-4ebd-870a-da3e70708858" />
<img width="800" height="1280" alt="photo_2026-06-18 22 02 16" src="https://github.com/user-attachments/assets/f1dd82cb-bcfa-4810-ab53-51f9cc9c4d60" />  
</details>

<details>
  <summary>Screenshots after</summary>
<img width="800" height="1280" alt="photo_2026-06-18 22 02 12" src="https://github.com/user-attachments/assets/72bab31b-699c-4028-9686-a5a270f5e903" />
<img width="800" height="1280" alt="photo_2026-06-18 22 02 18" src="https://github.com/user-attachments/assets/8fddae41-34b8-4661-b068-a12dc1f24462" />
</details>