### PR TITLE
feat: Add `Show older releases` expander to changelog dialogs

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
@@ -170,6 +170,13 @@ sealed class RemotePatchBundle(
         }
     }
 
+    /**
+     * Full stable history from `main`, ignoring `stopAfterFirstStable`. Older history
+     * consists of stable releases by definition, so we always fetch from `main`.
+     * Cached separately from [fetchChangelogEntries] with the `|full` suffix.
+     */
+    open suspend fun fetchFullChangelogEntries(): List<ChangelogEntry> = emptyList()
+
     fun clearChangelogCache() {
         val assetKey = "$uid|$endpoint"
         changelogCacheMutex.tryLock()
@@ -383,6 +390,15 @@ class JsonPatchBundle(
         }
     }
 
+    override suspend fun fetchFullChangelogEntries(): List<ChangelogEntry> {
+        val api: MorpheAPI by inject()
+        val stableEndpoint = switchBranchInUrl(endpoint, BRANCH_STABLE)
+        val changelogUrl = api.changelogUrlFromBundleEndpoint(stableEndpoint) ?: return emptyList()
+        return fetchAndCacheEntries("$uid|$changelogUrl|full", sinceVersion = null) {
+            api.fetchChangelogFromUrl(changelogUrl, stopAfterFirstStable = false)
+        }
+    }
+
     override fun copy(
         error: Throwable?,
         name: String,
@@ -465,6 +481,11 @@ class APIPatchBundle(
             api.fetchPatchesChangelog(branch, stopAfterFirstStable = usePrerelease)
         }
     }
