### PR TITLE
fix: Shizuku auto-install hang

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/installer/SessionInstaller.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/SessionInstaller.kt
@@ -21,6 +21,7 @@ import androidx.core.net.toUri
 import app.morphe.manager.R
 import app.morphe.manager.util.APK_MIMETYPE
 import app.morphe.manager.util.PLAY_STORE_INSTALLER_PACKAGE
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuProvider
@@ -247,6 +248,8 @@ class SessionInstaller(private val app: Application) {
                 PackageInstaller.STATUS_FAILURE_ABORTED -> throw InstallCancelledException()
                 else -> InstallResult.Failure(e.message)
             }
+        } catch (_: TimeoutCancellationException) {
+            InstallResult.Failure("Timed out waiting for Shizuku install result")
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/domain/installer/ShizukuInstaller.kt
+++ b/app/src/main/java/app/morphe/manager/domain/installer/ShizukuInstaller.kt
@@ -17,6 +17,7 @@ import android.os.RemoteException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import rikka.shizuku.Shizuku
 import rikka.shizuku.ShizukuBinderWrapper
 import rikka.shizuku.ShizukuProvider
@@ -25,6 +26,7 @@ import rikka.sui.Sui
 import java.io.File
 import java.io.IOException
 import java.lang.reflect.Constructor
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Performs silent APK installation via the Shizuku/Sui privileged service.
@@ -85,6 +87,7 @@ class ShizukuInstaller(private val app: Application) {
             ShizukuBinderWrapper(packageInstaller.openSession(sessionId).asBinder())
         )
         val session = PackageInstallerCompat.createSession(sessionBinder)
+        var completed = false
 
         try {
             sourceFile.inputStream().use { input ->
@@ -102,12 +105,16 @@ class ShizukuInstaller(private val app: Application) {
             }
 
             session.commit(intentSender)
-            val result = resultDeferred.await()
+            val result = withTimeout(INSTALL_RESULT_TIMEOUT) { resultDeferred.await() }
+            completed = true
             if (result.status != PackageInstaller.STATUS_SUCCESS) {
                 throw InstallerOperationException(result.status, result.message)
             }
             result
         } finally {
+            if (!completed) {
+                runCatching { packageInstallerWrapper.abandonSession(sessionId) }
+            }
             runCatching { session.close() }
         }
     }
@@ -134,6 +141,7 @@ class ShizukuInstaller(private val app: Application) {
     companion object {
         private const val SHELL_PACKAGE = "com.android.shell"
         private const val BASE_APK_NAME = "base.apk"
+        private val INSTALL_RESULT_TIMEOUT = 5.minutes
         internal const val PACKAGE_NAME = "moe.shizuku.privileged.api"
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/PatcherScreen.kt
@@ -299,7 +299,9 @@ fun PatcherScreen(
         InstalledSourceConflictDialog(
             onUninstall = {
                 showInstalledSourceConflictDialog.value = false
-                conflictPackageName?.let { installViewModel.requestUninstall(it) }
+                conflictPackageName?.let {
+                    installViewModel.requestUninstall(it, installAfterUninstall = true)
+                }
             },
             onDismiss = {
                 showInstalledSourceConflictDialog.value = false
@@ -593,7 +595,7 @@ fun PatcherScreen(
                             }
                         },
                         onUninstall = { packageName ->
-                            installViewModel.requestUninstall(packageName)
+                            installViewModel.requestUninstall(packageName, installAfterUninstall = true)
                         },
                         onOpen = {
                             installViewModel.openApp()

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -262,7 +262,9 @@ fun InstalledAppInfoDialog(
         show = showSignatureConflictDialog.value,
         onUninstall = {
             showSignatureConflictDialog.value = false
-            conflictPackageName.value?.let { installViewModel.requestUninstall(it) }
+            conflictPackageName.value?.let {
+                installViewModel.requestUninstall(it, installAfterUninstall = true)
+            }
         },
         onDismiss = {
             showSignatureConflictDialog.value = false

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstallViewModel.kt
@@ -521,9 +521,18 @@ class InstallViewModel : ViewModel(), KoinComponent {
                 app.toast(app.getString(R.string.install_app_success))
             }
             is InstallResult.Conflict -> handleConflict(targetPackageName, result.message)
-            is InstallResult.Failure -> handleInstallError(
-                app.getString(R.string.install_app_fail, result.message ?: "Unknown error")
-            )
+            is InstallResult.Failure -> {
+                if (confirmInstallCompleted(outputFile, targetPackageName)) {
+                    Log.w(TAG, "Shizuku Play Store result failed but APK SHA-256 verification succeeded for $targetPackageName")
+                    onPersistApp(targetPackageName, InstallType.SHIZUKU_PLAY_STORE)
+                    handleInstallSuccess(targetPackageName)
+                    app.toast(app.getString(R.string.install_app_success))
+                } else {
+                    handleInstallError(
+                        app.getString(R.string.install_app_fail, result.message ?: "Unknown error")
+                    )
+                }
+            }
         }
     }
 
@@ -561,9 +570,18 @@ class InstallViewModel : ViewModel(), KoinComponent {
                 app.toast(app.getString(R.string.install_app_success))
             }
             is InstallResult.Conflict -> handleConflict(targetPackageName, result.message)
-            is InstallResult.Failure -> handleInstallError(
-                app.getString(R.string.install_app_fail, result.message ?: "Unknown error")
-            )
+            is InstallResult.Failure -> {
+                if (confirmInstallCompleted(outputFile, targetPackageName)) {
+                    Log.w(TAG, "Shizuku result failed but APK SHA-256 verification succeeded for $targetPackageName")
+                    onPersistApp(targetPackageName, InstallType.SHIZUKU)
+                    handleInstallSuccess(targetPackageName)
+                    app.toast(app.getString(R.string.install_app_success))
+                } else {
+                    handleInstallError(
+                        app.getString(R.string.install_app_fail, result.message ?: "Unknown error")
+                    )
+                }
+            }
         }
     }
 
@@ -1036,14 +1054,27 @@ class InstallViewModel : ViewModel(), KoinComponent {
 
     /**
      * Launches system uninstall UI for [packageName] and suspends until the user confirms.
-     * Resets [installState] to [InstallState.Ready] after successful uninstall so the user
-     * can immediately retry installation.
+     * Resets [installState] to [InstallState.Ready] after successful uninstall, or retries
+     * the pending install request when [installAfterUninstall] is true.
      */
-    fun requestUninstall(packageName: String) {
+    fun requestUninstall(packageName: String, installAfterUninstall: Boolean = false) {
         viewModelScope.launch {
             try {
                 sessionInstaller.uninstall(packageName)
-                installState = InstallState.Ready
+                if (installAfterUninstall) {
+                    val file = pendingInstallFile
+                    val originalPkg = pendingOriginalPackageName
+                    val callback = pendingPersistCallback
+                    if (file != null && originalPkg != null && callback != null) {
+                        installState = InstallState.Ready
+                        install(file, originalPkg, callback)
+                    } else {
+                        Log.w(TAG, "Cannot restart install after uninstall: pending install data missing")
+                        installState = InstallState.Ready
+                    }
+                } else {
+                    installState = InstallState.Ready
+                }
             } catch (_: UninstallCancelledException) {
                 // User dismissed the dialog - keep current state
             }


### PR DESCRIPTION
Fixes issue where Auto-install after patching could get stuck indefinitely when Shizuku was selected as the installer.

## What changed

- Resume the pending patched APK install after the user confirms uninstall for a signature mismatch.
- Ensure both patcher conflict paths continue the install after uninstall completes.
- Add a timeout around Shizuku PackageInstaller result callbacks so a missing callback cannot leave the UI spinning forever.
- If Shizuku reports failure, verify whether the patched APK was actually installed by comparing APK hashes before showing an error.

Fixes #680

It's AI-generated, but I tested with shizuku and it works as intended.