### PR TITLE
feat: Add Replace/Merge choice dialog on settings and selections import

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -1234,7 +1234,7 @@ class PatchBundleRepository(
             // Check if this is already a raw URL: owner/repo/-/raw/branch/path
             val rawIndex = pathSegments.indexOf("raw")
             if (rawIndex >= 2 && pathSegments.getOrNull(rawIndex - 1) == "-") {
-                // Already a raw URL — normalize it
+                // Already a raw URL - normalize it
                 val normalizedPath = "/" + pathSegments.joinToString("/")
                 val pathNoQuery = normalizedPath.substringBefore('?').substringBefore('#')
                 if (!pathNoQuery.endsWith(".json", ignoreCase = true)) {
@@ -1807,7 +1807,7 @@ class PatchBundleRepository(
     }
 
     sealed class BundleState {
-        /** DB not yet read — UI shows shimmer */
+        /** DB not yet read - UI shows shimmer */
         data object Loading : BundleState()
 
         /** Pipeline ready (even if sources list is empty) */
@@ -1885,26 +1885,73 @@ class PatchBundleRepository(
     }
 
     /**
-     * Import a list of [BundleSnapshot] entries produced by [exportCustomBundles].
-     * Skips bundles whose source URL already exists, so this is safe to call on repeated imports.
-     * Triggers a full reload and starts a download job for newly added bundles.
+     * Import strategy for [importCustomBundles].
      */
-    suspend fun importCustomBundles(snapshots: List<BundleSnapshot>) {
-        if (snapshots.isEmpty()) return
-        dispatchAction("Import custom bundles") { state ->
+    enum class ImportMode {
+        /** Add only bundles whose endpoint is not present. Keep everything else. */
+        Merge,
+        /** Match the backup exactly: remove custom remotes not in the backup, then add missing ones. */
+        Replace,
+    }
+
+    /**
+     * Import a list of [BundleSnapshot] entries produced by [exportCustomBundles].
+     *
+     * In [ImportMode.Merge] mode this only adds bundles whose endpoint is not already present.
+     * In [ImportMode.Replace] mode this first removes existing custom remote bundles that are
+     * absent from [snapshots] (the default source and local bundles are always kept), then adds
+     * the missing ones. Triggers a full reload and starts a download job for newly added bundles.
+     */
+    suspend fun importCustomBundles(
+        snapshots: List<BundleSnapshot>,
+        mode: ImportMode = ImportMode.Merge,
+    ) {
+        // Empty snapshot in Merge mode is a no-op; in Replace mode it still needs to clear existing customs
+        if (snapshots.isEmpty() && mode == ImportMode.Merge) return
+
+        dispatchAction("Import custom bundles ($mode)") { state ->
             val ready = state as? BundleState.Ready ?: return@dispatchAction state
-            val existingEndpoints = ready.sources.values
+
+            val incomingEndpoints = snapshots
+                .mapNotNull { runCatching { normalizeRemoteBundleUrl(it.source) }.getOrNull() }
+                .map { it.lowercase(Locale.US) }
+                .toSet()
+
+            val customRemotes = ready.sources.values
                 .filterIsInstance<RemotePatchBundle>()
+                .filter { it.uid != DEFAULT_SOURCE_UID }
+
+            var changedAny = false
+
+            // Replace mode: remove custom remotes whose endpoint is not in the backup
+            if (mode == ImportMode.Replace) {
+                val toRemove = customRemotes
+                    .filter { it.endpoint.lowercase(Locale.US) !in incomingEndpoints }
+                if (toRemove.isNotEmpty()) {
+                    toRemove.forEach { bundle ->
+                        dao.remove(bundle.uid)
+                        directoryOf(bundle.uid).deleteRecursively()
+                    }
+                    val removedUids = toRemove.map { it.uid }.toSet()
+                    metadataFetchErrorsFlow.update { it - removedUids }
+                    val (affectedCount, remaining) = cancelRemoteUpdates(removedUids)
+                    updateProgressAfterRemoval(affectedCount, remaining)
+                    changedAny = true
+                }
+            }
+
+            // Endpoints that survive the (possible) Replace pruning - used to skip duplicates
+            val keptEndpoints = customRemotes
+                .filter { mode == ImportMode.Merge || it.endpoint.lowercase(Locale.US) in incomingEndpoints }
                 .map { it.endpoint.lowercase(Locale.US) }
                 .toSet()
 
-            var addedAny = false
             snapshots.forEach { snapshot ->
                 val normalizedUrl = runCatching {
                     normalizeRemoteBundleUrl(snapshot.source)
                 }.getOrNull() ?: return@forEach
 
-                if (normalizedUrl.lowercase(Locale.US) in existingEndpoints) return@forEach
+                if (normalizedUrl.lowercase(Locale.US) in keptEndpoints) return@forEach
 
                 createEntity(
                     name = snapshot.name,
@@ -1915,10 +1962,10 @@ class PatchBundleRepository(
                     createdAt = snapshot.createdAt,
                     updatedAt = snapshot.updatedAt,
                 )
-                addedAny = true
+                changedAny = true
             }
 
-            if (!addedAny) return@dispatchAction state
+            if (!changedAny) return@dispatchAction state
 
             val newState = doReload()
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/SettingsScreen.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.manager.ui.screen
 
+import android.net.Uri
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -181,10 +182,12 @@ fun SettingsScreen(
         onResult = { uri -> uri?.let { importExportViewModel.startKeystoreImport(it) } }
     )
 
+    // Import goes through a mode dialog so the user chooses between Replace and Merge
+    var pendingSettingsImportUri by remember { mutableStateOf<Uri?>(null) }
     val importSettingsLauncher = rememberAdaptiveFilePicker(
         mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
         customPickerMimeTypes = arrayOf(JSON_MIMETYPE),
-        onResult = { uri -> uri?.let { importExportViewModel.importManagerSettings(it) } }
+        onResult = { uri -> uri?.let { pendingSettingsImportUri = it } }
     )
 
     // Export launchers
@@ -236,6 +239,19 @@ fun SettingsScreen(
         ChangelogDialog(
             onDismiss = { showChangelogDialog.value = false },
             updateViewModel = updateViewModel
+        )
+    }
+
+    // Import-mode dialog for manager settings: user picks Replace or Merge
+    pendingSettingsImportUri?.let { uri ->
+        ImportModeDialog(
+            titleRes = R.string.settings_system_import_manager_settings_mode_title,
+            descriptionRes = R.string.settings_system_import_manager_settings_mode_description,
+            onDismiss = { pendingSettingsImportUri = null },
+            onSelect = { mode ->
+                importExportViewModel.importManagerSettings(uri, mode)
+                pendingSettingsImportUri = null
+            }
         )
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ImportModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ImportModeDialog.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.settings.system
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.MergeType
+import androidx.compose.material.icons.outlined.SwapVert
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import app.morphe.manager.domain.repository.PatchBundleRepository.ImportMode
+import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.util.isDarkBackground
+
+/**
+ * Two-choice dialog that asks the user how an import should be applied:
+ * Replace overwrites current state to match the backup exactly (destructive);
+ * Merge only adds missing entries and preserves everything that already exists.
+ */
+@Composable
+fun ImportModeDialog(
+    @StringRes titleRes: Int,
+    @StringRes descriptionRes: Int,
+    onDismiss: () -> Unit,
+    onSelect: (ImportMode) -> Unit,
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(titleRes),
+        footer = {
+            MorpheDialogOutlinedButton(
+                text = stringResource(android.R.string.cancel),
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
+            Text(
+                text = stringResource(descriptionRes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalDialogTextColor.current
+            )
+
+            ImportModeOption(
+                icon = Icons.Outlined.SwapVert,
+                title = stringResource(R.string.import_mode_replace_title),
+                description = stringResource(R.string.import_mode_replace_description),
+                isDestructive = true,
+                onClick = { onSelect(ImportMode.Replace) }
+            )
+
+            ImportModeOption(
+                icon = Icons.AutoMirrored.Outlined.MergeType,
+                title = stringResource(R.string.import_mode_merge_title),
+                description = stringResource(R.string.import_mode_merge_description),
+                isDestructive = false,
+                onClick = { onSelect(ImportMode.Merge) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ImportModeOption(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    isDestructive: Boolean,
+    onClick: () -> Unit,
+) {
+    val textColor = LocalDialogTextColor.current
+    val isDark = !textColor.isDarkBackground()
+    val accent = if (isDestructive) {
+        Color.Red.copy(alpha = if (isDark) 0.85f else 0.75f)
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val borderColor = accent.copy(alpha = if (isDark) 0.4f else 0.3f)
+    val containerColor = accent.copy(alpha = if (isDark) 0.14f else 0.08f)
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = containerColor,
+        border = BorderStroke(1.dp, borderColor),
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accent,
+                modifier = Modifier.size(28.dp)
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = textColor
+                )
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = LocalDialogSecondaryTextColor.current
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.manager.ui.screen.settings.system
 
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
@@ -53,6 +54,7 @@ fun PatchSelectionManagementDialog(
     val showResetAllConfirmation = remember { mutableStateOf(false) }
     val resetTarget = remember { mutableStateOf<ResetTarget?>(null) }
     val showPatchDetailsTarget = remember { mutableStateOf<PatchDetailsTarget?>(null) }
+    var pendingImportUri by remember { mutableStateOf<Uri?>(null) }
 
     val selections by settingsViewModel.selectionsSummary.collectAsStateWithLifecycle()
     val bundleNames by settingsViewModel.bundleNames.collectAsStateWithLifecycle()
@@ -70,8 +72,22 @@ fun PatchSelectionManagementDialog(
         onDismiss = onDismiss,
         onShowResetAllConfirmation = { showResetAllConfirmation.value = true },
         onSetResetTarget = { resetTarget.value = it },
-        onShowPatchDetails = { showPatchDetailsTarget.value = it }
+        onShowPatchDetails = { showPatchDetailsTarget.value = it },
+        onImportUriPicked = { pendingImportUri = it }
     )
+
+    // Import-mode dialog: user picks Replace or Merge before selections are applied
+    pendingImportUri?.let { uri ->
+        ImportModeDialog(
+            titleRes = R.string.settings_system_import_selections_mode_title,
+            descriptionRes = R.string.settings_system_import_selections_mode_description,
+            onDismiss = { pendingImportUri = null },
+            onSelect = { mode ->
+                importExportViewModel.importAllSelections(uri, mode)
+                pendingImportUri = null
+            }
+        )
+    }
 
     // Reset all confirmation dialog
     if (showResetAllConfirmation.value) {
@@ -159,14 +175,13 @@ private fun PatchSelectionManagementDialogContent(
     onDismiss: () -> Unit,
     onShowResetAllConfirmation: () -> Unit,
     onSetResetTarget: (ResetTarget) -> Unit,
-    onShowPatchDetails: (PatchDetailsTarget) -> Unit
+    onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    onImportUriPicked: (Uri) -> Unit
 ) {
     val openImportAllSelectionsPicker = rememberAdaptiveFilePicker(
         mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
         customPickerMimeTypes = arrayOf(JSON_MIMETYPE),
-        onResult = { uri ->
-            uri?.let { importExportViewModel.importAllSelections(it) }
-        }
+        onResult = { uri -> uri?.let(onImportUriPicked) }
     )
 
     val exportAllSelectionsLauncher = rememberLauncherForActivityResult(

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -202,7 +202,10 @@ class ImportExportViewModel(
         }
     }
 
-    fun importManagerSettings(source: Uri) = viewModelScope.launch {
+    fun importManagerSettings(
+        source: Uri,
+        mode: PatchBundleRepository.ImportMode = PatchBundleRepository.ImportMode.Merge,
+    ) = viewModelScope.launch {
         uiSafe(app, R.string.settings_system_import_manager_settings_fail, "Failed to import manager settings") {
             val exportFile = withContext(Dispatchers.IO) {
                 contentResolver.openInputStream(source)!!.use {
@@ -218,10 +221,11 @@ class ImportExportViewModel(
                 applyAppLanguage(it)
             }
 
-            val bundles = exportFile.settings.customBundles
-            if (!bundles.isNullOrEmpty()) {
-                patchBundleRepository.importCustomBundles(bundles)
-            }
+            // Always call the repository so Replace can clear existing custom sources even when the backup has none
+            patchBundleRepository.importCustomBundles(
+                exportFile.settings.customBundles.orEmpty(),
+                mode,
+            )
 
             app.toast(app.getString(R.string.settings_system_import_manager_settings_success))
         }
@@ -352,9 +356,16 @@ class ImportExportViewModel(
      * Import patch selections and options from a file.
      * Supports both [PatchBundleDataExportFile] (single bundle) and
      * [AllSelectionsExportFile] (all bundles) formats, detected automatically.
-     * Merges into existing selections without clearing them first.
+     *
+     * In [PatchBundleRepository.ImportMode.Merge] mode existing selections are preserved
+     * and new ones are added on top. In [PatchBundleRepository.ImportMode.Replace] mode the
+     * imported state fully overwrites the current state: bundles absent from the backup have
+     * their selections and options cleared.
      */
-    fun importAllSelections(source: Uri) = viewModelScope.launch {
+    fun importAllSelections(
+        source: Uri,
+        mode: PatchBundleRepository.ImportMode = PatchBundleRepository.ImportMode.Merge,
+    ) = viewModelScope.launch {
         uiSafe(app, R.string.settings_system_import_source_data_fail, "Failed to import selections") {
             val bytes = withContext(Dispatchers.IO) {
                 contentResolver.openInputStream(source)!!.use { it.readBytes() }
@@ -375,29 +386,63 @@ class ImportExportViewModel(
             }
 
             withContext(Dispatchers.IO) {
-                bundleFiles.forEach { exportFile ->
-                    // Remap the exported UID to the current device's UID for the same bundle.
-                    // Without this, imported selections are silently discarded on fresh installs
-                    // because bundle UIDs are randomly generated and don't match across devices.
-                    val bundleUid = exportFile.bundleSource
+                // Remap exported UIDs to current-device UIDs. Bundle UIDs are randomly generated
+                // per device so the raw exported value only matches on the origin device
+                val remapped = bundleFiles.map { file ->
+                    val uid = file.bundleSource
                         ?.let { patchBundleRepository.resolveUidForEndpoint(it) }
-                        ?: exportFile.bundleUid
-                    // Skip if the bundle is not loaded - inserting with an unknown UID would
-                    // violate the patch_selections FK constraint on patch_bundles.uid.
-                    if (!patchBundleRepository.isUidLoaded(bundleUid)) return@forEach
-                    exportFile.selections.forEach { (packageName, patchList) ->
-                        patchSelectionRepository.importForPackageAndBundle(
-                            packageName = packageName,
-                            bundleUid = bundleUid,
-                            patches = patchList
-                        )
+                        ?: file.bundleUid
+                    file to uid
+                }
+                val incomingUids = remapped
+                    .map { it.second }
+                    .filter { patchBundleRepository.isUidLoaded(it) }
+                    .toSet()
+
+                // Replace mode: clear selections/options for bundles that currently have data
+                // but are not represented in the backup
+                if (mode == PatchBundleRepository.ImportMode.Replace) {
+                    val existingUids = patchSelectionRepository.getAllBundleUids().toSet()
+                    (existingUids - incomingUids).forEach { uid ->
+                        patchSelectionRepository.import(uid, emptyMap())
+                        patchOptionsRepository.resetOptionsForPatchBundle(uid)
                     }
-                    exportFile.options?.forEach { (packageName, packageOptions) ->
-                        patchOptionsRepository.importOptionsForBundle(
-                            packageName = packageName,
-                            bundleUid = bundleUid,
-                            options = packageOptions
-                        )
+                }
+
+                remapped.forEach { (exportFile, bundleUid) ->
+                    // Skip if the bundle is not loaded - inserting with an unknown UID would
+                    // violate the patch_selections FK constraint on patch_bundles.uid
+                    if (!patchBundleRepository.isUidLoaded(bundleUid)) return@forEach
+
+                    when (mode) {
+                        PatchBundleRepository.ImportMode.Replace -> {
+                            // Full per-bundle replace: reset first, then load from backup
+                            patchSelectionRepository.import(bundleUid, exportFile.selections)
+                            patchOptionsRepository.resetOptionsForPatchBundle(bundleUid)
+                            exportFile.options?.forEach { (packageName, packageOptions) ->
+                                patchOptionsRepository.importOptionsForBundle(
+                                    packageName = packageName,
+                                    bundleUid = bundleUid,
+                                    options = packageOptions
+                                )
+                            }
+                        }
+                        PatchBundleRepository.ImportMode.Merge -> {
+                            exportFile.selections.forEach { (packageName, patchList) ->
+                                patchSelectionRepository.importForPackageAndBundle(
+                                    packageName = packageName,
+                                    bundleUid = bundleUid,
+                                    patches = patchList
+                                )
+                            }
+                            exportFile.options?.forEach { (packageName, packageOptions) ->
+                                patchOptionsRepository.importOptionsForBundle(
+                                    packageName = packageName,
+                                    bundleUid = bundleUid,
+                                    options = packageOptions
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -733,6 +733,14 @@ The image dimensions must be as follows:
     <string name="settings_system_import_manager_settings_description">Backs up and restores your Morphe settings</string>
     <string name="settings_system_import_manager_settings_fail">Failed to import Morphe settings: %s</string>
     <string name="settings_system_import_manager_settings_success">Morphe settings imported</string>
+    <string name="settings_system_import_manager_settings_mode_title">Import Morphe settings</string>
+    <string name="settings_system_import_manager_settings_mode_description">Choose how the imported settings and sources should be applied</string>
+    <string name="settings_system_import_selections_mode_title">Import patch selections</string>
+    <string name="settings_system_import_selections_mode_description">Choose how the imported selections and patch options should be applied</string>
+    <string name="import_mode_replace_title">Replace existing</string>
+    <string name="import_mode_replace_description">Match the backup exactly. Items missing from the backup will be removed</string>
+    <string name="import_mode_merge_title">Merge with existing</string>
+    <string name="import_mode_merge_description">Add missing items from the backup. Existing items are kept unchanged</string>
     <string name="settings_system_export_manager_settings_fail">Failed to export Morphe settings: %s</string>
     <string name="settings_system_export_manager_settings_success">Morphe settings exported</string>
     <string name="settings_system_debug">Debug</string>


### PR DESCRIPTION
Adds a mode dialog to Morphe settings and patch selections import so the user can choose between restoring the backup exactly or merging it with existing state. Resolves the case where imports silently merged instead of restoring, leaving stale items untouched.
___
![Screenshot_2026-07-01-15-38-36-613_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/29d0d0c5-1fc8-4d20-8a43-fc1a9c6368ec)

