### PR TITLE
fix: Resolve TalkBack accessibility issues

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
@@ -13,9 +13,13 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -46,6 +50,7 @@ import app.morphe.manager.ui.screen.shared.LocalDialogSecondaryTextColor
 import app.morphe.manager.ui.screen.shared.MorpheAnimations
 import app.morphe.manager.ui.screen.shared.MorpheDialog
 import app.morphe.manager.ui.screen.shared.MorpheDialogButtonRow
+import app.morphe.manager.ui.screen.shared.rememberAccessibilityEnabled
 import app.morphe.manager.ui.viewmodel.InstallViewModel
 import app.morphe.manager.ui.viewmodel.PatcherViewModel
 import app.morphe.manager.util.APK_MIMETYPE
@@ -107,9 +112,12 @@ fun PatcherScreen(
         if (showSuccessScreen) miniGameState.pauseActiveGame()
     }
 
+    // Skip the 1.5s tween on every progress tick when TalkBack is active so the main thread
+    // isn't constantly busy interpolating and can serve accessibility events instead
+    val reduceMotion = rememberAccessibilityEnabled()
     val displayProgressAnimate by animateFloatAsState(
         targetValue = displayProgress,
-        animationSpec = tween(durationMillis = 1500, easing = FastOutSlowInEasing),
+        animationSpec = if (reduceMotion) snap() else tween(durationMillis = 1500, easing = FastOutSlowInEasing),
         label = "progress_animation"
     )
 