+
+    override suspend fun fetchFullChangelogEntries(): List<ChangelogEntry> =
+        fetchAndCacheEntries("$uid|$BRANCH_STABLE|full", sinceVersion = null) {
+            api.fetchPatchesChangelog(BRANCH_STABLE, stopAfterFirstStable = false)
+        }
 
     override fun copy(
         error: Throwable?,

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -44,10 +44,7 @@ import app.morphe.manager.ui.screen.home.GlobalOnboardingState
 import app.morphe.manager.ui.screen.settings.AdvancedTabContent
 import app.morphe.manager.ui.screen.settings.AppearanceTabContent
 import app.morphe.manager.ui.screen.settings.SystemTabContent
-import app.morphe.manager.ui.screen.settings.system.AboutDialog
-import app.morphe.manager.ui.screen.settings.system.ChangelogDialog
-import app.morphe.manager.ui.screen.settings.system.InstallerSelectionDialogContainer
-import app.morphe.manager.ui.screen.settings.system.KeystoreCredentialsDialog
+import app.morphe.manager.ui.screen.settings.system.*
 import app.morphe.manager.ui.screen.shared.MorpheAnimations
 import app.morphe.manager.ui.screen.shared.isLandscape
 import app.morphe.manager.ui.viewmodel.*

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
@@ -291,21 +291,20 @@ fun ManagerUpdateDetailsDialog(
                             items = entries,
                             key = { index, _ -> "missed_$index" }
                         ) { index, entry ->
-                            Column(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalArrangement = Arrangement.spacedBy(20.dp)
-                            ) {
-                                if (index > 0) {
-                                    HorizontalDivider(
-                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-                                    )
-                                }
-                                ChangelogEntrySection(
-                                    entry = entry,
-                                    headerIcon = Icons.Outlined.NewReleases,
-                                    textColor = textColor
+                            if (index > 0) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(
+                                        top = MorpheDefaults.ContentPaddingSmall,
+                                        bottom = MorpheDefaults.ContentPadding
+                                    ),
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
                                 )
                             }
+                            ChangelogEntrySection(
+                                entry = entry,
+                                headerIcon = Icons.Outlined.NewReleases,
+                                textColor = textColor
+                            )
                         }
                         changelogOlderItems(
                             entries = updateViewModel.olderManagerEntries,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
@@ -6,6 +6,8 @@
 package app.morphe.manager.ui.screen.home
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -53,6 +55,11 @@ fun ManagerUpdateDetailsDialog(
         }
     }
 
+    // Collapse "Show older releases" when the dialog closes so it reopens fresh next time
+    DisposableEffect(Unit) {
+        onDispose { updateViewModel.resetOlderManagerEntries() }
+    }
+
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(
@@ -65,6 +72,7 @@ fun ManagerUpdateDetailsDialog(
                 UpdateViewModel.State.SUCCESS -> R.string.update_completed
             }
         ),
+        scrollable = false,
         footer = {
             when (state) {
                 UpdateViewModel.State.CAN_DOWNLOAD -> {
@@ -170,12 +178,9 @@ fun ManagerUpdateDetailsDialog(
         val textColor = LocalDialogTextColor.current
         val secondaryColor = LocalDialogSecondaryTextColor.current
 
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
             when (state) {
-                UpdateViewModel.State.DOWNLOADING -> {
+                UpdateViewModel.State.DOWNLOADING -> item("download_progress") {
                     DownloadProgressSection(
                         downloadedSize = updateViewModel.downloadedSize,
                         totalSize = updateViewModel.totalSize,
@@ -184,8 +189,9 @@ fun ManagerUpdateDetailsDialog(
                     )
                 }
 
-                UpdateViewModel.State.INSTALLING -> {
+                UpdateViewModel.State.INSTALLING -> item("installing") {
                     Column(
+                        modifier = Modifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(20.dp)
                     ) {
@@ -200,7 +206,7 @@ fun ManagerUpdateDetailsDialog(
                 }
 
                 UpdateViewModel.State.FAILED -> {
-                    if (updateViewModel.installError.isNotEmpty()) {
+                    if (updateViewModel.installError.isNotEmpty()) item("failed_error") {
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
                             shape = RoundedCornerShape(16.dp),
@@ -239,7 +245,7 @@ fun ManagerUpdateDetailsDialog(
                     }
                 }
 
-                UpdateViewModel.State.SUCCESS -> {
+                UpdateViewModel.State.SUCCESS -> item("success") {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -279,18 +285,46 @@ fun ManagerUpdateDetailsDialog(
                 UpdateViewModel.State.CAN_DOWNLOAD, UpdateViewModel.State.CAN_INSTALL -> {
                     val entries = updateViewModel.missedChangelogEntries
                     if (entries == null) {
-                        // Shimmer loading state
-                        ChangelogSectionLoading()
+                        item("missed_loading") { ChangelogSectionLoading() }
                     } else {
-                        ChangelogEntriesList(
-                            entries = entries,
-                            headerIcon = Icons.Outlined.NewReleases,
+                        itemsIndexed(
+                            items = entries,
+                            key = { index, _ -> "missed_$index" }
+                        ) { index, entry ->
+                            Column(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalArrangement = Arrangement.spacedBy(20.dp)
+                            ) {
+                                if (index > 0) {
+                                    HorizontalDivider(
+                                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+                                    )
+                                }
+                                ChangelogEntrySection(
+                                    entry = entry,
+                                    headerIcon = Icons.Outlined.NewReleases,
+                                    textColor = textColor
+                                )
+                            }
+                        }
+                        changelogOlderItems(
+                            entries = updateViewModel.olderManagerEntries,
+                            isLoading = updateViewModel.isLoadingOlderEntries,
+                            onExpand = {
+                                updateViewModel.loadOlderManagerEntries(
+                                    exclude = entries.map { it.version }.toSet()
+                                )
+                            },
                             textColor = textColor
                         )
                     }
                 }
             }
         }
+    }
+
+    MorpheOverlay(visible = updateViewModel.isLoadingOlderEntries) {
+        PulsingLogoIndicator()
     }
 
     // Internet check dialog

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -56,14 +56,14 @@ import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.*
-import com.mikepenz.markdown.model.parseMarkdownFlow
 import compose.icons.FontAwesomeIcons
 import compose.icons.fontawesomeicons.Brands
 import compose.icons.fontawesomeicons.brands.Github
 import compose.icons.fontawesomeicons.brands.Gitlab
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import com.mikepenz.markdown.model.State as MarkdownRenderState
 
@@ -1140,6 +1140,8 @@ fun BundleChangelogDialog(
     onDismissRequest: () -> Unit
 ) {
     var state: BundleChangelogState by remember { mutableStateOf(BundleChangelogState.Loading) }
+    var olderState: OlderBundleState by remember { mutableStateOf(OlderBundleState.Collapsed) }
+    val scope = rememberCoroutineScope()
     // 0 = waiting for dialog enter; incremented to trigger fetch, again on retry
     var fetchTrigger by remember { mutableIntStateOf(0) }
 
@@ -1183,7 +1185,7 @@ fun BundleChangelogDialog(
                 if (entries.isNotEmpty()) {
                     BundleChangelogState.Entries(
                         entries = entries,
-                        parsedMarkdown = preParseEntries(entries),
+                        parsedMarkdown = preParseChangelogEntries(entries),
                         latestPageUrl = latestPageUrl
                     )
                 } else {
@@ -1198,12 +1200,39 @@ fun BundleChangelogDialog(
                     )
                     BundleChangelogState.Entries(
                         entries = fallbackEntries,
-                        parsedMarkdown = preParseEntries(fallbackEntries),
+                        parsedMarkdown = preParseChangelogEntries(fallbackEntries),
                         latestPageUrl = asset.pageUrl
                     )
                 }
             } catch (t: Throwable) {
                 BundleChangelogState.Error(t)
+            }
+        }
+    }
+
+    val loadOlder: () -> Unit = load@{
+        if (olderState !is OlderBundleState.Collapsed) return@load
+        val shownVersions = (state as? BundleChangelogState.Entries)
+            ?.entries
+            ?.map { it.version.removePrefix("v").trim() }
+            ?.toSet()
+            .orEmpty()
+        olderState = OlderBundleState.Loading
+        scope.launch {
+            olderState = withContext(Dispatchers.Default) {
+                runCatching {
+                    val all = src.fetchFullChangelogEntries()
+                    val filtered = all.filter {
+                        // Skip versions already shown above and any pre-release leftovers;
+                        // history is meaningful only as the stable timeline
+                        it.version.removePrefix("v").trim() !in shownVersions
+                                && !it.version.contains("-")
+                    }
+                    OlderBundleState.Loaded(filtered)
+                }.getOrElse {
+                    // Surface failure as collapsed so a retry click re-triggers the fetch
+                    OlderBundleState.Collapsed
+                }
             }
         }
     }
@@ -1239,7 +1268,7 @@ fun BundleChangelogDialog(
                 is BundleChangelogState.Error -> {
                     MorpheDialogButtonColumn {
                         MorpheDialogButton(
-                            text = stringResource(R.string.changelog_retry),
+                            text = stringResource(R.string.retry),
                             onClick = { fetchTrigger++ },
                             modifier = Modifier.fillMaxWidth()
                         )
@@ -1260,12 +1289,24 @@ fun BundleChangelogDialog(
             }
         }
     ) {
-        BundleChangelogContent(state)
+        BundleChangelogContent(
+            state = state,
+            olderState = olderState,
+            onExpandOlder = loadOlder
+        )
+    }
+
+    MorpheOverlay(visible = olderState is OlderBundleState.Loading) {
+        PulsingLogoIndicator()
     }
 }
 
 @Composable
-private fun BundleChangelogContent(state: BundleChangelogState) {
+private fun BundleChangelogContent(
+    state: BundleChangelogState,
+    olderState: OlderBundleState,
+    onExpandOlder: () -> Unit,
+) {
     Crossfade(
         targetState = state,
         animationSpec = tween(MorpheDefaults.ANIMATION_DURATION),
@@ -1300,6 +1341,12 @@ private fun BundleChangelogContent(state: BundleChangelogState) {
                                 precomputedMarkdown = current.parsedMarkdown.getOrNull(index)
                             )
                         }
+                        changelogOlderItems(
+                            entries = (olderState as? OlderBundleState.Loaded)?.entries,
+                            isLoading = olderState is OlderBundleState.Loading,
+                            onExpand = onExpandOlder,
+                            textColor = textColor
+                        )
                     }
                 }
             }
@@ -1362,18 +1409,12 @@ private sealed interface BundleChangelogState {
     data class Error(val throwable: Throwable) : BundleChangelogState
 }
 
-private suspend fun preParseEntries(entries: List<ChangelogEntry>): List<MarkdownRenderState?> =
-    coroutineScope {
-        entries.map { entry ->
-            async {
-                if (entry.content.isBlank()) null
-                else runCatching {
-                    parseMarkdownFlow(entry.content.trimIndent())
-                        .first { it !is MarkdownRenderState.Loading }
-                }.getOrNull()
-            }
-        }.awaitAll()
-    }
+private sealed interface OlderBundleState {
+    data object Collapsed : OlderBundleState
+    data object Loading : OlderBundleState
+    /** [entries] are full-history stable entries, already filtered to exclude what's shown above. */
+    data class Loaded(val entries: List<ChangelogEntry>) : OlderBundleState
+}
 
 private val doubleBracketLinkRegex = Regex("""\[\[([^]]+)]\(([^)]+)\)]""")
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -1330,7 +1330,10 @@ private fun BundleChangelogContent(
                         itemsIndexed(current.entries) { index, entry ->
                             if (index > 0) {
                                 HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = 20.dp),
+                                    modifier = Modifier.padding(
+                                        top = MorpheDefaults.ContentPaddingSmall,
+                                        bottom = MorpheDefaults.ContentPadding
+                                    ),
                                     color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
                                 )
                             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ChangelogDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ChangelogDialog.kt
@@ -6,12 +6,15 @@
 package app.morphe.manager.ui.screen.settings.system
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import app.morphe.manager.BuildConfig
 import app.morphe.manager.R
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.UpdateViewModel
@@ -20,7 +23,8 @@ import app.morphe.manager.util.releasePageUrl
 
 /**
  * Changelog dialog.
- * Displays the changelog for currently installed manager version.
+ * Displays the changelog for the currently installed manager version, with an optional
+ * "Show older releases" expander that lazy-loads the rest of the history below.
  */
 @Composable
 fun ChangelogDialog(
@@ -29,15 +33,19 @@ fun ChangelogDialog(
 ) {
     val textColor = LocalDialogTextColor.current
     val entry = updateViewModel.currentVersionChangelogEntry
+    val installedVersion = BuildConfig.VERSION_NAME.removePrefix("v")
 
-    // Load current version changelog when dialog opens
     LaunchedEffect(Unit) {
         updateViewModel.loadCurrentVersionChangelog()
+    }
+    DisposableEffect(Unit) {
+        onDispose { updateViewModel.resetOlderManagerEntries() }
     }
 
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.changelog),
+        scrollable = false,
         footer = {
             MorpheDialogButtonColumn {
                 ChangelogButton(
@@ -52,14 +60,30 @@ fun ChangelogDialog(
             }
         }
     ) {
-        if (entry == null) {
-            ChangelogSectionLoading()
-        } else {
-            ChangelogEntrySection(
-                entry = entry,
-                headerIcon = Icons.Outlined.NewReleases,
-                textColor = textColor
-            )
+        LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            if (entry == null) {
+                item("changelog_loading") { ChangelogSectionLoading() }
+            } else {
+                item("changelog_installed_${entry.version}") {
+                    ChangelogEntrySection(
+                        entry = entry,
+                        headerIcon = Icons.Outlined.NewReleases,
+                        textColor = textColor
+                    )
+                }
+                changelogOlderItems(
+                    entries = updateViewModel.olderManagerEntries,
+                    isLoading = updateViewModel.isLoadingOlderEntries,
+                    onExpand = {
+                        updateViewModel.loadOlderManagerEntries(exclude = setOf(installedVersion))
+                    },
+                    textColor = textColor
+                )
+            }
         }
+    }
+
+    MorpheOverlay(visible = updateViewModel.isLoadingOlderEntries) {
+        PulsingLogoIndicator()
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogOlderReleasesExpander.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogOlderReleasesExpander.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import app.morphe.manager.util.ChangelogEntry
+
+/**
+ * Adds a "Show older releases" section to a [LazyListScope].
+ *
+ * Emits items into the caller's `LazyColumn` so each entry composes only when scrolled
+ * into view. Markdown bodies render via their built-in async loading state, so the main
+ * thread is never blocked parsing many entries up front.
+ */
+fun LazyListScope.changelogOlderItems(
+    entries: List<ChangelogEntry>?,
+    isLoading: Boolean,
+    onExpand: () -> Unit,
+    textColor: Color,
+) {
+    item("changelog_older_divider") {
+        HorizontalDivider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 20.dp),
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+        )
+    }
+
+    when {
+        entries == null -> item("changelog_older_button") {
+            MorpheDialogOutlinedButton(
+                text = stringResource(R.string.changelog_show_older),
+                onClick = onExpand,
+                icon = Icons.Outlined.History,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        entries.isEmpty() -> item("changelog_older_empty") {
+            Text(
+                text = stringResource(R.string.changelog_older_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        else -> itemsIndexed(
+            items = entries,
+            key = { index, _ -> "changelog_older_$index" }
+        ) { index, entry ->
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                if (index > 0) {
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+                    )
+                }
+                ChangelogEntrySection(
+                    entry = entry,
+                    headerIcon = Icons.Outlined.History,
+                    textColor = textColor
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogOlderReleasesExpander.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogOlderReleasesExpander.kt
@@ -5,8 +5,6 @@
 
 package app.morphe.manager.ui.screen.shared
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
@@ -19,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
 import app.morphe.manager.util.ChangelogEntry
 
@@ -40,7 +37,10 @@ fun LazyListScope.changelogOlderItems(
         HorizontalDivider(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(vertical = 20.dp),
+                .padding(
+                    top = MorpheDefaults.ContentPaddingSmall,
+                    bottom = MorpheDefaults.ContentPadding
+                ),
             color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
         )
     }
@@ -67,21 +67,20 @@ fun LazyListScope.changelogOlderItems(
             items = entries,
             key = { index, _ -> "changelog_older_$index" }
         ) { index, entry ->
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(20.dp)
-            ) {
-                if (index > 0) {
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-                    )
-                }
-                ChangelogEntrySection(
-                    entry = entry,
-                    headerIcon = Icons.Outlined.History,
-                    textColor = textColor
+            if (index > 0) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(
+                        top = MorpheDefaults.ContentPaddingSmall,
+                        bottom = MorpheDefaults.ContentPadding
+                    ),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
                 )
             }
+            ChangelogEntrySection(
+                entry = entry,
+                headerIcon = Icons.Outlined.History,
+                textColor = textColor
+            )
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/ChangelogSection.kt
@@ -60,7 +60,7 @@ fun ChangelogSectionLoading(
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
     ) {
         // Header shimmer
         ShimmerChangelogHeader()
@@ -82,7 +82,7 @@ fun ChangelogEntrySection(
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
     ) {
         ChangelogEntryHeader(
             version = entry.version,
@@ -92,47 +92,6 @@ fun ChangelogEntrySection(
         )
         if (entry.content.isNotBlank()) {
             Changelog(markdown = entry.content, precomputedState = precomputedMarkdown)
-        }
-    }
-}
-
-/**
- * Displays a list of [ChangelogEntry] items, separated by dividers.
- */
-@Composable
-fun ChangelogEntriesList(
-    entries: List<ChangelogEntry>,
-    headerIcon: ImageVector = Icons.Outlined.NewReleases,
-    emptyText: String? = null,
-    textColor: Color = LocalDialogTextColor.current
-) {
-    if (entries.isEmpty()) {
-        if (emptyText != null) {
-            Text(
-                text = emptyText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
-        return
-    }
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
-    ) {
-        entries.forEachIndexed { index, entry ->
-            if (index > 0) {
-                HorizontalDivider(
-                    modifier = Modifier.padding(vertical = 20.dp),
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
-                )
-            }
-            ChangelogEntrySection(
-                entry = entry,
-                headerIcon = headerIcon,
-                textColor = textColor
-            )
         }
     }
 }
@@ -208,7 +167,7 @@ private fun ChangelogEntryHeader(
 }
 
 /**
- * Renders sanitized changelog markdown.
+ * Renders sanitized changelog Markdown.
  */
 @Composable
 fun Changelog(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
@@ -45,6 +45,7 @@ object MorpheDefaults {
     val SettingsCornerRadius = 14.dp
     val SectionCornerRadius = 18.dp
     val IconSize = 24.dp
+    val ContentPaddingSmall = 8.dp
     val ContentPadding = 16.dp
     val ContentPaddingMedium = 24.dp
     val ContentPaddingExpanded = 32.dp

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/UpdateViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/UpdateViewModel.kt
@@ -11,7 +11,10 @@ import app.morphe.manager.BuildConfig
 import app.morphe.manager.R
 import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.platform.NetworkInfo
-import app.morphe.manager.domain.installer.*
+import app.morphe.manager.domain.installer.InstallCancelledException
+import app.morphe.manager.domain.installer.InstallResult
+import app.morphe.manager.domain.installer.InstallerManager
+import app.morphe.manager.domain.installer.SessionInstaller
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.network.api.MorpheAPI
 import app.morphe.manager.network.dto.MorpheAsset
@@ -19,10 +22,10 @@ import app.morphe.manager.network.service.HttpService
 import app.morphe.manager.util.*
 import io.ktor.client.plugins.onDownload
 import io.ktor.client.request.url
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.*
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import kotlin.time.Duration.Companion.seconds
 
 class UpdateViewModel(
     private val downloadOnScreenEntry: Boolean,
@@ -66,6 +69,17 @@ class UpdateViewModel(
     // All changelog entries newer than the currently installed version (shown in update dialog)
     var missedChangelogEntries: List<ChangelogEntry>? by mutableStateOf(null)
         private set
+
+    // Older changelog entries loaded on-demand by the "Show older releases" expander.
+    // Reset on dialog dismiss so the expander reopens in a collapsed state next time
+    var olderManagerEntries: List<ChangelogEntry>? by mutableStateOf(null)
+        private set
+    var isLoadingOlderEntries by mutableStateOf(false)
+        private set
+
+    // Parsed CHANGELOG.md per branch (false = main, true = dev). Shared across all loaders
+    // and the older-entries expander to avoid duplicate fetches inside one VM lifetime
+    private val managerEntriesCache = mutableMapOf<Boolean, List<ChangelogEntry>>()
 
     var canResumeDownload by mutableStateOf(false)
         private set
@@ -345,7 +359,9 @@ class UpdateViewModel(
             // is available and its changelog lives on the dev branch
             val targetIsPrerelease = releaseInfo?.version?.contains('-') == true
             val forDevBranch = morpheAPI.isDevBuild || targetIsPrerelease
-            val entries = morpheAPI.fetchManagerChangelog(forDevBranch = forDevBranch)
+            val entries = managerEntriesCache.getOrPut(forDevBranch) {
+                morpheAPI.fetchManagerChangelog(forDevBranch = forDevBranch)
+            }
             val newer = ChangelogParser.entriesNewerThan(entries, installedVersion)
             // Strip pre-release entries when on stable channel - main CHANGELOG.md
             // contains merged pre-release entries that stable users should not see
@@ -361,9 +377,40 @@ class UpdateViewModel(
     fun loadCurrentVersionChangelog() = viewModelScope.launch {
         uiSafe(app, R.string.download_manager_failed, "Failed to load changelog") {
             val currentVersion = BuildConfig.VERSION_NAME.removePrefix("v")
-            val entries = morpheAPI.fetchManagerChangelog()
+            val entries = managerEntriesCache.getOrPut(morpheAPI.isDevBuild) {
+                morpheAPI.fetchManagerChangelog()
+            }
             currentVersionChangelogEntry = ChangelogParser.findVersion(entries, currentVersion)
         }
+    }
+
+    /**
+     * Loads older stable changelog entries on demand, dropping versions in [exclude].
+     * Always reads from main; older history is the stable release timeline by definition,
+     * regardless of which channel the user is currently on.
+     * Idempotent: repeat calls while loading or after a successful load are a no-op.
+     */
+    fun loadOlderManagerEntries(exclude: Set<String>) {
+        if (isLoadingOlderEntries || olderManagerEntries != null) return
+        isLoadingOlderEntries = true
+        viewModelScope.launch(Dispatchers.Default) {
+            uiSafe(app, R.string.download_manager_failed, "Failed to load older releases") {
+                val entries = managerEntriesCache.getOrPut(false) {
+                    morpheAPI.fetchManagerChangelog(forDevBranch = false)
+                }
+                val normalize = { v: String -> v.removePrefix("v").trim() }
+                val excludeNorm = exclude.map(normalize).toSet()
+                olderManagerEntries = entries.filter {
+                    normalize(it.version) !in excludeNorm && !it.version.contains('-')
+                }
+            }
+            isLoadingOlderEntries = false
+        }
+    }
+
+    fun resetOlderManagerEntries() {
+        olderManagerEntries = null
+        isLoadingOlderEntries = false
     }
 
     companion object {

--- a/app/src/main/java/app/morphe/manager/util/ChangelogPreParser.kt
+++ b/app/src/main/java/app/morphe/manager/util/ChangelogPreParser.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.util
+
+import com.mikepenz.markdown.model.parseMarkdownFlow
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import com.mikepenz.markdown.model.State as MarkdownRenderState
+
+/**
+ * Pre-parses Markdown content of each entry in parallel.
+ *
+ * Returns a list whose i-th element is the parsed state for `entries[i]`, or `null`
+ * for blank/failed entries. Pass the result into `ChangelogEntrySection`'s
+ * `precomputedMarkdown` slot to skip per-render Markdown parsing, which would
+ * otherwise block the main thread when rendering many entries at once.
+ */
+suspend fun preParseChangelogEntries(entries: List<ChangelogEntry>): List<MarkdownRenderState?> =
+    coroutineScope {
+        entries.map { entry ->
+            async {
+                if (entry.content.isBlank()) null
+                else runCatching {
+                    parseMarkdownFlow(entry.content.trimIndent())
+                        .first { it !is MarkdownRenderState.Loading }
+                }.getOrNull()
+            }
+        }.awaitAll()
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -908,8 +908,9 @@ The image dimensions must be as follows:
     <string name="changelog">View changelogs</string>
     <string name="changelog_description">Check out the latest changes in this update</string>
     <string name="changelog_download_fail">Failed to download changelog: %s</string>
-    <string name="changelog_retry">Retry</string>
     <string name="changelog_empty">No changelog available</string>
+    <string name="changelog_show_older">Show older releases</string>
+    <string name="changelog_older_empty">No older releases to show</string>
     <string name="no_network_toast">No internet connection available</string>
 
     <string name="update_available">An update is available</string>


### PR DESCRIPTION
## Summary
- Adds a collapsible `Show older releases` section at the end of three places so can browse past releases without leaving the app.
- Default behavior is unchanged (installed version / missed entries shown first); older releases are only fetched when tap the button.
- Renders the older list lazily via `LazyColumn`, so only entries scrolled into view actually compose.