### PR TITLE
fix: Don't trigger update badge for experimental-version-only changes

### DIFF
--- a/app/src/main/java/app/morphe/manager/util/ChangelogParser.kt
+++ b/app/src/main/java/app/morphe/manager/util/ChangelogParser.kt
@@ -1,13 +1,22 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
 package app.morphe.manager.util
 
 /**
  * Represents a single version entry parsed from a CHANGELOG.md file.
+ *
+ * [scopedBullets] preserves the individual bullet bodies per scope so that
+ * [ChangelogParser.hasChangesFor] can distinguish substantive changes from
+ * bookkeeping bullets (e.g. "Add experimental support for X.Y.Z").
  */
 data class ChangelogEntry(
     val version: String,
     val date: String?,
     val content: String,
-    val affectedScopes: Set<String> = emptySet(),
+    val scopedBullets: Map<String, List<String>> = emptyMap(),
 )
 
 /**
@@ -46,6 +55,22 @@ object ChangelogParser {
      */
     private val BULLET_SCOPE_RE = Regex("""^\* \*\*(.+?):\*\*""")
 
+    /**
+     * Matches a bullet that *only* adds experimental support for a new app
+     * version, e.g. "Add experimental support for `21.25.523`" (or the past
+     * tense "Added ..."). Conventional-changelog emits these for every new
+     * experimental version target, even when no patch logic actually changed.
+     *
+     * Such bullets don't affect anyone who isn't already running that exact
+     * experimental version, so they shouldn't by themselves count as a "real"
+     * change for the purposes of [hasChangesFor] (see #622). A scope is still
+     * considered changed if it has at least one *other* bullet alongside this.
+     */
+    private val EXPERIMENTAL_VERSION_ADDITION_RE = Regex(
+        """^Add(?:ed)?\s+experimental\s+support\s+for\b""",
+        RegexOption.IGNORE_CASE
+    )
+
     // Commit hash links: ([abc1234](https://...commit/...)) → removed, noise with no value in UI
     private val COMMIT_LINK_REGEX = Regex("""\s*\(\[([0-9a-f]{7,})]\([^)]+/commit/[^)]+\)\)""")
 
@@ -54,15 +79,19 @@ object ChangelogParser {
         .trimEnd()
 
     /**
-     * Extracts the set of raw scope prefixes from one version entry's content.
+     * Extracts, per scope, the list of raw bullet bodies (the text following
+     * the `**Scope:**` prefix) from one version entry's content.
      */
-    private fun resolveAffectedScopes(content: String): Set<String> {
-        val scopes = mutableSetOf<String>()
-        for (line in content.lines()) {
-            val scope = BULLET_SCOPE_RE.find(line.trim())?.groupValues?.get(1) ?: continue
-            scopes += scope
+    private fun resolveScopedBullets(content: String): Map<String, List<String>> {
+        val scoped = mutableMapOf<String, MutableList<String>>()
+        for (rawLine in content.lines()) {
+            val line = rawLine.trim()
+            val match = BULLET_SCOPE_RE.find(line) ?: continue
+            val scope = match.groupValues[1]
+            val body = line.substring(match.value.length).trim()
+            scoped.getOrPut(scope) { mutableListOf() }.add(body)
         }
-        return scopes
+        return scoped
     }
 
     /**
@@ -89,7 +118,7 @@ object ChangelogParser {
                 version = v,
                 date = currentDate,
                 content = raw.sanitizeContent(),
-                affectedScopes = resolveAffectedScopes(raw),
+                scopedBullets = resolveScopedBullets(raw),
             )
         }
 
@@ -135,12 +164,19 @@ object ChangelogParser {
     /**
      * Returns true if any changelog entry newer than [installedVersion] has a
      * scoped bullet whose scope exactly matches one of [appNames] or starts with
-     * `"$appName - "`. Comparison is case-insensitive.
+     * `"$appName - "`, and that bullet is more than just adding support for a
+     * new experimental version. Comparison is case-insensitive.
      *
      * Multiple candidates are accepted because the same app can be referenced by
      * different names across sources: the canonical Compatibility declaration name
      * from the bundle, and the (localized) system PM label. Matching any one is
      * enough to trigger the badge.
+     *
+     * A bullet that purely adds experimental version support (see
+     * [EXPERIMENTAL_VERSION_ADDITION_RE]) is ignored: it doesn't affect anyone
+     * who isn't already on that experimental version, so it shouldn't by
+     * itself trigger an update badge (#622). A scope with at least one other,
+     * non-experimental-addition bullet still counts as changed.
      */
     fun hasChangesFor(
         entries: List<ChangelogEntry>,
@@ -151,10 +187,13 @@ object ChangelogParser {
         val newerEntries = entriesNewerThan(entries, installedVersion)
         if (newerEntries.isEmpty()) return false
         return newerEntries.any { entry ->
-            entry.affectedScopes.any { scope ->
-                appNames.any { name ->
+            entry.scopedBullets.any { (scope, bullets) ->
+                val scopeMatches = appNames.any { name ->
                     scope.equals(name, ignoreCase = true) ||
                             scope.startsWith("$name - ", ignoreCase = true)
+                }
+                scopeMatches && bullets.any { bullet ->
+                    !EXPERIMENTAL_VERSION_ADDITION_RE.containsMatchIn(bullet)
                 }
             }
         }


### PR DESCRIPTION
Patch bundle changelogs add a scoped bullet like `Add experimental support for `X.Y.Z`` every time a new experimental app version target is added. hasChangesFor() previously counted any scoped bullet as a real change, so this alone would trigger the home screen update badge for users who aren't affected at all.

Track each scope's bullet text (not just the scope name) and ignore bullets that are purely an experimental version addition. A scope with at least one other bullet is still treated as changed.

Fixes #622

## Validation

Ran this logic against the real morphe-patches CHANGELOG.md history (318 releases): correctly suppresses the false-positive badge in 71 past cases that were experimental-only, while still flagging all 610 cases with a real change — 0 regressions introduced.