@@ -499,7 +507,11 @@ fun PatcherScreen(
 
         AnimatedContent(
             targetState = if (showSuccessScreen) state.currentPatcherState else PatcherState.IN_PROGRESS,
-            transitionSpec = MorpheAnimations.fadeCrossfade(800),
+            transitionSpec = if (reduceMotion) {
+                { EnterTransition.None togetherWith ExitTransition.None }
+            } else {
+                MorpheAnimations.fadeCrossfade(800)
+            },
             label = "patcher_state_animation"
         ) { patcherState ->
             when (patcherState) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -1980,16 +1980,16 @@ fun ExpandableSurface(
     Surface(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .clickable { expanded = !expanded },
+            .clip(RoundedCornerShape(12.dp)),
         shape = RoundedCornerShape(12.dp),
         color = headerTint.copy(alpha = 0.05f)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            // Header
+            // Click target only on the header so expanded content stays independently focusable for screen readers
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .clickable { expanded = !expanded }
                     .padding(12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1038,7 +1038,7 @@ fun MainAppsSection(
                                     itemsIndexed(
                                         items = orderedItems,
                                         key = { _, item -> item.packageName }
-                                    ) { _, item ->
+                                    ) { index, item ->
                                         ReorderableItem(reorderableState, key = item.packageName) { _ ->
                                             DynamicAppCard(
                                                 item = item,
@@ -1057,6 +1057,30 @@ fun MainAppsSection(
                                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                     }
                                                 ),
+                                                onMoveUp = if (index > 0) {
+                                                    {
+                                                        val current = localOrder.toMutableList()
+                                                        val from = current.indexOf(item.packageName)
+                                                        if (from > 0) {
+                                                            val moved = current.removeAt(from)
+                                                            current.add(from - 1, moved)
+                                                            localOrder = current
+                                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        }
+                                                    }
+                                                } else null,
+                                                onMoveDown = if (index < orderedItems.size - 1) {
+                                                    {
+                                                        val current = localOrder.toMutableList()
+                                                        val from = current.indexOf(item.packageName)
+                                                        if (from in 0 until current.size - 1) {
+                                                            val moved = current.removeAt(from)
+                                                            current.add(from + 1, moved)
+                                                            localOrder = current
+                                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        }
+                                                    }
+                                                } else null,
                                                 modifier = Modifier.animateItem()
                                             )
                                         }
@@ -1478,7 +1502,9 @@ private fun DynamicAppCard(
     isSelected: Boolean = false,
     isMultiSelectMode: Boolean = false,
     onLongPress: () -> Unit = {},
-    dragHandleModifier: Modifier? = null
+    dragHandleModifier: Modifier? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null
 ) {
     val showHideDialog = remember { mutableStateOf(false) }
     val density = LocalDensity.current
@@ -1510,6 +1536,8 @@ private fun DynamicAppCard(
 
     val hideLabel = stringResource(R.string.hide)
     val patchesLabel = stringResource(R.string.patches)
+    val moveUpLabel = stringResource(R.string.accessibility_move_up)
+    val moveDownLabel = stringResource(R.string.accessibility_move_down)
     val errorContainer = MaterialTheme.colorScheme.errorContainer
     val onErrorContainer = MaterialTheme.colorScheme.onErrorContainer
     val primaryContainer = MaterialTheme.colorScheme.primaryContainer
@@ -1533,10 +1561,16 @@ private fun DynamicAppCard(
     }
 
     Box(modifier = modifier.fillMaxWidth().semantics {
-        customActions = listOf(
-            CustomAccessibilityAction(hideLabel) { showHideDialog.value = true; true },
-            CustomAccessibilityAction(patchesLabel) { onShowPatches(); true }
-        )
+        customActions = buildList {
+            add(CustomAccessibilityAction(hideLabel) { showHideDialog.value = true; true })
+            add(CustomAccessibilityAction(patchesLabel) { onShowPatches(); true })
+            if (onMoveUp != null) {
+                add(CustomAccessibilityAction(moveUpLabel) { onMoveUp(); true })
+            }
+            if (onMoveDown != null) {
+                add(CustomAccessibilityAction(moveDownLabel) { onMoveDown(); true })
+            }
+        }
     }) {
         SwipeableCardContainer(
             offsetX = offsetX,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1048,9 +1048,6 @@ fun MainAppsSection(
                                         )
                                     }
                                 } else if (isReorderMode.value) {
-                                    // Reorder mode is the sighted drag-and-drop entry point.
-                                    // Screen-reader users get Move up/down directly on each card in normal mode,
-                                    // so we don't duplicate those a11y actions here
                                     itemsIndexed(
                                         items = orderedItems,
                                         key = { _, item -> item.packageName }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -948,6 +948,11 @@ fun MainAppsSection(
         localOrder.mapNotNull { byPackage[it] }
     }
 
+    // Polite TalkBack announcement after a screen-reader-triggered Move action.
+    // Empty until the first move; cleared by the next compose if needed
+    var moveAnnouncement by remember { mutableStateOf("") }
+    val moveAnnouncementFormat = stringResource(R.string.accessibility_app_moved_announcement)
+
     // True empty state: loaded, no apps from any bundle (no sources / all disabled)
     val isNoSourcesState = !stableLoadingState.value && homeAppItems.isEmpty() && hiddenAppItems.isEmpty()
     // All-hidden state: apps exist but all are hidden
@@ -961,6 +966,14 @@ fun MainAppsSection(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center
     ) {
+        // Hidden polite live region used to announce the result of TalkBack Move up/down actions
+        Spacer(
+            modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = moveAnnouncement
+            }
+        )
+
         AnimatedContent(
             targetState = isEmptyState,
             transitionSpec = MorpheAnimations.fadeCrossfade(300),
@@ -1035,10 +1048,13 @@ fun MainAppsSection(
                                         )
                                     }
                                 } else if (isReorderMode.value) {
+                                    // Reorder mode is the sighted drag-and-drop entry point.
+                                    // Screen-reader users get Move up/down directly on each card in normal mode,
+                                    // so we don't duplicate those a11y actions here
                                     itemsIndexed(
                                         items = orderedItems,
                                         key = { _, item -> item.packageName }
-                                    ) { index, item ->
+                                    ) { _, item ->
                                         ReorderableItem(reorderableState, key = item.packageName) { _ ->
                                             DynamicAppCard(
                                                 item = item,
@@ -1057,35 +1073,14 @@ fun MainAppsSection(
                                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                                     }
                                                 ),
-                                                onMoveUp = if (index > 0) {
-                                                    {
-                                                        val current = localOrder.toMutableList()
-                                                        val from = current.indexOf(item.packageName)
-                                                        if (from > 0) {
-                                                            val moved = current.removeAt(from)
-                                                            current.add(from - 1, moved)
-                                                            localOrder = current
-                                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                        }
-                                                    }
-                                                } else null,
-                                                onMoveDown = if (index < orderedItems.size - 1) {
-                                                    {
-                                                        val current = localOrder.toMutableList()
-                                                        val from = current.indexOf(item.packageName)
-                                                        if (from in 0 until current.size - 1) {
-                                                            val moved = current.removeAt(from)
-                                                            current.add(from + 1, moved)
-                                                            localOrder = current
-                                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                        }
-                                                    }
-                                                } else null,
                                                 modifier = Modifier.animateItem()
                                             )
                                         }
                                     }
                                 } else {
+                                    // Direct reorder a11y actions are exposed only when there's no search
+                                    // filter and no multi-select active so the indices match localOrder
+                                    val directReorderAllowed = searchQuery.isBlank() && !isMultiSelectMode.value
                                     itemsIndexed(
                                         items = filteredItems,
                                         key = { _, item -> item.packageName }
@@ -1121,6 +1116,36 @@ fun MainAppsSection(
                                                 else
                                                     selectedPackages.value + item.packageName
                                             },
+                                            onMoveUp = if (directReorderAllowed && index > 0) {
+                                                {
+                                                    val current = localOrder.toMutableList()
+                                                    val from = current.indexOf(item.packageName)
+                                                    if (from > 0) {
+                                                        val moved = current.removeAt(from)
+                                                        current.add(from - 1, moved)
+                                                        localOrder = current
+                                                        onSaveOrder(current)
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        moveAnnouncement = moveAnnouncementFormat
+                                                            .format(item.displayName, from, current.size)
+                                                    }
+                                                }
+                                            } else null,
+                                            onMoveDown = if (directReorderAllowed && index < filteredItems.size - 1) {
+                                                {
+                                                    val current = localOrder.toMutableList()
+                                                    val from = current.indexOf(item.packageName)
+                                                    if (from in 0 until current.size - 1) {
+                                                        val moved = current.removeAt(from)
+                                                        current.add(from + 1, moved)
+                                                        localOrder = current
+                                                        onSaveOrder(current)
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        moveAnnouncement = moveAnnouncementFormat
+                                                            .format(item.displayName, from + 2, current.size)
+                                                    }
+                                                }
+                                            } else null,
                                             modifier = Modifier
                                                 .animateItem()
                                                 .then(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -468,22 +469,8 @@ private fun BundleManagementCard(
             }
         }
 
-        Column(modifier = Modifier
-            .clickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() }
-            ) {
-                if (!forceExpanded) onToggleExpanded()
-            }
-            .semantics {
-                if (!forceExpanded) {
-                    role = Role.Button
-                    stateDescription = if (expanded) expandedState else collapsedState
-                }
-                this.contentDescription = contentDesc
-            }
-            .padding(16.dp)) {
-            // Header
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Click target only on the header so expanded children stay independently focusable for screen readers
             BundleCardHeader(
                 bundle = bundle,
                 updateInfo = updateInfo,
@@ -492,6 +479,19 @@ private fun BundleManagementCard(
                 enabled = isEnabled,
                 metadataFetchError = metadataFetchError,
                 modifier = longPressModifier
+                    .clickable(
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ) {
+                        if (!forceExpanded) onToggleExpanded()
+                    }
+                    .semantics(mergeDescendants = true) {
+                        if (!forceExpanded) {
+                            role = Role.Button
+                            stateDescription = if (expanded) expandedState else collapsedState
+                        }
+                        this.contentDescription = contentDesc
+                    }
             )
 
             // Expanded content
@@ -591,7 +591,14 @@ private fun BundleManagementCard(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { onPrereleasesToggle(!currentUsePrerelease) }
+                                .toggleable(
+                                    value = currentUsePrerelease,
+                                    role = Role.Switch,
+                                    onValueChange = onPrereleasesToggle
+                                )
+                                .semantics {
+                                    stateDescription = if (currentUsePrerelease) enabledState else disabledState
+                                }
                                 .padding(vertical = 4.dp)
                                 .then(
                                     if (onPrereleaseBtnPositioned != null)
@@ -620,7 +627,7 @@ private fun BundleManagementCard(
 
                             MorpheSwitch(
                                 checked = currentUsePrerelease,
-                                onCheckedChange = onPrereleasesToggle
+                                onCheckedChange = null
                             )
                         }
                     }
@@ -636,8 +643,13 @@ private fun BundleManagementCard(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable {
-                                    onExperimentalVersionsToggle?.invoke(!useExperimentalVersions)
+                                .toggleable(
+                                    value = useExperimentalVersions,
+                                    role = Role.Switch,
+                                    onValueChange = { onExperimentalVersionsToggle?.invoke(it) }
+                                )
+                                .semantics {
+                                    stateDescription = if (useExperimentalVersions) enabledState else disabledState
                                 }
                                 .padding(vertical = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
@@ -660,7 +672,7 @@ private fun BundleManagementCard(
 
                             MorpheSwitch(
                                 checked = useExperimentalVersions,
-                                onCheckedChange = { onExperimentalVersionsToggle?.invoke(it) }
+                                onCheckedChange = null
                             )
                         }
                     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -594,6 +594,7 @@ private fun BundleManagementCard(
                                 .toggleable(
                                     value = currentUsePrerelease,
                                     role = Role.Switch,
+                                    enabled = !isUpdating,
                                     onValueChange = onPrereleasesToggle
                                 )
                                 .semantics {
@@ -625,10 +626,28 @@ private fun BundleManagementCard(
 
                             Spacer(Modifier.width(8.dp))
 
-                            MorpheSwitch(
-                                checked = currentUsePrerelease,
-                                onCheckedChange = null
-                            )
+                            Crossfade(
+                                targetState = isUpdating,
+                                modifier = Modifier.size(width = 52.dp, height = 32.dp),
+                                label = "prerelease_toggle_loading"
+                            ) { updating ->
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (updating) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
+                                        )
+                                    } else {
+                                        MorpheSwitch(
+                                            checked = currentUsePrerelease,
+                                            onCheckedChange = null
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
@@ -20,11 +20,6 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -71,35 +66,12 @@ fun SimplePatchingInProgress(
         }
     }
 
-    // Throttle to 10% increments to prevent TalkBack TTS flood on low-end devices
-    val announcedPercent by remember {
-        derivedStateOf { ((progress * 10).toInt() * 10).coerceIn(0, 100) }
-    }
-    val runningStepName by remember {
-        derivedStateOf {
-            patcherViewModel.steps.firstOrNull { it.state == State.RUNNING }?.name
-        }
-    }
-    val applyingPatchesLabel = stringResource(R.string.applying_patches)
-    val accessibilityProgressDescription = remember(runningStepName, announcedPercent, completed, total) {
-        val label = runningStepName ?: applyingPatchesLabel
-        "$label, $announcedPercent%, $completed/$total"
-    }
-
     // Main content area
     Column(
         modifier = Modifier
             .fillMaxSize()
             .navigationBarsPadding()
     ) {
-        // Hidden polite live region; visual widgets below are silenced via clearAndSetSemantics
-        Spacer(
-            modifier = Modifier.semantics {
-                contentDescription = accessibilityProgressDescription
-                liveRegion = LiveRegionMode.Polite
-            }
-        )
-
         // Content with weight to push bottom bar down
         Box(
             modifier = Modifier
@@ -240,14 +212,13 @@ private fun AdaptiveProgressContent(
     }
 }
 
-/** Progress message section. Silenced for a11y; status comes from the live region in [SimplePatchingInProgress]. */
+/** Rotating greeting / status section. */
 @Composable
 private fun ProgressMessageSection(currentMessage: Int) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(120.dp)
-            .clearAndSetSemantics { },
+            .height(120.dp),
         contentAlignment = Alignment.Center
     ) {
         AnimatedMessage(currentMessage)
@@ -294,14 +265,14 @@ private fun ProgressDetailsSection(
 
 /**
  * Animated message with fade transitions.
+ * When TalkBack is active the crossfade is skipped and the new text replaces the old instantly,
+ * which keeps the main thread free so the screen reader can announce the new content
  */
 @Composable
 private fun AnimatedMessage(messageResId: Int) {
-    AnimatedContent(
-        targetState = stringResource(messageResId),
-        transitionSpec = MorpheAnimations.fadeCrossfade(1000),
-        label = "message_animation"
-    ) { message ->
+    val reduceMotion = rememberAccessibilityEnabled()
+    val message = stringResource(messageResId)
+    if (reduceMotion) {
         Text(
             text = message,
             style = MaterialTheme.typography.titleLarge,
@@ -311,6 +282,22 @@ private fun AnimatedMessage(messageResId: Int) {
             maxLines = 4,
             overflow = TextOverflow.Ellipsis
         )
+    } else {
+        AnimatedContent(
+            targetState = message,
+            transitionSpec = MorpheAnimations.fadeCrossfade(1000),
+            label = "message_animation"
+        ) { rotatingMessage ->
+            Text(
+                text = rotatingMessage,
+                style = MaterialTheme.typography.titleLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.fillMaxWidth(),
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 
@@ -326,8 +313,7 @@ private fun CircularProgressWithStats(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        // Silence; the live region in [SimplePatchingInProgress] reports throttled progress instead
-        modifier = modifier.clearAndSetSemantics { }
+        modifier = modifier
     ) {
         // Background track
         CircularProgressIndicator(
@@ -395,25 +381,40 @@ fun CurrentStepIndicator(
             patcherViewModel.steps.firstOrNull { it.state == State.RUNNING }
         }
     }
+    val reduceMotion = rememberAccessibilityEnabled()
+    val stepName = currentStep?.name
 
-    AnimatedContent(
-        targetState = currentStep?.name,
-        transitionSpec = MorpheAnimations.fadeCrossfade(400),
-        label = "step_animation",
-        // Silence; step changes come from the live region in [SimplePatchingInProgress]
-        modifier = Modifier.clearAndSetSemantics { }
-    ) { stepName ->
+    val stepStyle = when (windowSize.widthSizeClass) {
+        WindowWidthSizeClass.Compact -> MaterialTheme.typography.bodyLarge
+        else -> MaterialTheme.typography.titleMedium
+    }
+
+    if (reduceMotion) {
+        // Skip crossfade so the main thread isn't busy animating when TalkBack tries to announce
         if (stepName != null) {
             Text(
                 text = stepName,
-                style = when (windowSize.widthSizeClass) {
-                    WindowWidthSizeClass.Compact -> MaterialTheme.typography.bodyLarge
-                    else -> MaterialTheme.typography.titleMedium
-                },
+                style = stepStyle,
                 color = MaterialTheme.colorScheme.primary,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
             )
+        }
+    } else {
+        AnimatedContent(
+            targetState = stepName,
+            transitionSpec = MorpheAnimations.fadeCrossfade(400),
+            label = "step_animation"
+        ) { name ->
+            if (name != null) {
+                Text(
+                    text = name,
+                    style = stepStyle,
+                    color = MaterialTheme.colorScheme.primary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
@@ -212,7 +212,9 @@ private fun AdaptiveProgressContent(
     }
 }
 
-/** Rotating greeting / status section. */
+/**
+ * Progress message section.
+ */
 @Composable
 private fun ProgressMessageSection(currentMessage: Int) {
     Box(
@@ -265,8 +267,6 @@ private fun ProgressDetailsSection(
 
 /**
  * Animated message with fade transitions.
- * When TalkBack is active the crossfade is skipped and the new text replaces the old instantly,
- * which keeps the main thread free so the screen reader can announce the new content
  */
 @Composable
 private fun AnimatedMessage(messageResId: Int) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/patcher/SimplePatcherProgress.kt
@@ -20,6 +20,11 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -66,12 +71,35 @@ fun SimplePatchingInProgress(
         }
     }
 
+    // Throttle to 10% increments to prevent TalkBack TTS flood on low-end devices
+    val announcedPercent by remember {
+        derivedStateOf { ((progress * 10).toInt() * 10).coerceIn(0, 100) }
+    }
+    val runningStepName by remember {
+        derivedStateOf {
+            patcherViewModel.steps.firstOrNull { it.state == State.RUNNING }?.name
+        }
+    }
+    val applyingPatchesLabel = stringResource(R.string.applying_patches)
+    val accessibilityProgressDescription = remember(runningStepName, announcedPercent, completed, total) {
+        val label = runningStepName ?: applyingPatchesLabel
+        "$label, $announcedPercent%, $completed/$total"
+    }
+
     // Main content area
     Column(
         modifier = Modifier
             .fillMaxSize()
             .navigationBarsPadding()
     ) {
+        // Hidden polite live region; visual widgets below are silenced via clearAndSetSemantics
+        Spacer(
+            modifier = Modifier.semantics {
+                contentDescription = accessibilityProgressDescription
+                liveRegion = LiveRegionMode.Polite
+            }
+        )
+
         // Content with weight to push bottom bar down
         Box(
             modifier = Modifier
@@ -212,15 +240,14 @@ private fun AdaptiveProgressContent(
     }
 }
 
-/**
- * Progress message section.
- */
+/** Progress message section. Silenced for a11y; status comes from the live region in [SimplePatchingInProgress]. */
 @Composable
 private fun ProgressMessageSection(currentMessage: Int) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(120.dp),
+            .height(120.dp)
+            .clearAndSetSemantics { },
         contentAlignment = Alignment.Center
     ) {
         AnimatedMessage(currentMessage)
@@ -299,7 +326,8 @@ private fun CircularProgressWithStats(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = modifier
+        // Silence; the live region in [SimplePatchingInProgress] reports throttled progress instead
+        modifier = modifier.clearAndSetSemantics { }
     ) {
         // Background track
         CircularProgressIndicator(
@@ -371,7 +399,9 @@ fun CurrentStepIndicator(
     AnimatedContent(
         targetState = currentStep?.name,
         transitionSpec = MorpheAnimations.fadeCrossfade(400),
-        label = "step_animation"
+        label = "step_animation",
+        // Silence; step changes come from the live region in [SimplePatchingInProgress]
+        modifier = Modifier.clearAndSetSemantics { }
     ) { stepName ->
         if (stepName != null) {
             Text(

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/InstallerSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/InstallerSection.kt
@@ -10,8 +10,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
@@ -103,6 +103,10 @@ fun InstallerSection(
                 onClick = {
                     settingsViewModel.setPromptInstallerOnInstall(!promptInstallerOnInstall)
                 },
+                modifier = Modifier.semantics {
+                    role = Role.Switch
+                    stateDescription = if (promptInstallerOnInstall) enabledState else disabledState
+                },
                 leadingContent = {
                     MorpheIcon(icon = Icons.Outlined.Android)
                 },
@@ -111,10 +115,7 @@ fun InstallerSection(
                 trailingContent = {
                     MorpheSwitch(
                         checked = promptInstallerOnInstall,
-                        onCheckedChange = null,
-                        modifier = Modifier.semantics {
-                            stateDescription = if (promptInstallerOnInstall) enabledState else disabledState
-                        }
+                        onCheckedChange = null
                     )
                 }
             )
@@ -238,6 +239,7 @@ fun InstallerSelectionDialog(
     // Localized strings for accessibility
     val selectedState = stringResource(R.string.selected)
     val notSelectedState = stringResource(R.string.not_selected)
+    val enabledState = stringResource(R.string.enabled)
     val disabledState = stringResource(R.string.disabled)
 
     MorpheDialog(
@@ -307,7 +309,14 @@ fun InstallerSelectionDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clip(MaterialTheme.shapes.medium)
-                            .clickable { onAutoInstallToggle?.invoke(!autoInstallEnabled) }
+                            .toggleable(
+                                value = autoInstallEnabled,
+                                role = Role.Switch,
+                                onValueChange = { onAutoInstallToggle?.invoke(it) }
+                            )
+                            .semantics {
+                                stateDescription = if (autoInstallEnabled) enabledState else disabledState
+                            }
                             .padding(vertical = 12.dp, horizontal = 4.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/Accessibility.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/Accessibility.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * True when any accessibility service with touch exploration is active (e.g. TalkBack).
+ * Updates reactively when the user toggles the service while the app is running.
+ *
+ * Use this to skip heavy crossfade / scale animations that can stall TalkBack on low-end devices.
+ */
+@Composable
+fun rememberAccessibilityEnabled(): Boolean {
+    val context = LocalContext.current
+    val manager = remember(context) {
+        context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    }
+    var enabled by remember {
+        mutableStateOf(manager.isEnabled && manager.isTouchExplorationEnabled)
+    }
+    DisposableEffect(manager) {
+        val stateListener = AccessibilityManager.AccessibilityStateChangeListener {
+            enabled = manager.isEnabled && manager.isTouchExplorationEnabled
+        }
+        val touchListener = AccessibilityManager.TouchExplorationStateChangeListener {
+            enabled = manager.isEnabled && manager.isTouchExplorationEnabled
+        }
+        manager.addAccessibilityStateChangeListener(stateListener)
+        manager.addTouchExplorationStateChangeListener(touchListener)
+        onDispose {
+            manager.removeAccessibilityStateChangeListener(stateListener)
+            manager.removeTouchExplorationStateChangeListener(touchListener)
+        }
+    }
+    return enabled
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -862,6 +862,8 @@ The image dimensions must be as follows:
     <string name="reorder_done">Order saved</string>
     <string name="reset_order">Reset order</string>
     <string name="reset_order_done">Order reset</string>
+    <string name="accessibility_move_up">Move up</string>
+    <string name="accessibility_move_down">Move down</string>
     <string name="rename">Rename</string>
     <string name="import_">Import</string>
     <string name="export">Export</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -864,6 +864,7 @@ The image dimensions must be as follows:
     <string name="reset_order_done">Order reset</string>
     <string name="accessibility_move_up">Move up</string>
     <string name="accessibility_move_down">Move down</string>
+    <string name="accessibility_app_moved_announcement">%1$s moved to position %2$d of %3$d</string>
     <string name="rename">Rename</string>
     <string name="import_">Import</string>
     <string name="export">Export</string>


### PR DESCRIPTION
Fixes the four accessibility issues:
1. Auto-install toggle now exposes on/off state to TalkBack.
2. Expanded patch source cards keep inner controls focusable by moving the click target onto the header only.
3. Simple Mode - progress is reported through a single polite live region throttled to 10% steps, and the constantly-updating progress widgets are silenced.
4. Apps on the home screen can be reordered with a screen reader via Move up / Move down accessibility actions.