### PR TITLE
feat: Multi-select bulk actions for saved APKs and patch selections

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -912,13 +912,11 @@ private fun PatchOptionsDialog(
         onDismissRequest = onDismiss,
         title = patch.name,
         titleTrailingContent = {
-            IconButton(onClick = onReset) {
-                Icon(
-                    imageVector = Icons.Outlined.Restore,
-                    contentDescription = stringResource(R.string.reset),
-                    tint = LocalDialogTextColor.current
-                )
-            }
+            DialogTitleAction(
+                icon = Icons.Outlined.Restore,
+                contentDescription = stringResource(R.string.reset),
+                onClick = onReset
+            )
         },
         footer = {
             MorpheDialogOutlinedButton(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -76,7 +76,7 @@ fun HomeDialogs(
 
     // APK selection processing overlay - blocks interaction while APK is loaded/validated in background
     MorpheOverlay(visible = homeViewModel.processingApkSelection) {
-        PulsingLogoIndicator()
+        PulsingLogoWithCaption(caption = stringResource(R.string.processing_apk))
     }
 
     // Dialog 1: APK availability

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ManagerUpdateAvailableDialog.kt
@@ -176,7 +176,6 @@ fun ManagerUpdateDetailsDialog(
         }
     ) {
         val textColor = LocalDialogTextColor.current
-        val secondaryColor = LocalDialogSecondaryTextColor.current
 
         LazyColumn(modifier = Modifier.fillMaxWidth()) {
             when (state) {
@@ -190,19 +189,9 @@ fun ManagerUpdateDetailsDialog(
                 }
 
                 UpdateViewModel.State.INSTALLING -> item("installing") {
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(20.dp)
-                    ) {
-                        PulsingLogoIndicator()
-                        Text(
-                            text = stringResource(R.string.installing_manager_update),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = secondaryColor,
-                            textAlign = TextAlign.Center
-                        )
-                    }
+                    PulsingLogoWithCaption(
+                        caption = stringResource(R.string.installing_manager_update)
+                    )
                 }
 
                 UpdateViewModel.State.FAILED -> {
@@ -323,7 +312,7 @@ fun ManagerUpdateDetailsDialog(
     }
 
     MorpheOverlay(visible = updateViewModel.isLoadingOlderEntries) {
-        PulsingLogoIndicator()
+        PulsingLogoWithCaption(caption = stringResource(R.string.loading_older_releases))
     }
 
     // Internet check dialog

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1657,10 +1657,6 @@ private fun MultiSelectBar(
         action()
     }
 
-    val selectAllLabel = stringResource(R.string.select_all)
-    val selectAllDone = stringResource(R.string.select_all_done)
-    val deselectAllLabel = stringResource(R.string.deselect_all)
-    val deselectAllDone = stringResource(R.string.deselect_all_done)
     val cancelLabel = stringResource(android.R.string.cancel)
     val reorderListLabel = stringResource(R.string.reorder_list)
     val reorderListHint = stringResource(R.string.reorder_list_hint)
@@ -1669,118 +1665,70 @@ private fun MultiSelectBar(
     val resetOrderDone = stringResource(R.string.reset_order_done)
     val doneLabel = stringResource(R.string.done)
 
-    AnimatedVisibility(
-        visible = visible,
-        enter = MorpheAnimations.springSlideUpEnter,
-        exit = MorpheAnimations.springSlideDownExit,
-        modifier = modifier
-    ) {
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            shape = RoundedCornerShape(16.dp),
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shadowElevation = 8.dp,
-            tonalElevation = 4.dp
-        ) {
-            AnimatedContent(
-                targetState = effectiveReorderMode,
-                transitionSpec = MorpheAnimations.fadeCrossfade(200),
-                label = "multibar_mode"
-            ) { inReorder ->
-                if (inReorder) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            text = reorderListHint,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+    MultiSelectShell(visible = visible, modifier = modifier) {
+        AnimatedContent(
+            targetState = effectiveReorderMode,
+            transitionSpec = MorpheAnimations.fadeCrossfade(200),
+            label = "multibar_mode"
+        ) { inReorder ->
+            if (inReorder) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = reorderListHint,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    ActionPillRow {
+                        ActionPillButton(
+                            onClick = withToast(resetOrderDone, onResetOrder),
+                            icon = Icons.Outlined.Restore,
+                            contentDescription = resetOrderLabel,
+                            tooltip = resetOrderLabel
                         )
-                        ActionPillRow {
-                            ActionPillButton(
-                                onClick = withToast(resetOrderDone, onResetOrder),
-                                icon = Icons.Outlined.Restore,
-                                contentDescription = resetOrderLabel,
-                                tooltip = resetOrderLabel
-                            )
-                            ActionPillButton(
-                                onClick = onCancelReorder,
-                                icon = Icons.Outlined.Close,
-                                contentDescription = cancelLabel,
-                                tooltip = cancelLabel
-                            )
-                            ActionPillButton(
-                                onClick = withToast(reorderDone, onSaveOrder),
-                                icon = Icons.Outlined.Check,
-                                contentDescription = doneLabel,
-                                tooltip = doneLabel
-                            )
-                        }
+                        ActionPillButton(
+                            onClick = onCancelReorder,
+                            icon = Icons.Outlined.Close,
+                            contentDescription = cancelLabel,
+                            tooltip = cancelLabel
+                        )
+                        ActionPillButton(
+                            onClick = withToast(reorderDone, onSaveOrder),
+                            icon = Icons.Outlined.Check,
+                            contentDescription = doneLabel,
+                            tooltip = doneLabel
+                        )
                     }
-                } else {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        AnimatedContent(
-                            targetState = selectedCount,
-                            transitionSpec = MorpheAnimations.compactCounterTransitionSpec,
-                            label = "selected_count"
-                        ) { count ->
-                            Text(
-                                text = "$count ${stringResource(R.string.selected).lowercase()}",
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-
-                        ActionPillRow {
-                            ActionPillButton(
-                                onClick = withToast(selectAllDone, onSelectAll),
-                                icon = Icons.Outlined.DoneAll,
-                                contentDescription = selectAllLabel,
-                                tooltip = selectAllLabel,
-                                enabled = selectedCount < totalCount
-                            )
-                            ActionPillButton(
-                                onClick = withToast(deselectAllDone, onDeselectAll),
-                                icon = Icons.Outlined.RemoveDone,
-                                contentDescription = deselectAllLabel,
-                                tooltip = deselectAllLabel,
-                                enabled = selectedCount > 0
-                            )
-                            ActionPillButton(
-                                onClick = onCancel,
-                                icon = Icons.Outlined.Close,
-                                contentDescription = cancelLabel,
-                                tooltip = cancelLabel
-                            )
-                            ActionPillButton(
-                                onClick = withToast(actionDoneMessage, onAction),
-                                icon = actionIcon,
-                                contentDescription = actionContentDescription,
-                                tooltip = actionContentDescription,
-                                enabled = selectedCount > 0,
-                                colors = actionColors
-                            )
-                            if (showReorderButton) {
-                                ActionPillButton(
-                                    onClick = onEnterReorder,
-                                    icon = Icons.Outlined.Reorder,
-                                    contentDescription = reorderListLabel,
-                                    tooltip = reorderListLabel
-                                )
-                            }
-                        }
+                }
+            } else {
+                SelectionActionBar(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                    selectedCount = selectedCount,
+                    totalCount = totalCount,
+                    onSelectAll = onSelectAll,
+                    onDeselectAll = onDeselectAll,
+                    onCancel = onCancel
+                ) {
+                    ActionPillButton(
+                        onClick = withToast(actionDoneMessage, onAction),
+                        icon = actionIcon,
+                        contentDescription = actionContentDescription,
+                        tooltip = actionContentDescription,
+                        enabled = selectedCount > 0,
+                        colors = actionColors
+                    )
+                    if (showReorderButton) {
+                        ActionPillButton(
+                            onClick = onEnterReorder,
+                            icon = Icons.Outlined.Reorder,
+                            contentDescription = reorderListLabel,
+                            tooltip = reorderListLabel
+                        )
                     }
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1447,63 +1447,6 @@ private fun HomeSearchTextField(
 }
 
 /**
- * App card with optional selection overlay - shared between [DynamicAppCard] and [HiddenAppsDialog].
- *
- * Renders [AppCardLayout] with the given [content], and overlays an animated checkmark badge
- * when [isSelected] is true. Dims the card when [isMultiSelectMode] is active but this card
- * is not selected.
- */
-@Composable
-private fun SelectableAppCard(
-    modifier: Modifier = Modifier,
-    isSelected: Boolean,
-    isMultiSelectMode: Boolean,
-    content: @Composable () -> Unit
-) {
-    val checkScale by animateFloatAsState(
-        targetValue = if (isSelected) 1f else 0f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "check_scale"
-    )
-    val cardAlpha by animateFloatAsState(
-        targetValue = if (isMultiSelectMode && !isSelected) 0.55f else 1f,
-        animationSpec = tween(200),
-        label = "card_alpha"
-    )
-
-    Box(modifier = modifier) {
-        Box(modifier = Modifier.graphicsLayer { alpha = cardAlpha }) {
-            content()
-        }
-
-        // Animated checkmark badge - top-right corner
-        if (checkScale > 0f) {
-            Box(
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(top = 8.dp, end = 8.dp)
-                    .graphicsLayer { scaleX = checkScale; scaleY = checkScale }
-            ) {
-                Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(28.dp)
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = Icons.Outlined.Check,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onPrimary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
  * Single dynamic app card with horizontal swipe gestures:
  * - Swipe LEFT  → reveal hide action
  * - Swipe RIGHT → reveal patches dialog
@@ -1612,9 +1555,9 @@ private fun DynamicAppCard(
                 )
             }
         ) {
-            SelectableAppCard(
+            SelectableCard(
                 isSelected = isSelected,
-                isMultiSelectMode = isMultiSelectMode
+                isSelectionMode = isMultiSelectMode
             ) {
                 Crossfade(
                     targetState = isLoading,
@@ -2726,14 +2669,14 @@ internal fun HiddenAppsDialog(
                         if (isMultiSelectMode.value) offsetX.animateTo(0f, tween(200))
                     }
 
-                    SelectableAppCard(
+                    SelectableCard(
                         modifier = Modifier.animateItem(
                             fadeInSpec = tween(MorpheDefaults.ANIMATION_DURATION),
                             fadeOutSpec = tween(MorpheDefaults.ANIMATION_DURATION_SHORT),
                             placementSpec = spring(stiffness = 400f, dampingRatio = 0.8f)
                         ),
                         isSelected = isSelected,
-                        isMultiSelectMode = isMultiSelectMode.value
+                        isSelectionMode = isMultiSelectMode.value
                     ) {
                         SwipeableCardContainer(
                             offsetX = offsetX,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -834,7 +834,7 @@ fun MainAppsSection(
 ) {
     // Multi-select state - set of packageNames chosen for bulk hide
     val isMultiSelectMode = remember { mutableStateOf(false) }
-    val selectedPackages = remember { mutableStateOf(emptySet<String>()) }
+    val selectedPackages = rememberSelectionState<String>()
 
     // Reorder state
     val isReorderMode = remember { mutableStateOf(false) }
@@ -847,7 +847,7 @@ fun MainAppsSection(
     // Back gesture/button cancels multi-select instead of navigating back
     BackHandler(enabled = isMultiSelectMode.value) {
         isMultiSelectMode.value = false
-        selectedPackages.value = emptySet()
+        selectedPackages.clear()
     }
 
     // Back gesture/button exits reorder mode without saving
@@ -858,11 +858,9 @@ fun MainAppsSection(
 
     // Sync selection and local order with current item list
     LaunchedEffect(homeAppItems) {
-        val filtered = selectedPackages.value.filter { pkg ->
-            homeAppItems.any { it.packageName == pkg }
-        }.toSet()
-        selectedPackages.value = filtered
-        if (filtered.isEmpty()) isMultiSelectMode.value = false
+        val currentPackages = homeAppItems.mapTo(mutableSetOf()) { it.packageName }
+        selectedPackages.retain { it in currentPackages }
+        if (selectedPackages.isEmpty) isMultiSelectMode.value = false
 
         if (!isReorderMode.value) {
             localOrder = homeAppItems.map { it.packageName }
@@ -1082,7 +1080,7 @@ fun MainAppsSection(
                                         items = filteredItems,
                                         key = { _, item -> item.packageName }
                                     ) { index, item ->
-                                        val isSelected = item.packageName in selectedPackages.value
+                                        val isSelected = selectedPackages.contains(item.packageName)
                                         DynamicAppCard(
                                             item = item,
                                             isLoading = stableLoadingState.value,
@@ -1090,10 +1088,7 @@ fun MainAppsSection(
                                             onAppClick = {
                                                 if (isMultiSelectMode.value) {
                                                     // In multi-select mode taps toggle selection
-                                                    selectedPackages.value = if (isSelected)
-                                                        selectedPackages.value - item.packageName
-                                                    else
-                                                        selectedPackages.value + item.packageName
+                                                    selectedPackages.toggle(item.packageName)
                                                 } else {
                                                     onAppClick(item)
                                                 }
@@ -1108,10 +1103,7 @@ fun MainAppsSection(
                                             onLongPress = {
                                                 // Long-press enters multi-select and toggles this card
                                                 isMultiSelectMode.value = true
-                                                selectedPackages.value = if (isSelected)
-                                                    selectedPackages.value - item.packageName
-                                                else
-                                                    selectedPackages.value + item.packageName
+                                                selectedPackages.toggle(item.packageName)
                                             },
                                             onMoveUp = if (directReorderAllowed && index > 0) {
                                                 {
@@ -1283,29 +1275,29 @@ fun MainAppsSection(
 
                     // Multi-select / reorder bar - slides up from bottom
                     MultiSelectBar(
-                        selectedCount = selectedPackages.value.size,
+                        selectedCount = selectedPackages.size,
                         totalCount = homeAppItems.size,
                         visible = isMultibarVisible,
                         isReorderMode = isReorderMode.value,
                         onSelectAll = {
-                            selectedPackages.value = homeAppItems.map { it.packageName }.toSet()
+                            selectedPackages.setAll(homeAppItems.map { it.packageName })
                         },
-                        onDeselectAll = { selectedPackages.value = emptySet() },
+                        onDeselectAll = { selectedPackages.clear() },
                         onAction = {
-                            onHideMultiple(selectedPackages.value)
+                            onHideMultiple(selectedPackages.keys.toSet())
                             isMultiSelectMode.value = false
-                            selectedPackages.value = emptySet()
+                            selectedPackages.clear()
                         },
                         actionIcon = Icons.Outlined.VisibilityOff,
                         actionContentDescription = stringResource(R.string.hide),
                         actionDoneMessage = stringResource(R.string.hidden),
                         onCancel = {
                             isMultiSelectMode.value = false
-                            selectedPackages.value = emptySet()
+                            selectedPackages.clear()
                         },
                         onEnterReorder = {
                             isMultiSelectMode.value = false
-                            selectedPackages.value = emptySet()
+                            selectedPackages.clear()
                             isReorderMode.value = true
                         },
                         onSaveOrder = {
@@ -2554,15 +2546,13 @@ internal fun HiddenAppsDialog(
 ) {
     val itemSpacing = rememberWindowSize().itemSpacing
     val isMultiSelectMode = remember { mutableStateOf(false) }
-    val selectedPackages = remember { mutableStateOf(emptySet<String>()) }
+    val selectedPackages = rememberSelectionState<String>()
 
     // Sync selection with current item list; exit mode if no items remain
     LaunchedEffect(hiddenAppItems) {
-        val filtered = selectedPackages.value.filter { pkg ->
-            hiddenAppItems.any { it.packageName == pkg }
-        }.toSet()
-        selectedPackages.value = filtered
-        if (filtered.isEmpty()) isMultiSelectMode.value = false
+        val currentPackages = hiddenAppItems.mapTo(mutableSetOf()) { it.packageName }
+        selectedPackages.retain { it in currentPackages }
+        if (selectedPackages.isEmpty) isMultiSelectMode.value = false
     }
 
     val view = LocalView.current
@@ -2597,7 +2587,7 @@ internal fun HiddenAppsDialog(
         onDismissRequest = {
             if (isMultiSelectMode.value) {
                 isMultiSelectMode.value = false
-                selectedPackages.value = emptySet()
+                selectedPackages.clear()
             } else {
                 onDismiss()
             }
@@ -2607,18 +2597,18 @@ internal fun HiddenAppsDialog(
         footer = {
             if (isMultiSelectMode.value) {
                 MultiSelectBar(
-                    selectedCount = selectedPackages.value.size,
+                    selectedCount = selectedPackages.size,
                     totalCount = hiddenAppItems.size,
                     visible = true,
                     showReorderButton = false,
                     onSelectAll = {
-                        selectedPackages.value = hiddenAppItems.map { it.packageName }.toSet()
+                        selectedPackages.setAll(hiddenAppItems.map { it.packageName })
                     },
-                    onDeselectAll = { selectedPackages.value = emptySet() },
+                    onDeselectAll = { selectedPackages.clear() },
                     onAction = {
-                        onUnhideMultiple(selectedPackages.value)
+                        onUnhideMultiple(selectedPackages.keys.toSet())
                         isMultiSelectMode.value = false
-                        selectedPackages.value = emptySet()
+                        selectedPackages.clear()
                     },
                     actionIcon = Icons.Outlined.Visibility,
                     actionContentDescription = stringResource(R.string.unhide),
@@ -2629,7 +2619,7 @@ internal fun HiddenAppsDialog(
                     ),
                     onCancel = {
                         isMultiSelectMode.value = false
-                        selectedPackages.value = emptySet()
+                        selectedPackages.clear()
                     },
                     onEnterReorder = {},
                     onSaveOrder = {},
@@ -2661,7 +2651,7 @@ internal fun HiddenAppsDialog(
                     items = hiddenAppItems,
                     key = { it.packageName }
                 ) { item ->
-                    val isSelected = item.packageName in selectedPackages.value
+                    val isSelected = selectedPackages.contains(item.packageName)
                     val offsetX = remember(item.packageName) { Animatable(0f) }
 
                     // Snap card back when entering multi-select
@@ -2703,10 +2693,7 @@ internal fun HiddenAppsDialog(
                                 enabled = true,
                                 onClick = {
                                     if (isMultiSelectMode.value) {
-                                        selectedPackages.value = if (isSelected)
-                                            selectedPackages.value - item.packageName
-                                        else
-                                            selectedPackages.value + item.packageName
+                                        selectedPackages.toggle(item.packageName)
                                     } else {
                                         onUnhide(item.packageName)
                                     }
@@ -2714,10 +2701,7 @@ internal fun HiddenAppsDialog(
                                 onLongClick = {
                                     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                                     isMultiSelectMode.value = true
-                                    selectedPackages.value = if (isSelected)
-                                        selectedPackages.value - item.packageName
-                                    else
-                                        selectedPackages.value + item.packageName
+                                    selectedPackages.toggle(item.packageName)
                                 },
                                 modifier = Modifier.fillMaxWidth()
                             ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -1297,7 +1297,7 @@ fun BundleChangelogDialog(
     }
 
     MorpheOverlay(visible = olderState is OlderBundleState.Loading) {
-        PulsingLogoIndicator()
+        PulsingLogoWithCaption(caption = stringResource(R.string.loading_older_releases))
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/PatchOptionsDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/PatchOptionsDialogs.kt
@@ -75,7 +75,9 @@ fun ThemeColorDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.settings_advanced_patch_options_theme_colors),
         titleTrailingContent = {
-            IconButton(
+            DialogTitleAction(
+                icon = Icons.Outlined.Restore,
+                contentDescription = stringResource(R.string.reset),
                 onClick = {
                     patchOptionsViewModel.resetThemeColors(
                         prefs = patchOptionsPrefs,
@@ -83,12 +85,7 @@ fun ThemeColorDialog(
                         isYouTube = packageName == KnownApps.YOUTUBE
                     )
                 }
-            ) {
-                MorpheIcon(
-                    icon = Icons.Outlined.Restore,
-                    tint = LocalDialogTextColor.current
-                )
-            }
+            )
         },
         footer = {
             MorpheDialogButton(

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -48,11 +48,6 @@ import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
 
 /** Type of APKs to manage. */
 enum class ApkManagementType {
@@ -456,6 +451,7 @@ private fun ApkManagementDialogContent(
     val scope = rememberCoroutineScope()
     var showDeleteAllConfirmation by remember { mutableStateOf(false) }
     var showDeleteSelectedConfirmation by remember { mutableStateOf(false) }
+    var isExporting by remember { mutableStateOf(false) }
     val selection = rememberSelectionState<String>()
     val selectedItems = items.filter { selection.contains(it.selectionKey) }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
@@ -476,15 +472,22 @@ private fun ApkManagementDialogContent(
         zipExportItems = emptyList()
         uri ?: return@rememberLauncherForActivityResult
         scope.launch {
-            val exported = withContext(Dispatchers.IO) {
-                exportSelectedApksToZip(context, uri, itemsToExport)
+            isExporting = true
+            try {
+                val exported = withContext(Dispatchers.IO) {
+                    ZipUtils.zip(context, uri, itemsToExport.mapNotNull { it.file })
+                }
+                context.toast(if (exported) zipExportSuccessText else zipExportFailedText)
+                if (exported) selection.clear()
+            } finally {
+                isExporting = false
             }
-            context.toast(if (exported) zipExportSuccessText else zipExportFailedText)
         }
     }
 
     MorpheDialog(
         onDismissRequest = {
+            if (isExporting) return@MorpheDialog
             if (selection.isNotEmpty) selection.clear() else onDismissRequest()
         },
         title = title,
@@ -539,7 +542,7 @@ private fun ApkManagementDialogContent(
                             ActionPillButton(
                                 onClick = {
                                     zipExportItems = selectedItems
-                                    zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
+                                    zipExportLauncher.launch(FilenameUtils.timestamped(zipExportFileName))
                                 },
                                 icon = Icons.Outlined.Upload,
                                 contentDescription = exportLabel,
@@ -616,6 +619,10 @@ private fun ApkManagementDialogContent(
                 }
             }
         }
+    }
+
+    MorpheOverlay(visible = isExporting) {
+        PulsingLogoIndicator()
     }
 
     if (showDeleteAllConfirmation && deleteAllTitle != null && onDeleteAllConfirm != null) {
@@ -859,50 +866,6 @@ private suspend fun shareApkFiles(context: Context, files: List<File>) {
     try {
         context.startActivity(Intent.createChooser(intent, null))
     } catch (_: android.content.ActivityNotFoundException) { }
-}
-
-private fun exportSelectedApksToZip(
-    context: Context,
-    uri: Uri,
-    items: List<ApkItemData>
-): Boolean {
-    val files = items.mapNotNull { it.file?.takeIf { file -> file.exists() } }
-    if (files.isEmpty()) return false
-
-    return runCatching {
-        context.contentResolver.openOutputStream(uri)?.use { output ->
-            val usedNames = mutableSetOf<String>()
-            ZipOutputStream(output).use { zip ->
-                files.forEach { file ->
-                    zip.putNextEntry(ZipEntry(uniqueZipEntryName(file, usedNames)))
-                    file.inputStream().use { input -> input.copyTo(zip) }
-                    zip.closeEntry()
-                }
-            }
-        } ?: error("Failed to open export stream")
-    }.isSuccess
-}
-
-private fun timestampedZipFileName(fileName: String): String {
-    val timestamp = SimpleDateFormat("yyyy-MM-dd-HHmmss", Locale.US).format(Date())
-    val baseName = fileName.removeSuffix(".zip")
-    return "$baseName-$timestamp.zip"
-}
-
-private fun uniqueZipEntryName(file: File, usedNames: MutableSet<String>): String {
-    val originalName = file.name.ifBlank { "apk-${usedNames.size + 1}.apk" }
-    var candidate = originalName
-    val dotIndex = originalName.lastIndexOf('.')
-    val base = if (dotIndex > 0) originalName.substring(0, dotIndex) else originalName
-    val extension = if (dotIndex > 0) originalName.substring(dotIndex) else ".apk"
-    var suffix = 2
-
-    while (!usedNames.add(candidate)) {
-        candidate = "$base-$suffix$extension"
-        suffix++
-    }
-
-    return candidate
 }
 
 @Composable

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -149,6 +151,7 @@ private fun PatchedApksContent(
 
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<InstalledApp?>(null) }
+    val showDeleteAllConfirmation = remember { mutableStateOf(false) }
 
     var itemToExport by remember { mutableStateOf<ApkItemData?>(null) }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -227,6 +230,9 @@ private fun PatchedApksContent(
         },
         onDelete = { index ->
             itemToDelete.value = apkItems[index].installedApp
+        },
+        onDeleteAll = {
+            showDeleteAllConfirmation.value = true
         }
     )
 
@@ -243,6 +249,24 @@ private fun PatchedApksContent(
                     repository.delete(itemToDelete.value!!)
                     context.toast(patchedApksDeletedText)
                     itemToDelete.value = null
+                }
+            }
+        )
+    }
+
+    if (showDeleteAllConfirmation.value) {
+        DeleteAllConfirmationDialog(
+            title = stringResource(R.string.settings_system_patched_apks_delete_all_title),
+            message = stringResource(R.string.settings_system_patched_apks_delete_all_confirm),
+            count = apkItems.size,
+            totalSize = totalSize,
+            onDismiss = { showDeleteAllConfirmation.value = false },
+            onConfirm = {
+                val appsToDelete = apkItems.map { it.installedApp }
+                scope.launch {
+                    appsToDelete.forEach { repository.delete(it) }
+                    context.toast(context.getString(R.string.settings_system_patched_apks_deleted_all))
+                    showDeleteAllConfirmation.value = false
                 }
             }
         )
@@ -293,6 +317,7 @@ private fun OriginalApksContent(
 
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<OriginalApk?>(null) }
+    val showDeleteAllConfirmation = remember { mutableStateOf(false) }
 
     var itemToExport by remember { mutableStateOf<ApkItemData?>(null) }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -348,6 +373,9 @@ private fun OriginalApksContent(
         onInstall = null,
         onDelete = { index ->
             itemToDelete.value = originalApks[index]
+        },
+        onDeleteAll = {
+            showDeleteAllConfirmation.value = true
         }
     )
 
@@ -368,6 +396,24 @@ private fun OriginalApksContent(
             }
         )
     }
+
+    if (showDeleteAllConfirmation.value) {
+        DeleteAllConfirmationDialog(
+            title = stringResource(R.string.settings_system_original_apks_delete_all_title),
+            message = stringResource(R.string.settings_system_original_apks_delete_all_confirm),
+            count = apkItems.size,
+            totalSize = totalSize,
+            onDismiss = { showDeleteAllConfirmation.value = false },
+            onConfirm = {
+                val apksToDelete = originalApks
+                scope.launch {
+                    apksToDelete.forEach { repository.delete(it) }
+                    context.toast(context.getString(R.string.settings_system_original_apks_deleted_all))
+                    showDeleteAllConfirmation.value = false
+                }
+            }
+        )
+    }
 }
 
 @Composable
@@ -384,11 +430,25 @@ private fun ApkManagementDialogContent(
     onShare: ((ApkItemData) -> Unit)?,
     onExport: ((ApkItemData) -> Unit)?,
     onInstall: ((ApkItemData) -> Unit)?,
-    onDelete: (Int) -> Unit
+    onDelete: (Int) -> Unit,
+    onDeleteAll: (() -> Unit)?
 ) {
     MorpheDialog(
         onDismissRequest = onDismissRequest,
         title = title,
+        titleTrailingContent = if (items.isNotEmpty() && onDeleteAll != null) {
+            {
+                IconButton(onClick = onDeleteAll) {
+                    Icon(
+                        imageVector = Icons.Outlined.DeleteForever,
+                        contentDescription = stringResource(R.string.delete_all),
+                        tint = LocalDialogTextColor.current
+                    )
+                }
+            }
+        } else {
+            null
+        },
         footer = {
             MorpheDialogOutlinedButton(
                 text = stringResource(R.string.close),
@@ -542,6 +602,55 @@ private fun ApkItemCard(
                         containerColor = MaterialTheme.colorScheme.errorContainer,
                         contentColor = MaterialTheme.colorScheme.onErrorContainer
                     )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteAllConfirmationDialog(
+    title: String,
+    message: String,
+    count: Int,
+    totalSize: Long,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = title,
+        footer = {
+            MorpheDialogButtonRow(
+                primaryText = stringResource(R.string.delete_all),
+                onPrimaryClick = onConfirm,
+                isPrimaryDestructive = true,
+                secondaryText = stringResource(android.R.string.cancel),
+                onSecondaryClick = onDismiss
+            )
+        }
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalDialogTextColor.current
+            )
+
+            DeletionWarningBox(
+                warningText = stringResource(R.string.settings_system_patch_selection_will_delete)
+            ) {
+                DeleteListItem(
+                    icon = Icons.Outlined.Delete,
+                    text = pluralStringResource(
+                        R.plurals.settings_system_apks_count,
+                        count,
+                        count
+                    )
+                )
+                DeleteListItem(
+                    icon = Icons.Outlined.Storage,
+                    text = stringResource(R.string.settings_system_apks_size, formatBytes(totalSize))
                 )
             }
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -308,8 +308,8 @@ private fun OriginalApksContent(
     var isLoading by remember { mutableStateOf(true) }
 
     // Pair raw OriginalApk with each rendered ApkItemData so callbacks resolve by key
-    val entries by produceState<List<OriginalApkEntry>>(
-        initialValue = emptyList(),
+    val entries by produceState(
+        initialValue = emptyList<OriginalApkEntry>(),
         key1 = originalApks
     ) {
         isLoading = true
@@ -460,15 +460,6 @@ private fun ApkManagementDialogContent(
     val selectedItems = items.filter { selection.contains(it.selectionKey) }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
     val selectedTotalSize = selectedItems.sumOf { it.fileSize }
-    val selectionTitle = if (selectedItems.isNotEmpty()) {
-        pluralStringResource(
-            R.plurals.settings_system_apks_selected_count,
-            selectedItems.size,
-            selectedItems.size
-        )
-    } else {
-        title
-    }
     val summaryCount = if (selectedItems.isNotEmpty()) selectedItems.size else count
     val summarySize = if (selectedItems.isNotEmpty()) selectedTotalSize else totalSize
     val zipExportSuccessText = stringResource(R.string.settings_system_apks_export_zip_success)
@@ -496,7 +487,7 @@ private fun ApkManagementDialogContent(
 
     MorpheDialog(
         onDismissRequest = onDismissRequest,
-        title = selectionTitle,
+        title = title,
         titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
                 IconButton(onClick = { showDeleteAllConfirmation = true }) {
@@ -511,11 +502,61 @@ private fun ApkManagementDialogContent(
             null
         },
         footer = {
-            MorpheDialogOutlinedButton(
-                text = stringResource(R.string.close),
-                onClick = onDismissRequest,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (selectedItems.isNotEmpty()) {
+                MultiSelectShell(visible = true) {
+                    SelectionActionBar(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        selectedCount = selectedItems.size,
+                        totalCount = items.size,
+                        onSelectAll = { selection.setAll(items.map { it.selectionKey }) },
+                        onCancel = { selection.clear() }
+                    ) {
+                        if (selectedFiles.isNotEmpty()) {
+                            val shareLabel = stringResource(R.string.share)
+                            ActionPillButton(
+                                onClick = {
+                                    scope.launch {
+                                        shareApkFiles(context, selectedFiles)
+                                    }
+                                },
+                                icon = Icons.Outlined.Share,
+                                contentDescription = shareLabel,
+                                tooltip = shareLabel
+                            )
+
+                            val exportLabel = stringResource(R.string.export)
+                            ActionPillButton(
+                                onClick = {
+                                    zipExportItems = selectedItems
+                                    zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
+                                },
+                                icon = Icons.Outlined.Upload,
+                                contentDescription = exportLabel,
+                                tooltip = exportLabel
+                            )
+                        }
+
+                        val deleteLabel = stringResource(R.string.delete)
+                        ActionPillButton(
+                            onClick = { showDeleteSelectedConfirmation = true },
+                            icon = Icons.Outlined.Delete,
+                            contentDescription = deleteLabel,
+                            tooltip = deleteLabel,
+                            enabled = selectedItems.isNotEmpty(),
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        )
+                    }
+                }
+            } else {
+                MorpheDialogOutlinedButton(
+                    text = stringResource(R.string.close),
+                    onClick = onDismissRequest,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         },
         scrollable = false,
         compactPadding = true
@@ -526,91 +567,21 @@ private fun ApkManagementDialogContent(
         ) {
             // Summary box
             item(key = "summary") {
-                Column {
-                    AnimatedVisibility(
-                        visible = selectedItems.isNotEmpty(),
-                        enter = MorpheAnimations.expandFadeEnter,
-                        exit = MorpheAnimations.shrinkFadeExit
-                    ) {
-                        ActionPillRow(
-                            modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = MorpheDefaults.ItemSpacing)
-                        ) {
-                            val selectAllLabel = stringResource(R.string.select_all)
-                            ActionPillButton(
-                                onClick = { selection.setAll(items.map { it.selectionKey }) },
-                                icon = Icons.Outlined.DoneAll,
-                                contentDescription = selectAllLabel,
-                                tooltip = selectAllLabel,
-                                enabled = selectedItems.isNotEmpty() && selectedItems.size < items.size
-                            )
-
-                            if (selectedFiles.isNotEmpty()) {
-                                val shareLabel = stringResource(R.string.share)
-                                ActionPillButton(
-                                    onClick = {
-                                        scope.launch {
-                                            shareApkFiles(context, selectedFiles)
-                                        }
-                                    },
-                                    icon = Icons.Outlined.Share,
-                                    contentDescription = shareLabel,
-                                    tooltip = shareLabel
-                                )
-
-                                val exportLabel = stringResource(R.string.export)
-                                ActionPillButton(
-                                    onClick = {
-                                        zipExportItems = selectedItems
-                                        zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
-                                    },
-                                    icon = Icons.Outlined.Upload,
-                                    contentDescription = exportLabel,
-                                    tooltip = exportLabel
-                                )
-                            }
-
-                            val deleteLabel = stringResource(R.string.delete)
-                            ActionPillButton(
-                                onClick = {
-                                    if (selectedItems.isNotEmpty()) showDeleteSelectedConfirmation = true
-                                },
-                                icon = Icons.Outlined.Delete,
-                                contentDescription = deleteLabel,
-                                tooltip = deleteLabel,
-                                enabled = selectedItems.isNotEmpty(),
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                                )
-                            )
-
-                            val deselectAllLabel = stringResource(R.string.deselect_all)
-                            ActionPillButton(
-                                onClick = { selection.clear() },
-                                icon = Icons.Outlined.Close,
-                                contentDescription = deselectAllLabel,
-                                tooltip = deselectAllLabel,
-                                enabled = selectedItems.isNotEmpty()
-                            )
-                        }
-                    }
-
-                    InfoBox(
-                        title = pluralStringResource(
-                            R.plurals.settings_system_apks_count,
-                            summaryCount,
-                            summaryCount
-                        ),
-                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                        titleColor = MaterialTheme.colorScheme.primary,
-                        icon = icon
-                    ) {
-                        Text(
-                            text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = LocalDialogSecondaryTextColor.current
-                        )
-                    }
+                InfoBox(
+                    title = pluralStringResource(
+                        R.plurals.settings_system_apks_count,
+                        summaryCount,
+                        summaryCount
+                    ),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                    titleColor = MaterialTheme.colorScheme.primary,
+                    icon = icon
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = LocalDialogSecondaryTextColor.current
+                    )
                 }
             }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -622,7 +622,7 @@ private fun ApkManagementDialogContent(
     }
 
     MorpheOverlay(visible = isExporting) {
-        PulsingLogoIndicator()
+        PulsingLogoWithCaption(caption = stringResource(R.string.exporting_apks))
     }
 
     if (showDeleteAllConfirmation && deleteAllTitle != null && onDeleteAllConfirm != null) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -486,7 +486,9 @@ private fun ApkManagementDialogContent(
     }
 
     MorpheDialog(
-        onDismissRequest = onDismissRequest,
+        onDismissRequest = {
+            if (selection.isNotEmpty) selection.clear() else onDismissRequest()
+        },
         title = title,
         titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && onDeleteAllConfirm != null) {
             {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -493,20 +493,12 @@ private fun ApkManagementDialogContent(
         title = title,
         titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
-                FilledTonalIconButton(
+                DialogTitleAction(
+                    icon = Icons.Outlined.DeleteForever,
+                    contentDescription = stringResource(R.string.delete_all),
                     onClick = { showDeleteAllConfirmation = true },
-                    modifier = Modifier.size(36.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.DeleteForever,
-                        contentDescription = stringResource(R.string.delete_all),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
+                    style = DialogTitleActionStyle.Destructive
+                )
             }
         } else {
             null

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
@@ -105,6 +104,12 @@ private data class ApkItemDataWithApp(
     )
 }
 
+/** Pairs a rendered [ApkItemData] with the underlying [OriginalApk] row. */
+private data class OriginalApkEntry(
+    val data: ApkItemData,
+    val apk: OriginalApk
+)
+
 /**
  * Universal dialog for managing APK files (patched or original).
  */
@@ -175,6 +180,13 @@ private fun PatchedApksContent(
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<InstalledApp?>(null) }
 
+    // Resolve callbacks by selectionKey so a concurrent apkItems update between
+    // dialog interaction and confirmation cannot shift indexes onto the wrong app
+    val displayItems = remember(apkItems) { apkItems.map { it.toApkItemData() } }
+    val appByKey = remember(apkItems) {
+        apkItems.associate { it.toApkItemData().selectionKey to it.installedApp }
+    }
+
     var itemToExport by remember { mutableStateOf<ApkItemData?>(null) }
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument(APK_MIMETYPE)
@@ -198,13 +210,13 @@ private fun PatchedApksContent(
     ApkManagementDialogContent(
         title = stringResource(R.string.settings_system_patched_apks_title),
         icon = Icons.Outlined.Apps,
-        count = apkItems.size,
+        count = displayItems.size,
         totalSize = totalSize,
         isLoading = isLoading,
-        isEmpty = apkItems.isEmpty() && !isLoading,
+        isEmpty = displayItems.isEmpty() && !isLoading,
         emptyMessage = stringResource(R.string.settings_system_patched_apks_empty),
         onDismissRequest = onDismissRequest,
-        items = apkItems.map { it.toApkItemData() },
+        items = displayItems,
         zipExportFileName = stringResource(R.string.settings_system_patched_apks_export_zip_name),
         onShare = { item ->
             item.file?.let { file ->
@@ -251,11 +263,11 @@ private fun PatchedApksContent(
                 }
             }
         },
-        onDelete = { index ->
-            itemToDelete.value = apkItems[index].installedApp
+        onDelete = { item ->
+            itemToDelete.value = appByKey[item.selectionKey] ?: return@ApkManagementDialogContent
         },
-        onDeleteSelectedConfirm = { selectedIndexes ->
-            val appsToDelete = selectedIndexes.map { apkItems[it].installedApp }
+        onDeleteSelectedConfirm = { selectedItems ->
+            val appsToDelete = selectedItems.mapNotNull { appByKey[it.selectionKey] }
             scope.launch {
                 appsToDelete.forEach { repository.delete(it) }
                 context.toast(apksDeletedAllText)
@@ -307,32 +319,38 @@ private fun OriginalApksContent(
     // Track loading state
     var isLoading by remember { mutableStateOf(true) }
 
-    // Pre-resolve all app data in a single effect
-    val apkItems by produceState(
+    // Pre-resolve all app data in a single effect and keep the raw OriginalApk
+    // alongside each rendered ApkItemData so callbacks can resolve rows by
+    // selectionKey without relying on positional indexes
+    val entries by produceState<List<OriginalApkEntry>>(
         initialValue = emptyList(),
         key1 = originalApks
     ) {
         isLoading = true
         value = withContext(Dispatchers.IO) {
             originalApks.map { apk ->
-                // Use AppDataResolver to get data
                 val resolvedData = appDataResolver.resolveAppData(
                     apk.packageName,
                     preferredSource = AppDataSource.ORIGINAL_APK
                 )
 
-                ApkItemData(
-                    packageName = apk.packageName,
-                    displayName = resolvedData.displayName,
-                    version = apk.version,
-                    fileSize = apk.fileSize,
-                    file = File(apk.filePath).takeIf { it.exists() }
+                OriginalApkEntry(
+                    data = ApkItemData(
+                        packageName = apk.packageName,
+                        displayName = resolvedData.displayName,
+                        version = apk.version,
+                        fileSize = apk.fileSize,
+                        file = File(apk.filePath).takeIf { it.exists() }
+                    ),
+                    apk = apk
                 )
             }
         }
         isLoading = false
     }
 
+    val apkItems = remember(entries) { entries.map { it.data } }
+    val apkByKey = remember(entries) { entries.associate { it.data.selectionKey to it.apk } }
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<OriginalApk?>(null) }
 
@@ -389,11 +407,11 @@ private fun OriginalApksContent(
             exportLauncher.launch("${item.displayName.replace(" ", "_")}.apk")
         },
         onInstall = null,
-        onDelete = { index ->
-            itemToDelete.value = originalApks[index]
+        onDelete = { item ->
+            itemToDelete.value = apkByKey[item.selectionKey] ?: return@ApkManagementDialogContent
         },
-        onDeleteSelectedConfirm = { selectedIndexes ->
-            val apksToDelete = selectedIndexes.map { originalApks[it] }
+        onDeleteSelectedConfirm = { selectedItems ->
+            val apksToDelete = selectedItems.mapNotNull { apkByKey[it.selectionKey] }
             scope.launch {
                 apksToDelete.forEach { repository.delete(it) }
                 context.toast(apksDeletedAllText)
@@ -401,7 +419,7 @@ private fun OriginalApksContent(
         },
         deleteAllTitle = stringResource(R.string.settings_system_original_apks_delete_all_title),
         onDeleteAllConfirm = {
-            val apksToDelete = originalApks
+            val apksToDelete = entries.map { it.apk }
             scope.launch {
                 apksToDelete.forEach { repository.delete(it) }
                 context.toast(apksDeletedAllText)
@@ -443,8 +461,8 @@ private fun ApkManagementDialogContent(
     onShare: ((ApkItemData) -> Unit)?,
     onExport: ((ApkItemData) -> Unit)?,
     onInstall: ((ApkItemData) -> Unit)?,
-    onDelete: (Int) -> Unit,
-    onDeleteSelectedConfirm: (List<Int>) -> Unit,
+    onDelete: (ApkItemData) -> Unit,
+    onDeleteSelectedConfirm: (List<ApkItemData>) -> Unit,
     deleteAllTitle: String?,
     onDeleteAllConfirm: (() -> Unit)?
 ) {
@@ -621,7 +639,7 @@ private fun ApkManagementDialogContent(
                 // Show shimmer while loading
                 isLoading -> items(3) { ShimmerApkItem() }
                 isEmpty -> item { EmptyState(message = emptyMessage) }
-                else -> itemsIndexed(items = items, key = { _, item -> item.selectionKey }) { index, item ->
+                else -> items(items = items, key = { it.selectionKey }) { item ->
                     val selected = item.selectionKey in selectedKeys
                     ApkItemCard(
                         data = item,
@@ -637,7 +655,7 @@ private fun ApkManagementDialogContent(
                         onShare = if (item.file != null) { { onShare?.invoke(item) } } else null,
                         onExport = if (item.file != null) { { onExport?.invoke(item) } } else null,
                         onInstall = if (item.file != null && onInstall != null) { { onInstall(item) } } else null,
-                        onDelete = { onDelete(index) }
+                        onDelete = { onDelete(item) }
                     )
                 }
             }
@@ -660,9 +678,6 @@ private fun ApkManagementDialogContent(
     }
 
     if (showDeleteSelectedConfirmation) {
-        val selectedIndexes = items.mapIndexedNotNull { index, item ->
-            index.takeIf { item.selectionKey in selectedKeys }
-        }
         DeleteAllConfirmationDialog(
             title = stringResource(R.string.settings_system_apks_delete_selected_title),
             message = stringResource(R.string.settings_system_apks_delete_selected_confirm),
@@ -671,7 +686,7 @@ private fun ApkManagementDialogContent(
             totalSize = selectedTotalSize,
             onDismiss = { showDeleteSelectedConfirmation = false },
             onConfirm = {
-                onDeleteSelectedConfirm(selectedIndexes)
+                onDeleteSelectedConfirm(selectedItems)
                 selectedKeys.clear()
                 showDeleteSelectedConfirmation = false
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -5,7 +5,9 @@
 
 package app.morphe.manager.ui.screen.settings.system
 
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
@@ -13,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -46,6 +49,8 @@ import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 /** Type of APKs to manage. */
 enum class ApkManagementType {
@@ -62,6 +67,9 @@ data class ApkItemData(
     val file: File? = null,
     val installType: InstallType? = null
 )
+
+private val ApkItemData.selectionKey: String
+    get() = file?.absolutePath ?: "$packageName:$version"
 
 /** Data class representing an APK item with reference to InstalledApp. */
 private data class ApkItemDataWithApp(
@@ -231,6 +239,13 @@ private fun PatchedApksContent(
         onDelete = { index ->
             itemToDelete.value = apkItems[index].installedApp
         },
+        onDeleteSelectedConfirm = { selectedIndexes ->
+            val appsToDelete = selectedIndexes.map { apkItems[it].installedApp }
+            scope.launch {
+                appsToDelete.forEach { repository.delete(it) }
+                context.toast(apksDeletedAllText)
+            }
+        },
         deleteAllTitle = stringResource(R.string.settings_system_patched_apks_delete_all_title),
         onDeleteAllConfirm = {
             val appsToDelete = apkItems.map { it.installedApp }
@@ -361,6 +376,13 @@ private fun OriginalApksContent(
         onDelete = { index ->
             itemToDelete.value = originalApks[index]
         },
+        onDeleteSelectedConfirm = { selectedIndexes ->
+            val apksToDelete = selectedIndexes.map { originalApks[it] }
+            scope.launch {
+                apksToDelete.forEach { repository.delete(it) }
+                context.toast(apksDeletedAllText)
+            }
+        },
         deleteAllTitle = stringResource(R.string.settings_system_original_apks_delete_all_title),
         onDeleteAllConfirm = {
             val apksToDelete = originalApks
@@ -405,15 +427,105 @@ private fun ApkManagementDialogContent(
     onExport: ((ApkItemData) -> Unit)?,
     onInstall: ((ApkItemData) -> Unit)?,
     onDelete: (Int) -> Unit,
+    onDeleteSelectedConfirm: (List<Int>) -> Unit,
     deleteAllTitle: String?,
     onDeleteAllConfirm: (() -> Unit)?
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     var showDeleteAllConfirmation by remember { mutableStateOf(false) }
+    var showDeleteSelectedConfirmation by remember { mutableStateOf(false) }
+    val selectedKeys = remember { mutableStateListOf<String>() }
+    val selectedItems = remember(items, selectedKeys.size) {
+        items.filter { it.selectionKey in selectedKeys }
+    }
+    val selectedFiles = remember(selectedItems) {
+        selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
+    }
+    val selectedTotalSize = remember(selectedItems) { selectedItems.sumOf { it.fileSize } }
+    var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
+
+    LaunchedEffect(items) {
+        val currentKeys = items.map { it.selectionKey }.toSet()
+        selectedKeys.removeAll { it !in currentKeys }
+    }
+
+    val zipExportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/zip")
+    ) { uri ->
+        val itemsToExport = zipExportItems
+        zipExportItems = emptyList()
+        uri ?: return@rememberLauncherForActivityResult
+        scope.launch {
+            val exported = withContext(Dispatchers.IO) {
+                exportSelectedApksToZip(context, uri, itemsToExport)
+            }
+            context.toast(
+                context.getString(
+                    if (exported) R.string.settings_system_apks_export_zip_success
+                    else R.string.settings_system_apks_export_zip_failed
+                )
+            )
+        }
+    }
 
     MorpheDialog(
         onDismissRequest = onDismissRequest,
-        title = title,
-        titleTrailingContent = if (items.isNotEmpty() && onDeleteAllConfirm != null) {
+        title = if (selectedItems.isNotEmpty()) {
+            pluralStringResource(
+                R.plurals.settings_system_apks_selected_count,
+                selectedItems.size,
+                selectedItems.size
+            )
+        } else {
+            title
+        },
+        titleTrailingContent = if (selectedItems.isNotEmpty()) {
+            {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (selectedFiles.isNotEmpty()) {
+                        IconButton(onClick = {
+                            scope.launch {
+                                shareApkFiles(context, selectedFiles)
+                            }
+                        }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Share,
+                                contentDescription = stringResource(R.string.share),
+                                tint = LocalDialogTextColor.current
+                            )
+                        }
+
+                        IconButton(onClick = {
+                            zipExportItems = selectedItems
+                            zipExportLauncher.launch("morphe-apks.zip")
+                        }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Upload,
+                                contentDescription = stringResource(R.string.export),
+                                tint = LocalDialogTextColor.current
+                            )
+                        }
+                    }
+
+                    IconButton(onClick = { showDeleteSelectedConfirmation = true }) {
+                        Icon(
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = stringResource(R.string.delete),
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                    }
+
+                    IconButton(onClick = { selectedKeys.clear() }) {
+                        Icon(
+                            imageVector = Icons.Outlined.Close,
+                            contentDescription = stringResource(R.string.close),
+                            tint = LocalDialogTextColor.current
+                        )
+                    }
+                }
+            }
+        } else if (items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
                 IconButton(onClick = { showDeleteAllConfirmation = true }) {
                     Icon(
@@ -465,10 +577,20 @@ private fun ApkManagementDialogContent(
                 // Show shimmer while loading
                 isLoading -> items(3) { ShimmerApkItem() }
                 isEmpty -> item { EmptyState(message = emptyMessage) }
-                else -> items(items = items, key = { it.packageName }) { item ->
+                else -> items(items = items, key = { it.selectionKey }) { item ->
                     val index = items.indexOf(item)
+                    val selected = item.selectionKey in selectedKeys
                     ApkItemCard(
                         data = item,
+                        selected = selected,
+                        selectionMode = selectedItems.isNotEmpty(),
+                        onSelectedChange = { checked ->
+                            if (checked) {
+                                if (item.selectionKey !in selectedKeys) selectedKeys += item.selectionKey
+                            } else {
+                                selectedKeys -= item.selectionKey
+                            }
+                        },
                         onShare = if (item.file != null) { { onShare?.invoke(item) } } else null,
                         onExport = if (item.file != null) { { onExport?.invoke(item) } } else null,
                         onInstall = if (item.file != null && onInstall != null) { { onInstall(item) } } else null,
@@ -482,6 +604,8 @@ private fun ApkManagementDialogContent(
     if (showDeleteAllConfirmation && deleteAllTitle != null && onDeleteAllConfirm != null) {
         DeleteAllConfirmationDialog(
             title = deleteAllTitle,
+            message = stringResource(R.string.settings_system_apks_delete_all_confirm),
+            primaryText = stringResource(R.string.delete_all),
             count = count,
             totalSize = totalSize,
             onDismiss = { showDeleteAllConfirmation = false },
@@ -491,11 +615,33 @@ private fun ApkManagementDialogContent(
             }
         )
     }
+
+    if (showDeleteSelectedConfirmation) {
+        val selectedIndexes = items.mapIndexedNotNull { index, item ->
+            index.takeIf { item.selectionKey in selectedKeys }
+        }
+        DeleteAllConfirmationDialog(
+            title = stringResource(R.string.settings_system_apks_delete_selected_title),
+            message = stringResource(R.string.settings_system_apks_delete_selected_confirm),
+            primaryText = stringResource(R.string.delete),
+            count = selectedItems.size,
+            totalSize = selectedTotalSize,
+            onDismiss = { showDeleteSelectedConfirmation = false },
+            onConfirm = {
+                onDeleteSelectedConfirm(selectedIndexes)
+                selectedKeys.clear()
+                showDeleteSelectedConfirmation = false
+            }
+        )
+    }
 }
 
 @Composable
 private fun ApkItemCard(
     data: ApkItemData,
+    selected: Boolean,
+    selectionMode: Boolean,
+    onSelectedChange: (Boolean) -> Unit,
     onShare: (() -> Unit)?,
     onExport: (() -> Unit)?,
     onInstall: (() -> Unit)?,
@@ -510,6 +656,11 @@ private fun ApkItemCard(
                 horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Checkbox(
+                    checked = selected,
+                    onCheckedChange = onSelectedChange
+                )
+
                 // App icon
                 AppIcon(
                     packageName = data.packageName,
@@ -545,54 +696,56 @@ private fun ApkItemCard(
                 }
             }
 
-            MorpheSettingsDivider()
+            if (!selectionMode) {
+                MorpheSettingsDivider()
 
-            // Action buttons
-            ActionPillRow(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-            ) {
-                if (onShare != null) {
-                    val shareLabel = stringResource(R.string.share)
+                // Action buttons
+                ActionPillRow(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                ) {
+                    if (onShare != null) {
+                        val shareLabel = stringResource(R.string.share)
+                        ActionPillButton(
+                            onClick = onShare,
+                            icon = Icons.Outlined.Share,
+                            contentDescription = shareLabel,
+                            tooltip = shareLabel
+                        )
+                    }
+
+                    if (onExport != null) {
+                        val exportLabel = stringResource(R.string.export)
+                        ActionPillButton(
+                            onClick = onExport,
+                            icon = Icons.Outlined.Upload,
+                            contentDescription = exportLabel,
+                            tooltip = exportLabel
+                        )
+                    }
+
+                    if (onInstall != null) {
+                        val isMountType = data.installType == InstallType.MOUNT
+                        val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
+                        ActionPillButton(
+                            onClick = onInstall,
+                            icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
+                            contentDescription = installLabel,
+                            tooltip = installLabel
+                        )
+                    }
+
+                    val deleteLabel = stringResource(R.string.delete)
                     ActionPillButton(
-                        onClick = onShare,
-                        icon = Icons.Outlined.Share,
-                        contentDescription = shareLabel,
-                        tooltip = shareLabel
+                        onClick = onDelete,
+                        icon = Icons.Outlined.Delete,
+                        contentDescription = deleteLabel,
+                        tooltip = deleteLabel,
+                        colors = IconButtonDefaults.filledTonalIconButtonColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer
+                        )
                     )
                 }
-
-                if (onExport != null) {
-                    val exportLabel = stringResource(R.string.export)
-                    ActionPillButton(
-                        onClick = onExport,
-                        icon = Icons.Outlined.Upload,
-                        contentDescription = exportLabel,
-                        tooltip = exportLabel
-                    )
-                }
-
-                if (onInstall != null) {
-                    val isMountType = data.installType == InstallType.MOUNT
-                    val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
-                    ActionPillButton(
-                        onClick = onInstall,
-                        icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
-                        contentDescription = installLabel,
-                        tooltip = installLabel
-                    )
-                }
-
-                val deleteLabel = stringResource(R.string.delete)
-                ActionPillButton(
-                    onClick = onDelete,
-                    icon = Icons.Outlined.Delete,
-                    contentDescription = deleteLabel,
-                    tooltip = deleteLabel,
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                )
             }
         }
     }
@@ -601,6 +754,8 @@ private fun ApkItemCard(
 @Composable
 private fun DeleteAllConfirmationDialog(
     title: String,
+    message: String,
+    primaryText: String,
     count: Int,
     totalSize: Long,
     onDismiss: () -> Unit,
@@ -611,7 +766,7 @@ private fun DeleteAllConfirmationDialog(
         title = title,
         footer = {
             MorpheDialogButtonRow(
-                primaryText = stringResource(R.string.delete_all),
+                primaryText = primaryText,
                 onPrimaryClick = onConfirm,
                 isPrimaryDestructive = true,
                 secondaryText = stringResource(android.R.string.cancel),
@@ -621,7 +776,7 @@ private fun DeleteAllConfirmationDialog(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
             Text(
-                text = stringResource(R.string.settings_system_apks_delete_all_confirm),
+                text = message,
                 style = MaterialTheme.typography.bodyMedium,
                 color = LocalDialogTextColor.current
             )
@@ -644,6 +799,71 @@ private fun DeleteAllConfirmationDialog(
             }
         }
     }
+}
+
+private suspend fun shareApkFiles(context: Context, files: List<File>) {
+    val existingFiles = files.filter { it.exists() }
+    if (existingFiles.isEmpty()) return
+
+    val uris = withContext(Dispatchers.IO) {
+        existingFiles.map { InstallerFileProvider.getUriForFile(context, it) }
+    }
+
+    val intent = if (uris.size == 1) {
+        Intent(Intent.ACTION_SEND).apply {
+            type = APK_MIMETYPE
+            putExtra(Intent.EXTRA_STREAM, uris.first())
+        }
+    } else {
+        Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+            type = APK_MIMETYPE
+            putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList<Uri>(uris))
+        }
+    }.apply {
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+
+    try {
+        context.startActivity(Intent.createChooser(intent, null))
+    } catch (_: android.content.ActivityNotFoundException) { }
+}
+
+private fun exportSelectedApksToZip(
+    context: Context,
+    uri: Uri,
+    items: List<ApkItemData>
+): Boolean {
+    val files = items.mapNotNull { it.file?.takeIf { file -> file.exists() } }
+    if (files.isEmpty()) return false
+
+    return runCatching {
+        context.contentResolver.openOutputStream(uri)?.use { output ->
+            val usedNames = mutableSetOf<String>()
+            ZipOutputStream(output).use { zip ->
+                files.forEach { file ->
+                    zip.putNextEntry(ZipEntry(uniqueZipEntryName(file, usedNames)))
+                    file.inputStream().use { input -> input.copyTo(zip) }
+                    zip.closeEntry()
+                }
+            }
+        } ?: error("Failed to open export stream")
+    }.isSuccess
+}
+
+private fun uniqueZipEntryName(file: File, usedNames: MutableSet<String>): String {
+    val originalName = file.name.ifBlank { "apk-${usedNames.size + 1}.apk" }
+    var candidate = originalName
+    val dotIndex = originalName.lastIndexOf('.')
+    val base = if (dotIndex > 0) originalName.substring(0, dotIndex) else originalName
+    val extension = if (dotIndex > 0) originalName.substring(dotIndex) else ".apk"
+    var suffix = 2
+
+    while (!usedNames.add(candidate)) {
+        candidate = "$base-$suffix$extension"
+        suffix++
+    }
+
+    return candidate
 }
 
 @Composable

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -50,6 +50,9 @@ import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
@@ -443,6 +446,15 @@ private fun ApkManagementDialogContent(
     val selectedItems = items.filter { it.selectionKey in selectedKeys }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
     val selectedTotalSize = selectedItems.sumOf { it.fileSize }
+    val selectionTitle = if (selectedItems.isNotEmpty()) {
+        pluralStringResource(
+            R.plurals.settings_system_apks_selected_count,
+            selectedItems.size,
+            selectedItems.size
+        ) + " - " + formatBytes(selectedTotalSize)
+    } else {
+        title
+    }
     var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
 
     LaunchedEffect(items) {
@@ -471,18 +483,23 @@ private fun ApkManagementDialogContent(
 
     MorpheDialog(
         onDismissRequest = onDismissRequest,
-        title = if (selectedItems.isNotEmpty()) {
-            pluralStringResource(
-                R.plurals.settings_system_apks_selected_count,
-                selectedItems.size,
-                selectedItems.size
-            )
-        } else {
-            title
-        },
+        title = selectionTitle,
         titleTrailingContent = if (selectedItems.isNotEmpty()) {
             {
                 Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (selectedItems.size < items.size) {
+                        IconButton(onClick = {
+                            selectedKeys.clear()
+                            selectedKeys += items.map { it.selectionKey }
+                        }) {
+                            Icon(
+                                imageVector = Icons.Outlined.DoneAll,
+                                contentDescription = stringResource(R.string.select_all),
+                                tint = LocalDialogTextColor.current
+                            )
+                        }
+                    }
+
                     if (selectedFiles.isNotEmpty()) {
                         IconButton(onClick = {
                             scope.launch {
@@ -498,7 +515,7 @@ private fun ApkManagementDialogContent(
 
                         IconButton(onClick = {
                             zipExportItems = selectedItems
-                            zipExportLauncher.launch(zipExportFileName)
+                            zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
                         }) {
                             Icon(
                                 imageVector = Icons.Outlined.Upload,
@@ -864,6 +881,12 @@ private fun exportSelectedApksToZip(
             }
         } ?: error("Failed to open export stream")
     }.isSuccess
+}
+
+private fun timestampedZipFileName(fileName: String): String {
+    val timestamp = SimpleDateFormat("yyyy-MM-dd-HHmmss", Locale.US).format(Date())
+    val baseName = fileName.removeSuffix(".zip")
+    return "$baseName-$timestamp.zip"
 }
 
 private fun uniqueZipEntryName(file: File, usedNames: MutableSet<String>): String {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -106,6 +106,7 @@ private fun PatchedApksContent(
     val scope = rememberCoroutineScope()
     val saveApkSuccessText = stringResource(R.string.save_apk_success)
     val patchedApksDeletedText = stringResource(R.string.settings_system_patched_apks_deleted)
+    val apksDeletedAllText = stringResource(R.string.settings_system_apks_deleted_all)
     val repository: InstalledAppRepository = koinInject()
     val filesystem: Filesystem = koinInject()
     val appDataResolver: AppDataResolver = koinInject()
@@ -151,7 +152,6 @@ private fun PatchedApksContent(
 
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<InstalledApp?>(null) }
-    val showDeleteAllConfirmation = remember { mutableStateOf(false) }
 
     var itemToExport by remember { mutableStateOf<ApkItemData?>(null) }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -231,8 +231,13 @@ private fun PatchedApksContent(
         onDelete = { index ->
             itemToDelete.value = apkItems[index].installedApp
         },
-        onDeleteAll = {
-            showDeleteAllConfirmation.value = true
+        deleteAllTitle = stringResource(R.string.settings_system_patched_apks_delete_all_title),
+        onDeleteAllConfirm = {
+            val appsToDelete = apkItems.map { it.installedApp }
+            scope.launch {
+                appsToDelete.forEach { repository.delete(it) }
+                context.toast(apksDeletedAllText)
+            }
         }
     )
 
@@ -253,24 +258,6 @@ private fun PatchedApksContent(
             }
         )
     }
-
-    if (showDeleteAllConfirmation.value) {
-        DeleteAllConfirmationDialog(
-            title = stringResource(R.string.settings_system_patched_apks_delete_all_title),
-            message = stringResource(R.string.settings_system_patched_apks_delete_all_confirm),
-            count = apkItems.size,
-            totalSize = totalSize,
-            onDismiss = { showDeleteAllConfirmation.value = false },
-            onConfirm = {
-                val appsToDelete = apkItems.map { it.installedApp }
-                scope.launch {
-                    appsToDelete.forEach { repository.delete(it) }
-                    context.toast(context.getString(R.string.settings_system_patched_apks_deleted_all))
-                    showDeleteAllConfirmation.value = false
-                }
-            }
-        )
-    }
 }
 
 @Composable
@@ -281,6 +268,7 @@ private fun OriginalApksContent(
     val scope = rememberCoroutineScope()
     val saveApkSuccessText = stringResource(R.string.save_apk_success)
     val originalApksDeletedText = stringResource(R.string.settings_system_original_apks_deleted)
+    val apksDeletedAllText = stringResource(R.string.settings_system_apks_deleted_all)
     val repository: OriginalApkRepository = koinInject()
     val appDataResolver: AppDataResolver = koinInject()
 
@@ -317,7 +305,6 @@ private fun OriginalApksContent(
 
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<OriginalApk?>(null) }
-    val showDeleteAllConfirmation = remember { mutableStateOf(false) }
 
     var itemToExport by remember { mutableStateOf<ApkItemData?>(null) }
     val exportLauncher = rememberLauncherForActivityResult(
@@ -374,8 +361,13 @@ private fun OriginalApksContent(
         onDelete = { index ->
             itemToDelete.value = originalApks[index]
         },
-        onDeleteAll = {
-            showDeleteAllConfirmation.value = true
+        deleteAllTitle = stringResource(R.string.settings_system_original_apks_delete_all_title),
+        onDeleteAllConfirm = {
+            val apksToDelete = originalApks
+            scope.launch {
+                apksToDelete.forEach { repository.delete(it) }
+                context.toast(apksDeletedAllText)
+            }
         }
     )
 
@@ -392,24 +384,6 @@ private fun OriginalApksContent(
                     repository.delete(itemToDelete.value!!)
                     context.toast(originalApksDeletedText)
                     itemToDelete.value = null
-                }
-            }
-        )
-    }
-
-    if (showDeleteAllConfirmation.value) {
-        DeleteAllConfirmationDialog(
-            title = stringResource(R.string.settings_system_original_apks_delete_all_title),
-            message = stringResource(R.string.settings_system_original_apks_delete_all_confirm),
-            count = apkItems.size,
-            totalSize = totalSize,
-            onDismiss = { showDeleteAllConfirmation.value = false },
-            onConfirm = {
-                val apksToDelete = originalApks
-                scope.launch {
-                    apksToDelete.forEach { repository.delete(it) }
-                    context.toast(context.getString(R.string.settings_system_original_apks_deleted_all))
-                    showDeleteAllConfirmation.value = false
                 }
             }
         )
@@ -431,14 +405,17 @@ private fun ApkManagementDialogContent(
     onExport: ((ApkItemData) -> Unit)?,
     onInstall: ((ApkItemData) -> Unit)?,
     onDelete: (Int) -> Unit,
-    onDeleteAll: (() -> Unit)?
+    deleteAllTitle: String?,
+    onDeleteAllConfirm: (() -> Unit)?
 ) {
+    var showDeleteAllConfirmation by remember { mutableStateOf(false) }
+
     MorpheDialog(
         onDismissRequest = onDismissRequest,
         title = title,
-        titleTrailingContent = if (items.isNotEmpty() && onDeleteAll != null) {
+        titleTrailingContent = if (items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
-                IconButton(onClick = onDeleteAll) {
+                IconButton(onClick = { showDeleteAllConfirmation = true }) {
                     Icon(
                         imageVector = Icons.Outlined.DeleteForever,
                         contentDescription = stringResource(R.string.delete_all),
@@ -500,6 +477,19 @@ private fun ApkManagementDialogContent(
                 }
             }
         }
+    }
+
+    if (showDeleteAllConfirmation && deleteAllTitle != null && onDeleteAllConfirm != null) {
+        DeleteAllConfirmationDialog(
+            title = deleteAllTitle,
+            count = count,
+            totalSize = totalSize,
+            onDismiss = { showDeleteAllConfirmation = false },
+            onConfirm = {
+                onDeleteAllConfirm()
+                showDeleteAllConfirmation = false
+            }
+        )
     }
 }
 
@@ -611,7 +601,6 @@ private fun ApkItemCard(
 @Composable
 private fun DeleteAllConfirmationDialog(
     title: String,
-    message: String,
     count: Int,
     totalSize: Long,
     onDismiss: () -> Unit,
@@ -632,7 +621,7 @@ private fun DeleteAllConfirmationDialog(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
             Text(
-                text = message,
+                text = stringResource(R.string.settings_system_apks_delete_all_confirm),
                 style = MaterialTheme.typography.bodyMedium,
                 color = LocalDialogTextColor.current
             )

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -456,8 +456,8 @@ private fun ApkManagementDialogContent(
     val scope = rememberCoroutineScope()
     var showDeleteAllConfirmation by remember { mutableStateOf(false) }
     var showDeleteSelectedConfirmation by remember { mutableStateOf(false) }
-    val selectedKeys = remember { mutableStateListOf<String>() }
-    val selectedItems = items.filter { it.selectionKey in selectedKeys }
+    val selection = rememberSelectionState<String>()
+    val selectedItems = items.filter { selection.contains(it.selectionKey) }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
     val selectedTotalSize = selectedItems.sumOf { it.fileSize }
     val selectionTitle = if (selectedItems.isNotEmpty()) {
@@ -477,7 +477,7 @@ private fun ApkManagementDialogContent(
 
     LaunchedEffect(items) {
         val currentKeys = items.map { it.selectionKey }.toSet()
-        selectedKeys.removeAll { it !in currentKeys }
+        selection.retain { it in currentKeys }
     }
 
     val zipExportLauncher = rememberLauncherForActivityResult(
@@ -537,10 +537,7 @@ private fun ApkManagementDialogContent(
                         ) {
                             val selectAllLabel = stringResource(R.string.select_all)
                             ActionPillButton(
-                                onClick = {
-                                    selectedKeys.clear()
-                                    selectedKeys += items.map { it.selectionKey }
-                                },
+                                onClick = { selection.setAll(items.map { it.selectionKey }) },
                                 icon = Icons.Outlined.DoneAll,
                                 contentDescription = selectAllLabel,
                                 tooltip = selectAllLabel,
@@ -589,7 +586,7 @@ private fun ApkManagementDialogContent(
 
                             val deselectAllLabel = stringResource(R.string.deselect_all)
                             ActionPillButton(
-                                onClick = { selectedKeys.clear() },
+                                onClick = { selection.clear() },
                                 icon = Icons.Outlined.Close,
                                 contentDescription = deselectAllLabel,
                                 tooltip = deselectAllLabel,
@@ -623,18 +620,12 @@ private fun ApkManagementDialogContent(
                 isLoading -> items(3) { ShimmerApkItem() }
                 isEmpty -> item { EmptyState(message = emptyMessage) }
                 else -> items(items = items, key = { it.selectionKey }) { item ->
-                    val selected = item.selectionKey in selectedKeys
+                    val selected = selection.contains(item.selectionKey)
                     ApkItemCard(
                         data = item,
                         selected = selected,
                         selectionMode = selectedItems.isNotEmpty(),
-                        onToggleSelection = {
-                            if (item.selectionKey in selectedKeys) {
-                                selectedKeys -= item.selectionKey
-                            } else {
-                                selectedKeys += item.selectionKey
-                            }
-                        },
+                        onToggleSelection = { selection.toggle(item.selectionKey) },
                         onShare = if (item.file != null) { { onShare?.invoke(item) } } else null,
                         onExport = if (item.file != null) { { onExport?.invoke(item) } } else null,
                         onInstall = if (item.file != null && onInstall != null) { { onInstall(item) } } else null,
@@ -670,7 +661,7 @@ private fun ApkManagementDialogContent(
             onDismiss = { showDeleteSelectedConfirmation = false },
             onConfirm = {
                 onDeleteSelectedConfirm(selectedItems)
-                selectedKeys.clear()
+                selection.clear()
                 showDeleteSelectedConfirmation = false
             }
         )

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -436,13 +437,9 @@ private fun ApkManagementDialogContent(
     var showDeleteAllConfirmation by remember { mutableStateOf(false) }
     var showDeleteSelectedConfirmation by remember { mutableStateOf(false) }
     val selectedKeys = remember { mutableStateListOf<String>() }
-    val selectedItems = remember(items, selectedKeys.size) {
-        items.filter { it.selectionKey in selectedKeys }
-    }
-    val selectedFiles = remember(selectedItems) {
-        selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
-    }
-    val selectedTotalSize = remember(selectedItems) { selectedItems.sumOf { it.fileSize } }
+    val selectedItems = items.filter { it.selectionKey in selectedKeys }
+    val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
+    val selectedTotalSize = selectedItems.sumOf { it.fileSize }
     var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
 
     LaunchedEffect(items) {
@@ -584,6 +581,13 @@ private fun ApkManagementDialogContent(
                         data = item,
                         selected = selected,
                         selectionMode = selectedItems.isNotEmpty(),
+                        onToggleSelection = {
+                            if (item.selectionKey in selectedKeys) {
+                                selectedKeys -= item.selectionKey
+                            } else {
+                                selectedKeys += item.selectionKey
+                            }
+                        },
                         onSelectedChange = { checked ->
                             if (checked) {
                                 if (item.selectionKey !in selectedKeys) selectedKeys += item.selectionKey
@@ -641,6 +645,7 @@ private fun ApkItemCard(
     data: ApkItemData,
     selected: Boolean,
     selectionMode: Boolean,
+    onToggleSelection: () -> Unit,
     onSelectedChange: (Boolean) -> Unit,
     onShare: (() -> Unit)?,
     onExport: (() -> Unit)?,
@@ -652,14 +657,22 @@ private fun ApkItemCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .combinedClickable(
+                        onClick = {
+                            if (selectionMode) onToggleSelection()
+                        },
+                        onLongClick = onToggleSelection
+                    )
                     .padding(horizontal = MorpheDefaults.ItemSpacing, vertical = MorpheDefaults.ItemSpacing),
                 horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Checkbox(
-                    checked = selected,
-                    onCheckedChange = onSelectedChange
-                )
+                if (selectionMode) {
+                    Checkbox(
+                        checked = selected,
+                        onCheckedChange = onSelectedChange
+                    )
+                }
 
                 // App icon
                 AppIcon(

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -490,11 +490,18 @@ private fun ApkManagementDialogContent(
         title = title,
         titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
-                IconButton(onClick = { showDeleteAllConfirmation = true }) {
+                FilledTonalIconButton(
+                    onClick = { showDeleteAllConfirmation = true },
+                    modifier = Modifier.size(36.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
                     Icon(
                         imageVector = Icons.Outlined.DeleteForever,
                         contentDescription = stringResource(R.string.delete_all),
-                        tint = LocalDialogTextColor.current
+                        modifier = Modifier.size(20.dp)
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -309,7 +309,7 @@ private fun OriginalApksContent(
 
     // Pair raw OriginalApk with each rendered ApkItemData so callbacks resolve by key
     val entries by produceState(
-        initialValue = emptyList<OriginalApkEntry>(),
+        initialValue = emptyList(),
         key1 = originalApks
     ) {
         isLoading = true

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -12,27 +12,16 @@ import android.view.HapticFeedbackConstants
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -180,8 +169,7 @@ private fun PatchedApksContent(
     val totalSize = remember(apkItems) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<InstalledApp?>(null) }
 
-    // Resolve callbacks by selectionKey so a concurrent apkItems update between
-    // dialog interaction and confirmation cannot shift indexes onto the wrong app
+    // Look up by selectionKey to avoid index shifts on concurrent list updates
     val displayItems = remember(apkItems) { apkItems.map { it.toApkItemData() } }
     val appByKey = remember(apkItems) {
         apkItems.associate { it.toApkItemData().selectionKey to it.installedApp }
@@ -319,9 +307,7 @@ private fun OriginalApksContent(
     // Track loading state
     var isLoading by remember { mutableStateOf(true) }
 
-    // Pre-resolve all app data in a single effect and keep the raw OriginalApk
-    // alongside each rendered ApkItemData so callbacks can resolve rows by
-    // selectionKey without relying on positional indexes
+    // Pair raw OriginalApk with each rendered ApkItemData so callbacks resolve by key
     val entries by produceState<List<OriginalApkEntry>>(
         initialValue = emptyList(),
         key1 = originalApks
@@ -485,6 +471,8 @@ private fun ApkManagementDialogContent(
     }
     val summaryCount = if (selectedItems.isNotEmpty()) selectedItems.size else count
     val summarySize = if (selectedItems.isNotEmpty()) selectedTotalSize else totalSize
+    val zipExportSuccessText = stringResource(R.string.settings_system_apks_export_zip_success)
+    val zipExportFailedText = stringResource(R.string.settings_system_apks_export_zip_failed)
     var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
 
     LaunchedEffect(items) {
@@ -502,12 +490,7 @@ private fun ApkManagementDialogContent(
             val exported = withContext(Dispatchers.IO) {
                 exportSelectedApksToZip(context, uri, itemsToExport)
             }
-            context.toast(
-                context.getString(
-                    if (exported) R.string.settings_system_apks_export_zip_success
-                    else R.string.settings_system_apks_export_zip_failed
-                )
-            )
+            context.toast(if (exported) zipExportSuccessText else zipExportFailedText)
         }
     }
 
@@ -706,156 +689,122 @@ private fun ApkItemCard(
     onDelete: () -> Unit
 ) {
     val view = LocalView.current
-    val checkScale by animateFloatAsState(
-        targetValue = if (selected) 1f else 0f,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioMediumBouncy,
-            stiffness = Spring.StiffnessMedium
-        ),
-        label = "apk_selection_check_scale"
-    )
-    val cardAlpha by animateFloatAsState(
-        targetValue = if (selectionMode && !selected) 0.55f else 1f,
-        animationSpec = tween(200),
-        label = "apk_card_alpha"
-    )
 
-    Box(modifier = Modifier.fillMaxWidth()) {
-        Box(modifier = Modifier.graphicsLayer { alpha = cardAlpha }) {
-            SectionCard {
-                Column {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .combinedClickable(
-                                onClick = {
-                                    if (selectionMode) onToggleSelection()
-                                },
-                                onLongClick = {
-                                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                                    onToggleSelection()
-                                }
-                            )
-                            .padding(horizontal = MorpheDefaults.ItemSpacing, vertical = MorpheDefaults.ItemSpacing),
-                        horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        // App icon
-                        AppIcon(
-                            packageName = data.packageName,
-                            contentDescription = null,
-                            modifier = Modifier.size(48.dp)
-                        )
-
-                        // App info
-                        Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(2.dp)
-                        ) {
-                            Text(
-                                text = data.displayName,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.Medium,
-                                color = LocalDialogTextColor.current
-                            )
-                            Text(
-                                text = data.packageName,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = LocalDialogSecondaryTextColor.current
-                            )
-                            Text(
-                                text = stringResource(
-                                    R.string.settings_system_apk_item_info,
-                                    data.version,
-                                    formatBytes(data.fileSize)
-                                ),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = LocalDialogSecondaryTextColor.current
-                            )
-                        }
-                    }
-
-                    AnimatedVisibility(
-                        visible = !selectionMode,
-                        enter = MorpheAnimations.expandFadeEnter,
-                        exit = MorpheAnimations.shrinkFadeExit
-                    ) {
-                        Column {
-                            MorpheSettingsDivider()
-
-                            // Action buttons
-                            ActionPillRow(
-                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                            ) {
-                                if (onShare != null) {
-                                    val shareLabel = stringResource(R.string.share)
-                                    ActionPillButton(
-                                        onClick = onShare,
-                                        icon = Icons.Outlined.Share,
-                                        contentDescription = shareLabel,
-                                        tooltip = shareLabel
-                                    )
-                                }
-
-                                if (onExport != null) {
-                                    val exportLabel = stringResource(R.string.export)
-                                    ActionPillButton(
-                                        onClick = onExport,
-                                        icon = Icons.Outlined.Upload,
-                                        contentDescription = exportLabel,
-                                        tooltip = exportLabel
-                                    )
-                                }
-
-                                if (onInstall != null) {
-                                    val isMountType = data.installType == InstallType.MOUNT
-                                    val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
-                                    ActionPillButton(
-                                        onClick = onInstall,
-                                        icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
-                                        contentDescription = installLabel,
-                                        tooltip = installLabel
-                                    )
-                                }
-
-                                val deleteLabel = stringResource(R.string.delete)
-                                ActionPillButton(
-                                    onClick = onDelete,
-                                    icon = Icons.Outlined.Delete,
-                                    contentDescription = deleteLabel,
-                                    tooltip = deleteLabel,
-                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                                        contentColor = MaterialTheme.colorScheme.onErrorContainer
-                                    )
-                                )
+    SelectableCard(
+        modifier = Modifier.fillMaxWidth(),
+        isSelected = selected,
+        isSelectionMode = selectionMode,
+        checkmarkContentDescription = stringResource(R.string.selected)
+    ) {
+        SectionCard {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {
+                                if (selectionMode) onToggleSelection()
+                            },
+                            onLongClick = {
+                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                onToggleSelection()
                             }
-                        }
+                        )
+                        .padding(horizontal = MorpheDefaults.ItemSpacing, vertical = MorpheDefaults.ItemSpacing),
+                    horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // App icon
+                    AppIcon(
+                        packageName = data.packageName,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp)
+                    )
+
+                    // App info
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        Text(
+                            text = data.displayName,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium,
+                            color = LocalDialogTextColor.current
+                        )
+                        Text(
+                            text = data.packageName,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
+                        Text(
+                            text = stringResource(
+                                R.string.settings_system_apk_item_info,
+                                data.version,
+                                formatBytes(data.fileSize)
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
                     }
                 }
-            }
-        }
 
-        if (checkScale > 0f) {
-            Surface(
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(top = 8.dp, end = 8.dp)
-                    .size(28.dp)
-                    .graphicsLayer {
-                        scaleX = checkScale
-                        scaleY = checkScale
+                AnimatedVisibility(
+                    visible = !selectionMode,
+                    enter = MorpheAnimations.expandFadeEnter,
+                    exit = MorpheAnimations.shrinkFadeExit
+                ) {
+                    Column {
+                        MorpheSettingsDivider()
+
+                        // Action buttons
+                        ActionPillRow(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                        ) {
+                            if (onShare != null) {
+                                val shareLabel = stringResource(R.string.share)
+                                ActionPillButton(
+                                    onClick = onShare,
+                                    icon = Icons.Outlined.Share,
+                                    contentDescription = shareLabel,
+                                    tooltip = shareLabel
+                                )
+                            }
+
+                            if (onExport != null) {
+                                val exportLabel = stringResource(R.string.export)
+                                ActionPillButton(
+                                    onClick = onExport,
+                                    icon = Icons.Outlined.Upload,
+                                    contentDescription = exportLabel,
+                                    tooltip = exportLabel
+                                )
+                            }
+
+                            if (onInstall != null) {
+                                val isMountType = data.installType == InstallType.MOUNT
+                                val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
+                                ActionPillButton(
+                                    onClick = onInstall,
+                                    icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
+                                    contentDescription = installLabel,
+                                    tooltip = installLabel
+                                )
+                            }
+
+                            val deleteLabel = stringResource(R.string.delete)
+                            ActionPillButton(
+                                onClick = onDelete,
+                                icon = Icons.Outlined.Delete,
+                                contentDescription = deleteLabel,
+                                tooltip = deleteLabel,
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                                )
+                            )
+                        }
                     }
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Outlined.Check,
-                        contentDescription = stringResource(R.string.selected),
-                        tint = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.size(16.dp)
-                    )
                 }
             }
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -192,6 +192,7 @@ private fun PatchedApksContent(
         emptyMessage = stringResource(R.string.settings_system_patched_apks_empty),
         onDismissRequest = onDismissRequest,
         items = apkItems.map { it.toApkItemData() },
+        zipExportFileName = stringResource(R.string.settings_system_patched_apks_export_zip_name),
         onShare = { item ->
             item.file?.let { file ->
                 scope.launch {
@@ -352,6 +353,7 @@ private fun OriginalApksContent(
         emptyMessage = stringResource(R.string.settings_system_original_apks_empty),
         onDismissRequest = onDismissRequest,
         items = apkItems,
+        zipExportFileName = stringResource(R.string.settings_system_original_apks_export_zip_name),
         onShare = { item ->
             item.file?.let { file ->
                 scope.launch {
@@ -424,6 +426,7 @@ private fun ApkManagementDialogContent(
     emptyMessage: String,
     onDismissRequest: () -> Unit,
     items: List<ApkItemData>,
+    zipExportFileName: String,
     onShare: ((ApkItemData) -> Unit)?,
     onExport: ((ApkItemData) -> Unit)?,
     onInstall: ((ApkItemData) -> Unit)?,
@@ -495,7 +498,7 @@ private fun ApkManagementDialogContent(
 
                         IconButton(onClick = {
                             zipExportItems = selectedItems
-                            zipExportLauncher.launch("morphe-apks.zip")
+                            zipExportLauncher.launch(zipExportFileName)
                         }) {
                             Icon(
                                 imageVector = Icons.Outlined.Upload,

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -8,26 +8,35 @@ package app.morphe.manager.ui.screen.settings.system
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.view.HapticFeedbackConstants
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -487,65 +496,7 @@ private fun ApkManagementDialogContent(
     MorpheDialog(
         onDismissRequest = onDismissRequest,
         title = selectionTitle,
-        titleTrailingContent = if (selectedItems.isNotEmpty()) {
-            {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (selectedItems.size < items.size) {
-                        IconButton(onClick = {
-                            selectedKeys.clear()
-                            selectedKeys += items.map { it.selectionKey }
-                        }) {
-                            Icon(
-                                imageVector = Icons.Outlined.DoneAll,
-                                contentDescription = stringResource(R.string.select_all),
-                                tint = LocalDialogTextColor.current
-                            )
-                        }
-                    }
-
-                    if (selectedFiles.isNotEmpty()) {
-                        IconButton(onClick = {
-                            scope.launch {
-                                shareApkFiles(context, selectedFiles)
-                            }
-                        }) {
-                            Icon(
-                                imageVector = Icons.Outlined.Share,
-                                contentDescription = stringResource(R.string.share),
-                                tint = LocalDialogTextColor.current
-                            )
-                        }
-
-                        IconButton(onClick = {
-                            zipExportItems = selectedItems
-                            zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
-                        }) {
-                            Icon(
-                                imageVector = Icons.Outlined.Upload,
-                                contentDescription = stringResource(R.string.export),
-                                tint = LocalDialogTextColor.current
-                            )
-                        }
-                    }
-
-                    IconButton(onClick = { showDeleteSelectedConfirmation = true }) {
-                        Icon(
-                            imageVector = Icons.Outlined.Delete,
-                            contentDescription = stringResource(R.string.delete),
-                            tint = MaterialTheme.colorScheme.error
-                        )
-                    }
-
-                    IconButton(onClick = { selectedKeys.clear() }) {
-                        Icon(
-                            imageVector = Icons.Outlined.Close,
-                            contentDescription = stringResource(R.string.deselect_all),
-                            tint = LocalDialogTextColor.current
-                        )
-                    }
-                }
-            }
-        } else if (items.isNotEmpty() && onDeleteAllConfirm != null) {
+        titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && onDeleteAllConfirm != null) {
             {
                 IconButton(onClick = { showDeleteAllConfirmation = true }) {
                     Icon(
@@ -574,21 +525,94 @@ private fun ApkManagementDialogContent(
         ) {
             // Summary box
             item(key = "summary") {
-                InfoBox(
-                    title = pluralStringResource(
-                        R.plurals.settings_system_apks_count,
-                        summaryCount,
-                        summaryCount
-                    ),
-                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                    titleColor = MaterialTheme.colorScheme.primary,
-                    icon = icon
-                ) {
-                    Text(
-                        text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
+                Column {
+                    AnimatedVisibility(
+                        visible = selectedItems.isNotEmpty(),
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        ActionPillRow(
+                            modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = MorpheDefaults.ItemSpacing)
+                        ) {
+                            val selectAllLabel = stringResource(R.string.select_all)
+                            ActionPillButton(
+                                onClick = {
+                                    selectedKeys.clear()
+                                    selectedKeys += items.map { it.selectionKey }
+                                },
+                                icon = Icons.Outlined.DoneAll,
+                                contentDescription = selectAllLabel,
+                                tooltip = selectAllLabel,
+                                enabled = selectedItems.isNotEmpty() && selectedItems.size < items.size
+                            )
+
+                            if (selectedFiles.isNotEmpty()) {
+                                val shareLabel = stringResource(R.string.share)
+                                ActionPillButton(
+                                    onClick = {
+                                        scope.launch {
+                                            shareApkFiles(context, selectedFiles)
+                                        }
+                                    },
+                                    icon = Icons.Outlined.Share,
+                                    contentDescription = shareLabel,
+                                    tooltip = shareLabel
+                                )
+
+                                val exportLabel = stringResource(R.string.export)
+                                ActionPillButton(
+                                    onClick = {
+                                        zipExportItems = selectedItems
+                                        zipExportLauncher.launch(timestampedZipFileName(zipExportFileName))
+                                    },
+                                    icon = Icons.Outlined.Upload,
+                                    contentDescription = exportLabel,
+                                    tooltip = exportLabel
+                                )
+                            }
+
+                            val deleteLabel = stringResource(R.string.delete)
+                            ActionPillButton(
+                                onClick = {
+                                    if (selectedItems.isNotEmpty()) showDeleteSelectedConfirmation = true
+                                },
+                                icon = Icons.Outlined.Delete,
+                                contentDescription = deleteLabel,
+                                tooltip = deleteLabel,
+                                enabled = selectedItems.isNotEmpty(),
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                                )
+                            )
+
+                            val deselectAllLabel = stringResource(R.string.deselect_all)
+                            ActionPillButton(
+                                onClick = { selectedKeys.clear() },
+                                icon = Icons.Outlined.Close,
+                                contentDescription = deselectAllLabel,
+                                tooltip = deselectAllLabel,
+                                enabled = selectedItems.isNotEmpty()
+                            )
+                        }
+                    }
+
+                    InfoBox(
+                        title = pluralStringResource(
+                            R.plurals.settings_system_apks_count,
+                            summaryCount,
+                            summaryCount
+                        ),
+                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
+                        titleColor = MaterialTheme.colorScheme.primary,
+                        icon = icon
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = LocalDialogSecondaryTextColor.current
+                        )
+                    }
                 }
             }
 
@@ -608,13 +632,6 @@ private fun ApkManagementDialogContent(
                                 selectedKeys -= item.selectionKey
                             } else {
                                 selectedKeys += item.selectionKey
-                            }
-                        },
-                        onSelectedChange = { checked ->
-                            if (checked) {
-                                if (item.selectionKey !in selectedKeys) selectedKeys += item.selectionKey
-                            } else {
-                                selectedKeys -= item.selectionKey
                             }
                         },
                         onShare = if (item.file != null) { { onShare?.invoke(item) } } else null,
@@ -668,117 +685,161 @@ private fun ApkItemCard(
     selected: Boolean,
     selectionMode: Boolean,
     onToggleSelection: () -> Unit,
-    onSelectedChange: (Boolean) -> Unit,
     onShare: (() -> Unit)?,
     onExport: (() -> Unit)?,
     onInstall: (() -> Unit)?,
     onDelete: () -> Unit
 ) {
-    SectionCard {
-        Column {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .combinedClickable(
-                        onClick = {
-                            if (selectionMode) onToggleSelection()
-                        },
-                        onLongClick = onToggleSelection
-                    )
-                    .padding(horizontal = MorpheDefaults.ItemSpacing, vertical = MorpheDefaults.ItemSpacing),
-                horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                if (selectionMode) {
-                    Checkbox(
-                        checked = selected,
-                        onCheckedChange = onSelectedChange
-                    )
-                }
+    val view = LocalView.current
+    val checkScale by animateFloatAsState(
+        targetValue = if (selected) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "apk_selection_check_scale"
+    )
+    val cardAlpha by animateFloatAsState(
+        targetValue = if (selectionMode && !selected) 0.55f else 1f,
+        animationSpec = tween(200),
+        label = "apk_card_alpha"
+    )
 
-                // App icon
-                AppIcon(
-                    packageName = data.packageName,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp)
-                )
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.graphicsLayer { alpha = cardAlpha }) {
+            SectionCard {
+                Column {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .combinedClickable(
+                                onClick = {
+                                    if (selectionMode) onToggleSelection()
+                                },
+                                onLongClick = {
+                                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                    onToggleSelection()
+                                }
+                            )
+                            .padding(horizontal = MorpheDefaults.ItemSpacing, vertical = MorpheDefaults.ItemSpacing),
+                        horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // App icon
+                        AppIcon(
+                            packageName = data.packageName,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp)
+                        )
 
-                // App info
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(2.dp)
-                ) {
-                    Text(
-                        text = data.displayName,
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Medium,
-                        color = LocalDialogTextColor.current
-                    )
-                    Text(
-                        text = data.packageName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
-                    Text(
-                        text = stringResource(
-                            R.string.settings_system_apk_item_info,
-                            data.version,
-                            formatBytes(data.fileSize)
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
+                        // App info
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(2.dp)
+                        ) {
+                            Text(
+                                text = data.displayName,
+                                style = MaterialTheme.typography.bodyLarge,
+                                fontWeight = FontWeight.Medium,
+                                color = LocalDialogTextColor.current
+                            )
+                            Text(
+                                text = data.packageName,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = LocalDialogSecondaryTextColor.current
+                            )
+                            Text(
+                                text = stringResource(
+                                    R.string.settings_system_apk_item_info,
+                                    data.version,
+                                    formatBytes(data.fileSize)
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = LocalDialogSecondaryTextColor.current
+                            )
+                        }
+                    }
+
+                    AnimatedVisibility(
+                        visible = !selectionMode,
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        Column {
+                            MorpheSettingsDivider()
+
+                            // Action buttons
+                            ActionPillRow(
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
+                            ) {
+                                if (onShare != null) {
+                                    val shareLabel = stringResource(R.string.share)
+                                    ActionPillButton(
+                                        onClick = onShare,
+                                        icon = Icons.Outlined.Share,
+                                        contentDescription = shareLabel,
+                                        tooltip = shareLabel
+                                    )
+                                }
+
+                                if (onExport != null) {
+                                    val exportLabel = stringResource(R.string.export)
+                                    ActionPillButton(
+                                        onClick = onExport,
+                                        icon = Icons.Outlined.Upload,
+                                        contentDescription = exportLabel,
+                                        tooltip = exportLabel
+                                    )
+                                }
+
+                                if (onInstall != null) {
+                                    val isMountType = data.installType == InstallType.MOUNT
+                                    val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
+                                    ActionPillButton(
+                                        onClick = onInstall,
+                                        icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
+                                        contentDescription = installLabel,
+                                        tooltip = installLabel
+                                    )
+                                }
+
+                                val deleteLabel = stringResource(R.string.delete)
+                                ActionPillButton(
+                                    onClick = onDelete,
+                                    icon = Icons.Outlined.Delete,
+                                    contentDescription = deleteLabel,
+                                    tooltip = deleteLabel,
+                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                                    )
+                                )
+                            }
+                        }
+                    }
                 }
             }
+        }
 
-            if (!selectionMode) {
-                MorpheSettingsDivider()
-
-                // Action buttons
-                ActionPillRow(
-                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                ) {
-                    if (onShare != null) {
-                        val shareLabel = stringResource(R.string.share)
-                        ActionPillButton(
-                            onClick = onShare,
-                            icon = Icons.Outlined.Share,
-                            contentDescription = shareLabel,
-                            tooltip = shareLabel
-                        )
+        if (checkScale > 0f) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 8.dp, end = 8.dp)
+                    .size(28.dp)
+                    .graphicsLayer {
+                        scaleX = checkScale
+                        scaleY = checkScale
                     }
-
-                    if (onExport != null) {
-                        val exportLabel = stringResource(R.string.export)
-                        ActionPillButton(
-                            onClick = onExport,
-                            icon = Icons.Outlined.Upload,
-                            contentDescription = exportLabel,
-                            tooltip = exportLabel
-                        )
-                    }
-
-                    if (onInstall != null) {
-                        val isMountType = data.installType == InstallType.MOUNT
-                        val installLabel = stringResource(if (isMountType) R.string.mount else R.string.install)
-                        ActionPillButton(
-                            onClick = onInstall,
-                            icon = if (isMountType) Icons.Outlined.Link else Icons.Outlined.InstallMobile,
-                            contentDescription = installLabel,
-                            tooltip = installLabel
-                        )
-                    }
-
-                    val deleteLabel = stringResource(R.string.delete)
-                    ActionPillButton(
-                        onClick = onDelete,
-                        icon = Icons.Outlined.Delete,
-                        contentDescription = deleteLabel,
-                        tooltip = deleteLabel,
-                        colors = IconButtonDefaults.filledTonalIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.errorContainer,
-                            contentColor = MaterialTheme.colorScheme.onErrorContainer
-                        )
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Outlined.Check,
+                        contentDescription = stringResource(R.string.selected),
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(16.dp)
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.Checkbox
@@ -536,7 +537,7 @@ private fun ApkManagementDialogContent(
                     IconButton(onClick = { selectedKeys.clear() }) {
                         Icon(
                             imageVector = Icons.Outlined.Close,
-                            contentDescription = stringResource(R.string.close),
+                            contentDescription = stringResource(R.string.deselect_all),
                             tint = LocalDialogTextColor.current
                         )
                     }
@@ -594,8 +595,7 @@ private fun ApkManagementDialogContent(
                 // Show shimmer while loading
                 isLoading -> items(3) { ShimmerApkItem() }
                 isEmpty -> item { EmptyState(message = emptyMessage) }
-                else -> items(items = items, key = { it.selectionKey }) { item ->
-                    val index = items.indexOf(item)
+                else -> itemsIndexed(items = items, key = { _, item -> item.selectionKey }) { index, item ->
                     val selected = item.selectionKey in selectedKeys
                     ApkItemCard(
                         data = item,

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -452,10 +452,12 @@ private fun ApkManagementDialogContent(
             R.plurals.settings_system_apks_selected_count,
             selectedItems.size,
             selectedItems.size
-        ) + " - " + formatBytes(selectedTotalSize)
+        )
     } else {
         title
     }
+    val summaryCount = if (selectedItems.isNotEmpty()) selectedItems.size else count
+    val summarySize = if (selectedItems.isNotEmpty()) selectedTotalSize else totalSize
     var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
 
     LaunchedEffect(items) {
@@ -575,15 +577,15 @@ private fun ApkManagementDialogContent(
                 InfoBox(
                     title = pluralStringResource(
                         R.plurals.settings_system_apks_count,
-                        count,
-                        count
+                        summaryCount,
+                        summaryCount
                     ),
                     containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
                     titleColor = MaterialTheme.colorScheme.primary,
                     icon = icon
                 ) {
                     Text(
-                        text = stringResource(R.string.settings_system_apks_size, formatBytes(totalSize)),
+                        text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
                         style = MaterialTheme.typography.bodyMedium,
                         color = LocalDialogSecondaryTextColor.current
                     )

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -460,8 +460,6 @@ private fun ApkManagementDialogContent(
     val selectedItems = items.filter { selection.contains(it.selectionKey) }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
     val selectedTotalSize = selectedItems.sumOf { it.fileSize }
-    val summaryCount = if (selectedItems.isNotEmpty()) selectedItems.size else count
-    val summarySize = if (selectedItems.isNotEmpty()) selectedTotalSize else totalSize
     val zipExportSuccessText = stringResource(R.string.settings_system_apks_export_zip_success)
     val zipExportFailedText = stringResource(R.string.settings_system_apks_export_zip_failed)
     var zipExportItems by remember { mutableStateOf<List<ApkItemData>>(emptyList()) }
@@ -517,6 +515,10 @@ private fun ApkManagementDialogContent(
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                         selectedCount = selectedItems.size,
                         totalCount = items.size,
+                        subtitle = stringResource(
+                            R.string.settings_system_apks_size,
+                            formatBytes(selectedTotalSize)
+                        ),
                         onSelectAll = { selection.setAll(items.map { it.selectionKey }) },
                         onCancel = { selection.clear() }
                     ) {
@@ -579,15 +581,15 @@ private fun ApkManagementDialogContent(
                 InfoBox(
                     title = pluralStringResource(
                         R.plurals.settings_system_apks_count,
-                        summaryCount,
-                        summaryCount
+                        count,
+                        count
                     ),
                     containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
                     titleColor = MaterialTheme.colorScheme.primary,
                     icon = icon
                 ) {
                     Text(
-                        text = stringResource(R.string.settings_system_apks_size, formatBytes(summarySize)),
+                        text = stringResource(R.string.settings_system_apks_size, formatBytes(totalSize)),
                         style = MaterialTheme.typography.bodyMedium,
                         color = LocalDialogSecondaryTextColor.current
                     )

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ChangelogDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ChangelogDialog.kt
@@ -84,6 +84,6 @@ fun ChangelogDialog(
     }
 
     MorpheOverlay(visible = updateViewModel.isLoadingOlderEntries) {
-        PulsingLogoIndicator()
+        PulsingLogoWithCaption(caption = stringResource(R.string.loading_older_releases))
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -6,11 +6,12 @@
 package app.morphe.manager.ui.screen.settings.system
 
 import android.net.Uri
+import android.view.HapticFeedbackConstants
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -22,6 +23,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -52,6 +54,7 @@ fun PatchSelectionManagementDialog(
 ) {
     val scope = rememberCoroutineScope()
     val showResetAllConfirmation = remember { mutableStateOf(false) }
+    val showResetSelectedConfirmation = remember { mutableStateOf(false) }
     val resetTarget = remember { mutableStateOf<ResetTarget?>(null) }
     val showPatchDetailsTarget = remember { mutableStateOf<PatchDetailsTarget?>(null) }
     var pendingImportUri by remember { mutableStateOf<Uri?>(null) }
@@ -61,6 +64,20 @@ fun PatchSelectionManagementDialog(
 
     val totalSelections = remember(selections) {
         selections.values.sumOf { bundleMap -> bundleMap.values.sum() }
+    }
+
+    val selectedPackages = rememberSelectionState<String>()
+    val isSelectionMode = remember { mutableStateOf(false) }
+
+    LaunchedEffect(selections) {
+        val currentPackages = selections.keys
+        selectedPackages.retain { it in currentPackages }
+        if (selectedPackages.isEmpty) isSelectionMode.value = false
+    }
+
+    val exitSelection = {
+        isSelectionMode.value = false
+        selectedPackages.clear()
     }
 
     PatchSelectionManagementDialogContent(
@@ -73,8 +90,39 @@ fun PatchSelectionManagementDialog(
         onShowResetAllConfirmation = { showResetAllConfirmation.value = true },
         onSetResetTarget = { resetTarget.value = it },
         onShowPatchDetails = { showPatchDetailsTarget.value = it },
-        onImportUriPicked = { pendingImportUri = it }
+        onImportUriPicked = { pendingImportUri = it },
+        selectedPackages = selectedPackages,
+        isSelectionMode = isSelectionMode.value,
+        onEnterSelection = { pkg ->
+            isSelectionMode.value = true
+            selectedPackages.toggle(pkg)
+        },
+        onToggleSelection = { pkg -> selectedPackages.toggle(pkg) },
+        onExitSelection = exitSelection,
+        onSelectAll = { selectedPackages.setAll(selections.keys) },
+        onShowResetSelectedConfirmation = { showResetSelectedConfirmation.value = true }
     )
+
+    if (showResetSelectedConfirmation.value) {
+        val selectedKeys = selectedPackages.keys.toList()
+        val selectedTotalPatches = remember(selections, selectedKeys) {
+            selectedKeys.sumOf { pkg ->
+                selections[pkg]?.values?.sum() ?: 0
+            }
+        }
+        ConfirmResetSelectedDialog(
+            packageCount = selectedKeys.size,
+            totalPatches = selectedTotalPatches,
+            onConfirm = {
+                scope.launch {
+                    selectedKeys.forEach { settingsViewModel.resetSelectionsForPackage(it) }
+                    exitSelection()
+                    showResetSelectedConfirmation.value = false
+                }
+            },
+            onDismiss = { showResetSelectedConfirmation.value = false }
+        )
+    }
 
     // Import-mode dialog: user picks Replace or Merge before selections are applied
     pendingImportUri?.let { uri ->
@@ -176,7 +224,14 @@ private fun PatchSelectionManagementDialogContent(
     onShowResetAllConfirmation: () -> Unit,
     onSetResetTarget: (ResetTarget) -> Unit,
     onShowPatchDetails: (PatchDetailsTarget) -> Unit,
-    onImportUriPicked: (Uri) -> Unit
+    onImportUriPicked: (Uri) -> Unit,
+    selectedPackages: SelectionState<String>,
+    isSelectionMode: Boolean,
+    onEnterSelection: (String) -> Unit,
+    onToggleSelection: (String) -> Unit,
+    onExitSelection: () -> Unit,
+    onSelectAll: () -> Unit,
+    onShowResetSelectedConfirmation: () -> Unit
 ) {
     val openImportAllSelectionsPicker = rememberAdaptiveFilePicker(
         mimeTypes = arrayOf(JSON_MIMETYPE, TEXT_MIMETYPE),
@@ -191,9 +246,11 @@ private fun PatchSelectionManagementDialogContent(
     }
 
     MorpheDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (isSelectionMode) onExitSelection() else onDismiss()
+        },
         title = stringResource(R.string.settings_system_patch_selections_title),
-        titleTrailingContent = if (selections.isNotEmpty()) {
+        titleTrailingContent = if (!isSelectionMode && selections.isNotEmpty()) {
             {
                 FilledTonalIconButton(
                     onClick = onShowResetAllConfirmation,
@@ -214,35 +271,60 @@ private fun PatchSelectionManagementDialogContent(
             null
         },
         footer = {
-            MorpheDialogButtonColumn {
-                if (selections.isNotEmpty()) {
-                    MorpheDialogButtonRow(
-                        primaryText = stringResource(R.string.export),
-                        onPrimaryClick = {
-                            exportAllSelectionsLauncher.launch(
-                                importExportViewModel.getAllSelectionsExportFileName()
+            if (isSelectionMode) {
+                MultiSelectShell(visible = true) {
+                    SelectionActionBar(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        selectedCount = selectedPackages.size,
+                        totalCount = selections.size,
+                        onSelectAll = onSelectAll,
+                        onCancel = onExitSelection
+                    ) {
+                        val resetLabel = stringResource(R.string.reset)
+                        ActionPillButton(
+                            onClick = onShowResetSelectedConfirmation,
+                            icon = Icons.Outlined.Delete,
+                            contentDescription = resetLabel,
+                            tooltip = resetLabel,
+                            enabled = selectedPackages.isNotEmpty,
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer,
+                                contentColor = MaterialTheme.colorScheme.onErrorContainer
                             )
-                        },
-                        primaryIcon = Icons.Outlined.Upload,
-                        secondaryText = stringResource(R.string.import_),
-                        onSecondaryClick = { openImportAllSelectionsPicker() },
-                        secondaryIcon = Icons.Outlined.Download,
-                        isSecondaryPrimary = true,
-                        layout = DialogButtonLayout.Horizontal
-                    )
-                } else {
-                    MorpheDialogButton(
-                        text = stringResource(R.string.import_),
-                        onClick = { openImportAllSelectionsPicker() },
-                        icon = Icons.Outlined.Download,
+                        )
+                    }
+                }
+            } else {
+                MorpheDialogButtonColumn {
+                    if (selections.isNotEmpty()) {
+                        MorpheDialogButtonRow(
+                            primaryText = stringResource(R.string.export),
+                            onPrimaryClick = {
+                                exportAllSelectionsLauncher.launch(
+                                    importExportViewModel.getAllSelectionsExportFileName()
+                                )
+                            },
+                            primaryIcon = Icons.Outlined.Upload,
+                            secondaryText = stringResource(R.string.import_),
+                            onSecondaryClick = { openImportAllSelectionsPicker() },
+                            secondaryIcon = Icons.Outlined.Download,
+                            isSecondaryPrimary = true,
+                            layout = DialogButtonLayout.Horizontal
+                        )
+                    } else {
+                        MorpheDialogButton(
+                            text = stringResource(R.string.import_),
+                            onClick = { openImportAllSelectionsPicker() },
+                            icon = Icons.Outlined.Download,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    MorpheDialogOutlinedButton(
+                        text = stringResource(R.string.close),
+                        onClick = onDismiss,
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
-                MorpheDialogOutlinedButton(
-                    text = stringResource(R.string.close),
-                    onClick = onDismiss,
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
         },
         scrollable = false,
@@ -258,7 +340,11 @@ private fun PatchSelectionManagementDialogContent(
                 settingsViewModel = settingsViewModel,
                 importExportViewModel = importExportViewModel,
                 onSetResetTarget = onSetResetTarget,
-                onShowPatchDetails = onShowPatchDetails
+                onShowPatchDetails = onShowPatchDetails,
+                selectedPackages = selectedPackages,
+                isSelectionMode = isSelectionMode,
+                onEnterSelection = onEnterSelection,
+                onToggleSelection = onToggleSelection
             )
         }
     }
@@ -275,7 +361,11 @@ private fun SelectionList(
     settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel,
     onSetResetTarget: (ResetTarget) -> Unit,
-    onShowPatchDetails: (PatchDetailsTarget) -> Unit
+    onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    selectedPackages: SelectionState<String>,
+    isSelectionMode: Boolean,
+    onEnterSelection: (String) -> Unit,
+    onToggleSelection: (String) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxWidth(),
@@ -322,7 +412,11 @@ private fun SelectionList(
                 onResetPackageBundle = { bundleUid ->
                     onSetResetTarget(ResetTarget.PackageBundle(packageName, bundleUid))
                 },
-                onShowPatchDetails = onShowPatchDetails
+                onShowPatchDetails = onShowPatchDetails,
+                isSelected = selectedPackages.contains(packageName),
+                isSelectionMode = isSelectionMode,
+                onEnterSelection = { onEnterSelection(packageName) },
+                onToggleSelection = { onToggleSelection(packageName) }
             )
         }
     }
@@ -340,11 +434,16 @@ private fun PackageSelectionItem(
     importExportViewModel: ImportExportViewModel,
     onResetPackage: () -> Unit,
     onResetPackageBundle: (Int) -> Unit,
-    onShowPatchDetails: (PatchDetailsTarget) -> Unit
+    onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    isSelected: Boolean,
+    isSelectionMode: Boolean,
+    onEnterSelection: () -> Unit,
+    onToggleSelection: () -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
     var displayName by remember { mutableStateOf(packageName) }
     var appDataSource by remember { mutableStateOf(AppDataSource.INSTALLED) }
+    val view = LocalView.current
 
     // Resolve app name and source
     LaunchedEffect(packageName) {
@@ -354,115 +453,137 @@ private fun PackageSelectionItem(
     }
 
     val totalPatches = remember(bundleMap) { bundleMap.values.sum() }
+    // In selection mode force cards closed so nested bundle taps do not race with tap-to-toggle
+    val effectiveExpanded = expanded && !isSelectionMode
     val expandRotation by animateFloatAsState(
-        targetValue = if (expanded) 180f else 0f,
+        targetValue = if (effectiveExpanded) 180f else 0f,
         label = "expand_rotation"
     )
 
-    SectionCard {
-        Column {
-            // Header with app icon
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { expanded = !expanded }
-                    .padding(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // App icon
-                AppIcon(
-                    packageName = packageName,
-                    contentDescription = displayName,
-                    modifier = Modifier.size(48.dp),
-                    preferredSource = appDataSource
-                )
-
-                // App info
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
+    SelectableCard(
+        modifier = Modifier.fillMaxWidth(),
+        isSelected = isSelected,
+        isSelectionMode = isSelectionMode
+    ) {
+        SectionCard {
+            Column {
+                // Header with app icon
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {
+                                if (isSelectionMode) onToggleSelection() else expanded = !expanded
+                            },
+                            onLongClick = {
+                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                onEnterSelection()
+                            }
+                        )
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = displayName,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = LocalDialogTextColor.current
+                    // App icon
+                    AppIcon(
+                        packageName = packageName,
+                        contentDescription = displayName,
+                        modifier = Modifier.size(48.dp),
+                        preferredSource = appDataSource
                     )
 
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                    // App info
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
-                        InfoBadge(
-                            text = pluralStringResource(
-                                R.plurals.patch_count,
-                                totalPatches,
-                                totalPatches
-                            ),
-                            style = InfoBadgeStyle.Primary,
-                            isCompact = true
+                        Text(
+                            text = displayName,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = LocalDialogTextColor.current
                         )
 
-                        if (bundleMap.size > 1) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
                             InfoBadge(
                                 text = pluralStringResource(
-                                    R.plurals.source_count,
-                                    bundleMap.size,
-                                    bundleMap.size
+                                    R.plurals.patch_count,
+                                    totalPatches,
+                                    totalPatches
                                 ),
-                                style = InfoBadgeStyle.Default,
+                                style = InfoBadgeStyle.Primary,
                                 isCompact = true
                             )
+
+                            if (bundleMap.size > 1) {
+                                InfoBadge(
+                                    text = pluralStringResource(
+                                        R.plurals.source_count,
+                                        bundleMap.size,
+                                        bundleMap.size
+                                    ),
+                                    style = InfoBadgeStyle.Default,
+                                    isCompact = true
+                                )
+                            }
                         }
+                    }
+
+                    // Expand icon (hidden in selection mode)
+                    AnimatedVisibility(
+                        visible = !isSelectionMode,
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.ExpandMore,
+                            contentDescription = if (effectiveExpanded)
+                                stringResource(R.string.collapse)
+                            else
+                                stringResource(R.string.expand),
+                            tint = LocalDialogSecondaryTextColor.current,
+                            modifier = Modifier.rotate(expandRotation)
+                        )
                     }
                 }
 
-                // Expand icon
-                Icon(
-                    imageVector = Icons.Outlined.ExpandMore,
-                    contentDescription = if (expanded)
-                        stringResource(R.string.collapse)
-                    else
-                        stringResource(R.string.expand),
-                    tint = LocalDialogSecondaryTextColor.current,
-                    modifier = Modifier.rotate(expandRotation)
-                )
-            }
-
-            // Expanded content
-            AnimatedVisibility(
-                visible = expanded,
-                enter = MorpheAnimations.expandTopFadeIn,
-                exit = MorpheAnimations.shrinkTopFadeOut
-            ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing)
+                // Expanded content
+                AnimatedVisibility(
+                    visible = effectiveExpanded,
+                    enter = MorpheAnimations.expandTopFadeIn,
+                    exit = MorpheAnimations.shrinkTopFadeOut
                 ) {
-                    bundleMap.forEach { (bundleUid, patchCount) ->
-                        BundleSelectionItem(
-                            packageName = packageName,
-                            bundleUid = bundleUid,
-                            bundleName = bundleNames[bundleUid],
-                            patchCount = patchCount,
-                            importExportViewModel = importExportViewModel,
-                            onReset = { onResetPackageBundle(bundleUid) },
-                            onShowDetails = {
-                                onShowPatchDetails(PatchDetailsTarget(packageName, bundleUid))
-                            }
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing)
+                    ) {
+                        bundleMap.forEach { (bundleUid, patchCount) ->
+                            BundleSelectionItem(
+                                packageName = packageName,
+                                bundleUid = bundleUid,
+                                bundleName = bundleNames[bundleUid],
+                                patchCount = patchCount,
+                                importExportViewModel = importExportViewModel,
+                                onReset = { onResetPackageBundle(bundleUid) },
+                                onShowDetails = {
+                                    onShowPatchDetails(PatchDetailsTarget(packageName, bundleUid))
+                                }
+                            )
+                        }
+
+                        MorpheSettingsDivider(fullWidth = true)
+
+                        // Reset all for this package
+                        MorpheDialogButton(
+                            text = stringResource(R.string.reset_all),
+                            onClick = onResetPackage,
+                            isDestructive = true,
+                            modifier = Modifier.fillMaxWidth()
                         )
                     }
-
-                    MorpheSettingsDivider(fullWidth = true)
-
-                    // Reset all for this package
-                    MorpheDialogButton(
-                        text = stringResource(R.string.reset_all),
-                        onClick = onResetPackage,
-                        isDestructive = true,
-                        modifier = Modifier.fillMaxWidth()
-                    )
                 }
             }
         }
@@ -583,6 +704,56 @@ private fun BundleSelectionItem(
                     contentColor = MaterialTheme.colorScheme.onErrorContainer
                 )
             )
+        }
+    }
+}
+
+/**
+ * Confirmation dialog for resetting selections across the currently selected packages.
+ */
+@Composable
+private fun ConfirmResetSelectedDialog(
+    packageCount: Int,
+    totalPatches: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.settings_system_patch_selection_reset_selected_confirm_title),
+        footer = {
+            MorpheDialogButtonRow(
+                primaryText = stringResource(R.string.reset),
+                onPrimaryClick = onConfirm,
+                secondaryText = stringResource(android.R.string.cancel),
+                onSecondaryClick = onDismiss,
+                isPrimaryDestructive = true
+            )
+        }
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
+            DeletionWarningBox(
+                warningText = stringResource(R.string.settings_system_patch_selection_will_delete)
+            ) {
+                val patchesText = pluralStringResource(
+                    R.plurals.patch_count,
+                    totalPatches,
+                    totalPatches
+                )
+                val packagesText = pluralStringResource(
+                    R.plurals.package_count,
+                    packageCount,
+                    packageCount
+                )
+                DeleteListItem(
+                    icon = Icons.Outlined.Delete,
+                    text = stringResource(
+                        R.string.settings_system_patch_selection_total_summary_format,
+                        patchesText,
+                        packagesText
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -195,11 +195,18 @@ private fun PatchSelectionManagementDialogContent(
         title = stringResource(R.string.settings_system_patch_selections_title),
         titleTrailingContent = if (selections.isNotEmpty()) {
             {
-                IconButton(onClick = onShowResetAllConfirmation) {
+                FilledTonalIconButton(
+                    onClick = onShowResetAllConfirmation,
+                    modifier = Modifier.size(36.dp),
+                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
                     Icon(
                         imageVector = Icons.Outlined.Restore,
                         contentDescription = stringResource(R.string.reset),
-                        tint = LocalDialogTextColor.current
+                        modifier = Modifier.size(20.dp)
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -252,20 +252,12 @@ private fun PatchSelectionManagementDialogContent(
         title = stringResource(R.string.settings_system_patch_selections_title),
         titleTrailingContent = if (!isSelectionMode && selections.isNotEmpty()) {
             {
-                FilledTonalIconButton(
+                DialogTitleAction(
+                    icon = Icons.Outlined.Restore,
+                    contentDescription = stringResource(R.string.reset),
                     onClick = onShowResetAllConfirmation,
-                    modifier = Modifier.size(36.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer,
-                        contentColor = MaterialTheme.colorScheme.onErrorContainer
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Restore,
-                        contentDescription = stringResource(R.string.reset),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
+                    style = DialogTitleActionStyle.Destructive
+                )
             }
         } else {
             null

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -228,14 +228,11 @@ fun AdaptiveIconCreatorDialog(
         onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.adaptive_icon_create),
         titleTrailingContent = {
-            IconButton(onClick = { showInfoDialog.value = true }) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = stringResource(R.string.adaptive_icon_guide),
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+            DialogTitleAction(
+                icon = Icons.Outlined.Info,
+                contentDescription = stringResource(R.string.adaptive_icon_guide),
+                onClick = { showInfoDialog.value = true }
+            )
         },
         compactPadding = true,
         footer = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -532,7 +532,7 @@ fun AdaptiveIconCreatorDialog(
                 }
             }
             MorpheContentOverlay(visible = isCreating) {
-                PulsingLogoIndicator()
+                PulsingLogoWithCaption(caption = stringResource(R.string.creating))
             }
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -225,14 +225,11 @@ fun HeaderCreatorDialog(
         onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.header_creator_create),
         titleTrailingContent = {
-            IconButton(onClick = { showInfoDialog.value = true }) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = stringResource(R.string.header_creator_guide),
-                    modifier = Modifier.size(24.dp),
-                    tint = LocalDialogTextColor.current
-                )
-            }
+            DialogTitleAction(
+                icon = Icons.Outlined.Info,
+                contentDescription = stringResource(R.string.header_creator_guide),
+                onClick = { showInfoDialog.value = true }
+            )
         },
         compactPadding = false,
         footer = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -411,7 +411,7 @@ fun HeaderCreatorDialog(
                 }
             }
             MorpheContentOverlay(visible = isCreating) {
-                PulsingLogoIndicator()
+                PulsingLogoWithCaption(caption = stringResource(R.string.creating))
             }
         }
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheDialog.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,6 +22,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
@@ -202,6 +207,58 @@ fun BoxScope.MorpheContentOverlay(
             contentAlignment = Alignment.Center,
             content = content
         )
+    }
+}
+
+/** Visual style of a [DialogTitleAction]. */
+enum class DialogTitleActionStyle {
+    /** Flat [IconButton], 24dp icon, dialog text tint. Use for info/reset actions */
+    Plain,
+
+    /** Tonal 36dp circle with errorContainer palette, 20dp icon. Use for bulk destructive actions */
+    Destructive
+}
+
+/**
+ * Icon action rendered inside the [MorpheDialog] title trailing slot. Uniforms the two
+ * button styles used across dialogs so callers only pick an icon and a semantic style.
+ */
+@Composable
+fun DialogTitleAction(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: DialogTitleActionStyle = DialogTitleActionStyle.Plain
+) {
+    when (style) {
+        DialogTitleActionStyle.Plain -> {
+            IconButton(onClick = onClick, modifier = modifier) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(24.dp),
+                    tint = LocalDialogTextColor.current
+                )
+            }
+        }
+
+        DialogTitleActionStyle.Destructive -> {
+            FilledTonalIconButton(
+                onClick = onClick,
+                modifier = modifier.size(36.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                )
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/PulsingLogoIndicator.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/PulsingLogoIndicator.kt
@@ -96,7 +96,7 @@ fun PulsingLogoWithCaption(
         PulsingLogoIndicator(size = size, contentDescription = caption)
         Text(
             text = caption,
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/PulsingLogoIndicator.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/PulsingLogoIndicator.kt
@@ -8,13 +8,20 @@ package app.morphe.manager.ui.screen.shared
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
@@ -68,4 +75,30 @@ fun PulsingLogoIndicator(
                 this.alpha = alpha
             }
     )
+}
+
+/**
+ * [PulsingLogoIndicator] with a centered caption below the logo, used to describe
+ * the operation running behind a full-screen overlay.
+ */
+@Composable
+fun PulsingLogoWithCaption(
+    caption: String,
+    modifier: Modifier = Modifier,
+    size: Dp = 180.dp,
+    spacing: Dp = 20.dp
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing)
+    ) {
+        PulsingLogoIndicator(size = size, contentDescription = caption)
+        Text(
+            text = caption,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectableCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectableCard.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+
+/**
+ * Wraps [content] with the shared selection affordances used by the home app grid and the
+ * saved-APK dialog: an animated check badge in the top-right corner when [isSelected] is true,
+ * and a dim overlay when [isSelectionMode] is active but this card is not selected.
+ */
+@Composable
+fun SelectableCard(
+    modifier: Modifier = Modifier,
+    isSelected: Boolean,
+    isSelectionMode: Boolean,
+    checkmarkContentDescription: String? = null,
+    content: @Composable () -> Unit
+) {
+    val checkScale by animateFloatAsState(
+        targetValue = if (isSelected) 1f else 0f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "check_scale"
+    )
+    val cardAlpha by animateFloatAsState(
+        targetValue = if (isSelectionMode && !isSelected) 0.55f else 1f,
+        animationSpec = tween(200),
+        label = "card_alpha"
+    )
+
+    Box(modifier = modifier) {
+        Box(modifier = Modifier.graphicsLayer { alpha = cardAlpha }) {
+            content()
+        }
+
+        // Animated checkmark badge - top-right corner
+        if (checkScale > 0f) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 8.dp, end = 8.dp)
+                    .graphicsLayer { scaleX = checkScale; scaleY = checkScale }
+            ) {
+                Surface(
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Outlined.Check,
+                            contentDescription = checkmarkContentDescription,
+                            tint = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionActionBar.kt
@@ -66,6 +66,7 @@ fun SelectionActionBar(
     totalCount: Int,
     onSelectAll: () -> Unit,
     modifier: Modifier = Modifier,
+    subtitle: String? = null,
     onDeselectAll: (() -> Unit)? = null,
     onCancel: (() -> Unit)? = null,
     actions: @Composable () -> Unit = {}
@@ -98,6 +99,20 @@ fun SelectionActionBar(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+
+        if (subtitle != null) {
+            AnimatedContent(
+                targetState = subtitle,
+                transitionSpec = MorpheAnimations.compactCounterTransitionSpec,
+                label = "selection_subtitle"
+            ) { text ->
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f)
+                )
+            }
         }
 
         ActionPillRow {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionActionBar.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.DoneAll
+import androidx.compose.material.icons.outlined.RemoveDone
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import app.morphe.manager.util.toast
+
+/**
+ * Slide-up surface used to host a multi-select action row. Keeps the surface, elevation
+ * and enter/exit animations consistent between the home multi-select bar and the saved-APK
+ * dialog footer.
+ */
+@Composable
+fun MultiSelectShell(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = MorpheAnimations.springSlideUpEnter,
+        exit = MorpheAnimations.springSlideDownExit,
+        modifier = modifier
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 8.dp,
+            tonalElevation = 4.dp,
+            content = content
+        )
+    }
+}
+
+/**
+ * Counter label ("N selected") followed by an [ActionPillRow] with SelectAll,
+ * optional DeselectAll and Cancel, and caller-provided [actions]. Meant to be placed
+ * inside a [MultiSelectShell].
+ */
+@Composable
+fun SelectionActionBar(
+    selectedCount: Int,
+    totalCount: Int,
+    onSelectAll: () -> Unit,
+    modifier: Modifier = Modifier,
+    onDeselectAll: (() -> Unit)? = null,
+    onCancel: (() -> Unit)? = null,
+    actions: @Composable () -> Unit = {}
+) {
+    val context = LocalContext.current
+    fun withToast(doneMessage: String, action: () -> Unit): () -> Unit = {
+        context.toast(doneMessage)
+        action()
+    }
+
+    val selectAllLabel = stringResource(R.string.select_all)
+    val selectAllDone = stringResource(R.string.select_all_done)
+    val deselectAllLabel = stringResource(R.string.deselect_all)
+    val deselectAllDone = stringResource(R.string.deselect_all_done)
+    val cancelLabel = stringResource(android.R.string.cancel)
+    val selectedLabel = stringResource(R.string.selected).lowercase()
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        AnimatedContent(
+            targetState = selectedCount,
+            transitionSpec = MorpheAnimations.compactCounterTransitionSpec,
+            label = "selected_count"
+        ) { count ->
+            Text(
+                text = "$count $selectedLabel",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        ActionPillRow {
+            ActionPillButton(
+                onClick = withToast(selectAllDone, onSelectAll),
+                icon = Icons.Outlined.DoneAll,
+                contentDescription = selectAllLabel,
+                tooltip = selectAllLabel,
+                enabled = selectedCount < totalCount
+            )
+            if (onDeselectAll != null) {
+                ActionPillButton(
+                    onClick = withToast(deselectAllDone, onDeselectAll),
+                    icon = Icons.Outlined.RemoveDone,
+                    contentDescription = deselectAllLabel,
+                    tooltip = deselectAllLabel,
+                    enabled = selectedCount > 0
+                )
+            }
+            if (onCancel != null) {
+                ActionPillButton(
+                    onClick = onCancel,
+                    icon = Icons.Outlined.Close,
+                    contentDescription = cancelLabel,
+                    tooltip = cancelLabel
+                )
+            }
+            actions()
+        }
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionState.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SelectionState.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+
+/**
+ * Snapshot-backed set of selection keys shared by the home multi-select bar
+ * and the saved-APK dialog. Holds only the keys - a separate explicit
+ * "selection mode" flag can live alongside if a caller needs one.
+ */
+@Stable
+class SelectionState<K : Any> internal constructor(initial: Collection<K> = emptyList()) {
+    private val backing = mutableStateListOf<K>().apply { addAll(initial.distinct()) }
+
+    val keys: List<K> get() = backing
+    val size: Int get() = backing.size
+    val isEmpty: Boolean get() = backing.isEmpty()
+    val isNotEmpty: Boolean get() = backing.isNotEmpty()
+
+    fun contains(key: K): Boolean = key in backing
+
+    fun toggle(key: K) {
+        if (!backing.remove(key)) backing.add(key)
+    }
+
+    fun add(key: K) {
+        if (key !in backing) backing.add(key)
+    }
+
+    fun remove(key: K) {
+        backing.remove(key)
+    }
+
+    fun setAll(keys: Collection<K>) {
+        backing.clear()
+        backing.addAll(keys.distinct())
+    }
+
+    fun clear() {
+        backing.clear()
+    }
+
+    // Drop keys that no longer satisfy the predicate, e.g. after an external list update
+    fun retain(predicate: (K) -> Boolean) {
+        backing.removeAll { !predicate(it) }
+    }
+}
+
+@Composable
+fun <K : Any> rememberSelectionState(): SelectionState<K> =
+    remember { SelectionState() }
+
+/**
+ * Variant that survives configuration changes when the key type is [String].
+ */
+@Composable
+fun rememberSaveableStringSelectionState(): SelectionState<String> =
+    rememberSaveable(saver = StringSelectionStateSaver) { SelectionState() }
+
+private val StringSelectionStateSaver: Saver<SelectionState<String>, Any> =
+    listSaver(
+        save = { it.keys.toList() },
+        restore = { SelectionState(it) }
+    )

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -347,10 +347,8 @@ class ImportExportViewModel(
     /**
      * Filename for the all-selections export file.
      */
-    fun getAllSelectionsExportFileName(): String {
-        val time = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(LocalDateTime.now())
-        return "morphe_all_selections_$time.json"
-    }
+    fun getAllSelectionsExportFileName(): String =
+        FilenameUtils.timestamped("morphe_all_selections.json")
 
     /**
      * Import patch selections and options from a file.
@@ -455,17 +453,13 @@ class ImportExportViewModel(
      * Get filename for package+bundle data export.
      */
     fun getPackageBundleDataExportFileName(packageName: String, bundleUid: Int, bundleName: String?): String {
-        val time = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(LocalDateTime.now())
         val bundle = bundleName?.replace(" ", "_")?.take(20) ?: "bundle_$bundleUid"
         val pkg = packageName.substringAfterLast('.').take(15)
-        return "morphe_${bundle}_${pkg}_$time.json"
+        return FilenameUtils.timestamped("morphe_${bundle}_${pkg}.json")
     }
 
     val debugLogFileName: String
-        get() {
-            val time = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH:mm").format(LocalDateTime.now())
-            return "morphe_logcat_$time.log"
-        }
+        get() = FilenameUtils.timestamped("morphe_logcat.log")
 
     /**
      * Writes the debug log content to [writer]. Returns the logcat exit code.

--- a/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
@@ -1,13 +1,16 @@
 package app.morphe.manager.util
 
-import java.text.SimpleDateFormat
-import java.util.Locale
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 /**
  * Utility helpers for working with filenames.
  */
 object FilenameUtils {
-    private val TIMESTAMP_FORMAT = SimpleDateFormat("yyyy-MM-dd-HHmmss", Locale.US)
+    // DateTimeFormatter is immutable and thread-safe, safe as a shared instance
+    private val TIMESTAMP_FORMAT: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss").withZone(ZoneId.systemDefault())
 
     /**
      * Sanitize a string so it can safely be used as part of a filename.
@@ -37,7 +40,7 @@ object FilenameUtils {
      * Insert a "yyyy-MM-dd-HHmmss" timestamp before the extension of [fileName].
      */
     fun timestamped(fileName: String): String {
-        val timestamp = TIMESTAMP_FORMAT.format(java.util.Date())
+        val timestamp = TIMESTAMP_FORMAT.format(Instant.now())
         val dotIndex = fileName.lastIndexOf('.')
         return if (dotIndex > 0) {
             "${fileName.substring(0, dotIndex)}-$timestamp${fileName.substring(dotIndex)}"

--- a/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
@@ -1,9 +1,14 @@
 package app.morphe.manager.util
 
+import java.text.SimpleDateFormat
+import java.util.Locale
+
 /**
  * Utility helpers for working with filenames.
  */
 object FilenameUtils {
+    private val TIMESTAMP_FORMAT = SimpleDateFormat("yyyy-MM-dd-HHmmss", Locale.US)
+
     /**
      * Sanitize a string so it can safely be used as part of a filename.
      */
@@ -26,5 +31,19 @@ object FilenameUtils {
             .replace(Regex("[_]{2,}"), "_")
             .replace(Regex("[-]{2,}"), "-")
             .trim('_', '-')
+    }
+
+    /**
+     * Insert a "yyyy-MM-dd-HHmmss" timestamp before the extension of [fileName],
+     * e.g. "backup.zip" -> "backup-2026-07-05-153000.zip".
+     */
+    fun timestamped(fileName: String): String {
+        val timestamp = TIMESTAMP_FORMAT.format(java.util.Date())
+        val dotIndex = fileName.lastIndexOf('.')
+        return if (dotIndex > 0) {
+            "${fileName.substring(0, dotIndex)}-$timestamp${fileName.substring(dotIndex)}"
+        } else {
+            "$fileName-$timestamp"
+        }
     }
 }

--- a/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FilenameUtils.kt
@@ -28,14 +28,13 @@ object FilenameUtils {
         }
 
         return raw
-            .replace(Regex("[_]{2,}"), "_")
-            .replace(Regex("[-]{2,}"), "-")
+            .replace(Regex("_{2,}"), "_")
+            .replace(Regex("-{2,}"), "-")
             .trim('_', '-')
     }
 
     /**
-     * Insert a "yyyy-MM-dd-HHmmss" timestamp before the extension of [fileName],
-     * e.g. "backup.zip" -> "backup-2026-07-05-153000.zip".
+     * Insert a "yyyy-MM-dd-HHmmss" timestamp before the extension of [fileName].
      */
     fun timestamped(fileName: String): String {
         val timestamp = TIMESTAMP_FORMAT.format(java.util.Date())

--- a/app/src/main/java/app/morphe/manager/util/ZipUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/ZipUtils.kt
@@ -1,0 +1,51 @@
+package app.morphe.manager.util
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Utility for writing plain files into a zip archive at a content [Uri].
+ */
+object ZipUtils {
+    /**
+     * Writes the existing files in [files] into a new zip archive at [uri].
+     * Non-existent files are silently skipped. Returns false if nothing was
+     * written or write failed.
+     */
+    fun zip(context: Context, uri: Uri, files: List<File>): Boolean {
+        val existingFiles = files.filter { it.exists() }
+        if (existingFiles.isEmpty()) return false
+
+        return runCatching {
+            context.contentResolver.openOutputStream(uri)?.use { output ->
+                val usedNames = mutableSetOf<String>()
+                ZipOutputStream(output).use { zip ->
+                    existingFiles.forEach { file ->
+                        zip.putNextEntry(ZipEntry(uniqueEntryName(file, usedNames)))
+                        file.inputStream().use { input -> input.copyTo(zip) }
+                        zip.closeEntry()
+                    }
+                }
+            } ?: error("Failed to open export stream")
+        }.isSuccess
+    }
+
+    private fun uniqueEntryName(file: File, usedNames: MutableSet<String>): String {
+        val originalName = file.name.ifBlank { "file-${usedNames.size + 1}" }
+        var candidate = originalName
+        val dotIndex = originalName.lastIndexOf('.')
+        val base = if (dotIndex > 0) originalName.substring(0, dotIndex) else originalName
+        val extension = if (dotIndex > 0) originalName.substring(dotIndex) else ""
+        var suffix = 2
+
+        while (!usedNames.add(candidate)) {
+            candidate = "$base-$suffix$extension"
+            suffix++
+        }
+
+        return candidate
+    }
+}

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -24,6 +24,10 @@
         <item quantity="one">%s APK file</item>
         <item quantity="other">%s APK files</item>
     </plurals>
+    <plurals name="settings_system_apks_selected_count">
+        <item quantity="one">%s selected</item>
+        <item quantity="other">%s selected</item>
+    </plurals>
     <plurals name="home_app_info_repatch_cleaned_invalid_data">
         <item quantity="one">Removed %s outdated patch from saved selection</item>
         <item quantity="other">Removed %s outdated patches from saved selection</item>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -24,10 +24,6 @@
         <item quantity="one">%s APK file</item>
         <item quantity="other">%s APK files</item>
     </plurals>
-    <plurals name="settings_system_apks_selected_count">
-        <item quantity="one">%s selected</item>
-        <item quantity="other">%s selected</item>
-    </plurals>
     <plurals name="home_app_info_repatch_cleaned_invalid_data">
         <item quantity="one">Removed %s outdated patch from saved selection</item>
         <item quantity="other">Removed %s outdated patches from saved selection</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -764,7 +764,11 @@ The image dimensions must be as follows:
     <string name="settings_system_files">Files &amp; storage</string>
     <string name="settings_system_apks_size">Total size: %s</string>
     <string name="settings_system_apks_delete_all_confirm">This will permanently delete the saved APK files shown here</string>
+    <string name="settings_system_apks_delete_selected_title">Delete selected APKs?</string>
+    <string name="settings_system_apks_delete_selected_confirm">This will permanently delete the selected APK files</string>
     <string name="settings_system_apks_deleted_all">APKs deleted successfully</string>
+    <string name="settings_system_apks_export_zip_success">Selected APKs exported</string>
+    <string name="settings_system_apks_export_zip_failed">Failed to export selected APKs</string>
     <string name="settings_system_apk_item_info" translatable="false">v%s • %s</string>
 
     <!-- Settings - System Tab - Storage Management - Patched APKs Management -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -779,6 +779,7 @@ The image dimensions must be as follows:
     <string name="settings_system_patched_apks_delete_confirm">Are you sure you want to delete the saved patched APK for %s?</string>
     <string name="settings_system_patched_apks_deleted">Patched APK deleted successfully</string>
     <string name="settings_system_patched_apks_delete_all_title">Delete all patched APKs?</string>
+    <string name="settings_system_patched_apks_export_zip_name" translatable="false">morphe-patched-apks.zip</string>
 
     <!-- Settings - System Tab - Storage Management - Original APKs Management -->
     <string name="settings_system_original_apks_title">Original APKs</string>
@@ -788,6 +789,7 @@ The image dimensions must be as follows:
     <string name="settings_system_original_apks_delete_title">Delete original APK?</string>
     <string name="settings_system_original_apks_delete_confirm">Delete original APK for %s? You won\'t be able to repatch without providing a new APK</string>
     <string name="settings_system_original_apks_delete_all_title">Delete all original APKs?</string>
+    <string name="settings_system_original_apks_export_zip_name" translatable="false">morphe-original-apks.zip</string>
 
     <!-- Settings - System Tab - Storage Management - Patch Selection Management -->
     <string name="settings_system_patch_selections_title">Patch selections</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -796,6 +796,7 @@ The image dimensions must be as follows:
     <string name="settings_system_patch_selections_description">Saved patch selections, retained after uninstall</string>
     <string name="settings_system_patch_selection_reset_all_confirm_title">Reset all selections?</string>
     <string name="settings_system_patch_selection_reset_package_confirm_title">Reset package selections?</string>
+    <string name="settings_system_patch_selection_reset_selected_confirm_title">Reset selected selections?</string>
     <string name="settings_system_patch_selection_reset_source_confirm_title">Reset source selection?</string>
     <string name="settings_system_patch_selection_no_saved">No saved patch selections</string>
     <string name="settings_system_patch_selection_total_summary_format">%1$s across %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -874,6 +874,10 @@ The image dimensions must be as follows:
     <string name="disable">Disable</string>
     <string name="enable">Enable</string>
     <string name="loading">Loading…</string>
+    <string name="loading_older_releases">Loading older releases…</string>
+    <string name="creating">Creating…</string>
+    <string name="processing_apk">Processing APK…</string>
+    <string name="exporting_apks">Exporting APKs…</string>
     <string name="not_installed">Not installed</string>
     <string name="view">View</string>
     <string name="search">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -763,6 +763,8 @@ The image dimensions must be as follows:
     <!-- Settings - System Tab - Files & Storage Section -->
     <string name="settings_system_files">Files &amp; storage</string>
     <string name="settings_system_apks_size">Total size: %s</string>
+    <string name="settings_system_apks_delete_all_confirm">This will permanently delete the saved APK files shown here</string>
+    <string name="settings_system_apks_deleted_all">APKs deleted successfully</string>
     <string name="settings_system_apk_item_info" translatable="false">v%s • %s</string>
 
     <!-- Settings - System Tab - Storage Management - Patched APKs Management -->
@@ -773,8 +775,6 @@ The image dimensions must be as follows:
     <string name="settings_system_patched_apks_delete_confirm">Are you sure you want to delete the saved patched APK for %s?</string>
     <string name="settings_system_patched_apks_deleted">Patched APK deleted successfully</string>
     <string name="settings_system_patched_apks_delete_all_title">Delete all patched APKs?</string>
-    <string name="settings_system_patched_apks_delete_all_confirm">This will permanently delete every saved patched APK file</string>
-    <string name="settings_system_patched_apks_deleted_all">Patched APKs deleted successfully</string>
 
     <!-- Settings - System Tab - Storage Management - Original APKs Management -->
     <string name="settings_system_original_apks_title">Original APKs</string>
@@ -784,8 +784,6 @@ The image dimensions must be as follows:
     <string name="settings_system_original_apks_delete_title">Delete original APK?</string>
     <string name="settings_system_original_apks_delete_confirm">Delete original APK for %s? You won\'t be able to repatch without providing a new APK</string>
     <string name="settings_system_original_apks_delete_all_title">Delete all original APKs?</string>
-    <string name="settings_system_original_apks_delete_all_confirm">This will permanently delete every saved original APK file. You won\'t be able to repatch without providing new APKs</string>
-    <string name="settings_system_original_apks_deleted_all">Original APKs deleted successfully</string>
 
     <!-- Settings - System Tab - Storage Management - Patch Selection Management -->
     <string name="settings_system_patch_selections_title">Patch selections</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,6 +772,9 @@ The image dimensions must be as follows:
     <string name="settings_system_patched_apks_delete_title">Delete patched APK?</string>
     <string name="settings_system_patched_apks_delete_confirm">Are you sure you want to delete the saved patched APK for %s?</string>
     <string name="settings_system_patched_apks_deleted">Patched APK deleted successfully</string>
+    <string name="settings_system_patched_apks_delete_all_title">Delete all patched APKs?</string>
+    <string name="settings_system_patched_apks_delete_all_confirm">This will permanently delete every saved patched APK file</string>
+    <string name="settings_system_patched_apks_deleted_all">Patched APKs deleted successfully</string>
 
     <!-- Settings - System Tab - Storage Management - Original APKs Management -->
     <string name="settings_system_original_apks_title">Original APKs</string>
@@ -780,6 +783,9 @@ The image dimensions must be as follows:
     <string name="settings_system_original_apks_deleted">Original APK deleted successfully</string>
     <string name="settings_system_original_apks_delete_title">Delete original APK?</string>
     <string name="settings_system_original_apks_delete_confirm">Delete original APK for %s? You won\'t be able to repatch without providing a new APK</string>
+    <string name="settings_system_original_apks_delete_all_title">Delete all original APKs?</string>
+    <string name="settings_system_original_apks_delete_all_confirm">This will permanently delete every saved original APK file. You won\'t be able to repatch without providing new APKs</string>
+    <string name="settings_system_original_apks_deleted_all">Original APKs deleted successfully</string>
 
     <!-- Settings - System Tab - Storage Management - Patch Selection Management -->
     <string name="settings_system_patch_selections_title">Patch selections</string>
@@ -858,6 +864,7 @@ The image dimensions must be as follows:
     <string name="skip">Skip</string>
     <string name="clear">Clear</string>
     <string name="delete">Delete</string>
+    <string name="delete_all">Delete All</string>
     <string name="remove">Remove</string>
     <string name="disable">Disable</string>
     <string name="enable">Enable</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -796,7 +796,7 @@ The image dimensions must be as follows:
     <string name="settings_system_patch_selections_description">Saved patch selections, retained after uninstall</string>
     <string name="settings_system_patch_selection_reset_all_confirm_title">Reset all selections?</string>
     <string name="settings_system_patch_selection_reset_package_confirm_title">Reset package selections?</string>
-    <string name="settings_system_patch_selection_reset_selected_confirm_title">Reset selected selections?</string>
+    <string name="settings_system_patch_selection_reset_selected_confirm_title">Reset selected packages?</string>
     <string name="settings_system_patch_selection_reset_source_confirm_title">Reset source selection?</string>
     <string name="settings_system_patch_selection_no_saved">No saved patch selections</string>
     <string name="settings_system_patch_selection_total_summary_format">%1$s across %2$s</string>
@@ -869,7 +869,7 @@ The image dimensions must be as follows:
     <string name="skip">Skip</string>
     <string name="clear">Clear</string>
     <string name="delete">Delete</string>
-    <string name="delete_all">Delete All</string>
+    <string name="delete_all">Delete all</string>
     <string name="remove">Remove</string>
     <string name="disable">Disable</string>
     <string name="enable">Enable</string>


### PR DESCRIPTION
Adds multi-select bulk actions to the saved-APK management dialog and the patch-selection dialog, with a shared selection UX derived from the home multi-select bar. Includes the original per-type "Delete all" action and the refactoring needed to reuse selection UI across dialogs.
___
![Screenshot_2026-07-06-09-34-04-024_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/f1bd110a-4593-4f5f-8885-426e68f4ad76)

