### PR TITLE
feat: Add app and source sort options

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
@@ -13,14 +13,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Manages user preferences for home screen app buttons: hidden packages, custom order, and sort mode.
+ * Manages user preferences for home screen app buttons: hidden packages, manual order, and sort mode.
  *
- * Morphe ordering:
+ * Recommended ordering:
  * 1. Patched (installed) apps first
  * 2. Apps with isPinnedByDefault = true
  * 3. All other apps, alphabetical
  *
- * Custom sort mode applies the saved manual order, falling back to Morphe ordering when no manual order exists.
+ * Manual sort mode applies the user's saved order, falling back to recommended ordering when no
+ * manual order exists. Fresh installations land on recommended; users upgrading from a pre-sort-mode
+ * build that already had a manual order keep it.
  */
 class HomeAppButtonPreferences(context: Context) {
 
@@ -45,8 +47,15 @@ class HomeAppButtonPreferences(context: Context) {
         return raw.split("\n").filter { it.isNotEmpty() }
     }
 
-    private fun loadSortMode(): HomeAppSortMode =
-        HomeAppSortMode.fromPreference(prefs.getString(KEY_SORT_MODE, null))
+    private fun loadSortMode(): HomeAppSortMode {
+        val stored = prefs.getString(KEY_SORT_MODE, null)
+        return when {
+            stored != null -> HomeAppSortMode.fromPreference(stored)
+            // Preserve manual order for users upgrading from a build without KEY_SORT_MODE
+            loadCustomOrder().isNotEmpty() -> HomeAppSortMode.MANUAL
+            else -> HomeAppSortMode.RECOMMENDED
+        }
+    }
 
     fun hide(packageName: String) {
         val current = _hiddenPackages.value.toMutableSet()
@@ -63,19 +72,19 @@ class HomeAppButtonPreferences(context: Context) {
     fun saveOrder(packageNames: List<String>) {
         prefs.edit {
             putString(KEY_CUSTOM_ORDER, packageNames.joinToString("\n"))
-            putString(KEY_SORT_MODE, HomeAppSortMode.CUSTOM.name)
+            putString(KEY_SORT_MODE, HomeAppSortMode.MANUAL.name)
         }
         _customOrder.value = packageNames
-        _sortMode.value = HomeAppSortMode.CUSTOM
+        _sortMode.value = HomeAppSortMode.MANUAL
     }
 
     fun resetOrder() {
         prefs.edit {
             remove(KEY_CUSTOM_ORDER)
-            putString(KEY_SORT_MODE, HomeAppSortMode.CUSTOM.name)
+            putString(KEY_SORT_MODE, HomeAppSortMode.MANUAL.name)
         }
         _customOrder.value = emptyList()
-        _sortMode.value = HomeAppSortMode.CUSTOM
+        _sortMode.value = HomeAppSortMode.MANUAL
     }
 
     fun setSortMode(mode: HomeAppSortMode) {

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
@@ -21,10 +21,7 @@ enum class HomeAppSortMode {
 
     companion object {
         fun fromPreference(value: String?): HomeAppSortMode =
-            when (value) {
-                "MORPHE" -> RECOMMENDED
-                else -> entries.firstOrNull { it.name == value } ?: CUSTOM
-            }
+            entries.firstOrNull { it.name == value } ?: CUSTOM
     }
 }
 
@@ -86,8 +83,12 @@ class HomeAppButtonPreferences(context: Context) {
     }
 
     fun resetOrder() {
-        prefs.edit { remove(KEY_CUSTOM_ORDER) }
+        prefs.edit {
+            remove(KEY_CUSTOM_ORDER)
+            putString(KEY_SORT_MODE, HomeAppSortMode.CUSTOM.name)
+        }
         _customOrder.value = emptyList()
+        _sortMode.value = HomeAppSortMode.CUSTOM
     }
 
     fun setSortMode(mode: HomeAppSortMode) {

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
@@ -12,15 +12,31 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+enum class HomeAppSortMode {
+    CUSTOM,
+    RECOMMENDED,
+    NAME_ASC,
+    NAME_DESC,
+    UPDATES_FIRST;
+
+    companion object {
+        fun fromPreference(value: String?): HomeAppSortMode =
+            when (value) {
+                "MORPHE" -> RECOMMENDED
+                else -> entries.firstOrNull { it.name == value } ?: CUSTOM
+            }
+    }
+}
+
 /**
- * Manages user preferences for home screen app buttons: hidden packages and custom sort order.
+ * Manages user preferences for home screen app buttons: hidden packages, custom order, and sort mode.
  *
- * Default ordering (applied when no custom order is set):
+ * Morphe ordering:
  * 1. Patched (installed) apps first
  * 2. Apps with isPinnedByDefault = true
  * 3. All other apps, alphabetical
  *
- * A custom order overrides the default sort and is persisted across sessions.
+ * Custom sort mode applies the saved manual order, falling back to Morphe ordering when no manual order exists.
  */
 class HomeAppButtonPreferences(context: Context) {
 
@@ -33,6 +49,9 @@ class HomeAppButtonPreferences(context: Context) {
     private val _customOrder = MutableStateFlow(loadCustomOrder())
     val customOrder: StateFlow<List<String>> = _customOrder.asStateFlow()
 
+    private val _sortMode = MutableStateFlow(loadSortMode())
+    val sortMode: StateFlow<HomeAppSortMode> = _sortMode.asStateFlow()
+
     private fun loadHiddenPackages(): Set<String> {
         return prefs.getStringSet(KEY_HIDDEN, null) ?: emptySet()
     }
@@ -41,6 +60,9 @@ class HomeAppButtonPreferences(context: Context) {
         val raw = prefs.getString(KEY_CUSTOM_ORDER, null) ?: return emptyList()
         return raw.split("\n").filter { it.isNotEmpty() }
     }
+
+    private fun loadSortMode(): HomeAppSortMode =
+        HomeAppSortMode.fromPreference(prefs.getString(KEY_SORT_MODE, null))
 
     fun hide(packageName: String) {
         val current = _hiddenPackages.value.toMutableSet()
@@ -55,13 +77,22 @@ class HomeAppButtonPreferences(context: Context) {
     }
 
     fun saveOrder(packageNames: List<String>) {
-        prefs.edit { putString(KEY_CUSTOM_ORDER, packageNames.joinToString("\n")) }
+        prefs.edit {
+            putString(KEY_CUSTOM_ORDER, packageNames.joinToString("\n"))
+            putString(KEY_SORT_MODE, HomeAppSortMode.CUSTOM.name)
+        }
         _customOrder.value = packageNames
+        _sortMode.value = HomeAppSortMode.CUSTOM
     }
 
     fun resetOrder() {
         prefs.edit { remove(KEY_CUSTOM_ORDER) }
         _customOrder.value = emptyList()
+    }
+
+    fun setSortMode(mode: HomeAppSortMode) {
+        prefs.edit { putString(KEY_SORT_MODE, mode.name) }
+        _sortMode.value = mode
     }
 
     private fun saveHiddenPackages(packages: Set<String>) {
@@ -75,5 +106,6 @@ class HomeAppButtonPreferences(context: Context) {
         private const val PREFS_NAME = "home_app_buttons"
         private const val KEY_HIDDEN = "hidden_packages"
         private const val KEY_CUSTOM_ORDER = "custom_order"
+        private const val KEY_SORT_MODE = "sort_mode"
     }
 }

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppButtonPreferences.kt
@@ -12,19 +12,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-enum class HomeAppSortMode {
-    CUSTOM,
-    RECOMMENDED,
-    NAME_ASC,
-    NAME_DESC,
-    UPDATES_FIRST;
-
-    companion object {
-        fun fromPreference(value: String?): HomeAppSortMode =
-            entries.firstOrNull { it.name == value } ?: CUSTOM
-    }
-}
-
 /**
  * Manages user preferences for home screen app buttons: hidden packages, custom order, and sort mode.
  *

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
@@ -12,7 +12,7 @@ enum class HomeAppSortMode(
     @param:StringRes override val labelRes: Int,
     @param:StringRes override val descriptionRes: Int
 ) : SortModeSpec {
-    CUSTOM(R.string.sources_sort_manual, R.string.home_app_sort_manual_description),
+    MANUAL(R.string.sources_sort_manual, R.string.home_app_sort_manual_description),
     RECOMMENDED(R.string.home_app_sort_recommended, R.string.home_app_sort_recommended_description),
     NAME_ASC(R.string.file_picker_sort_name_asc, R.string.home_app_sort_name_asc_description),
     NAME_DESC(R.string.file_picker_sort_name_desc, R.string.home_app_sort_name_desc_description),
@@ -20,6 +20,6 @@ enum class HomeAppSortMode(
 
     companion object {
         fun fromPreference(value: String?): HomeAppSortMode =
-            entries.firstOrNull { it.name == value } ?: CUSTOM
+            entries.firstOrNull { it.name == value } ?: RECOMMENDED
     }
 }

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.manager
+
+import androidx.annotation.StringRes
+import app.morphe.manager.R
+
+enum class HomeAppSortMode(
+    @param:StringRes override val labelRes: Int,
+    @param:StringRes override val descriptionRes: Int
+) : SortModeSpec {
+    CUSTOM(R.string.home_app_sort_custom, R.string.home_app_sort_custom_description),
+    RECOMMENDED(R.string.home_app_sort_recommended, R.string.home_app_sort_recommended_description),
+    NAME_ASC(R.string.file_picker_sort_name_asc, R.string.home_app_sort_name_asc_description),
+    NAME_DESC(R.string.file_picker_sort_name_desc, R.string.home_app_sort_name_desc_description),
+    UPDATES_FIRST(R.string.home_app_sort_updates_first, R.string.home_app_sort_updates_first_description);
+
+    companion object {
+        fun fromPreference(value: String?): HomeAppSortMode =
+            entries.firstOrNull { it.name == value } ?: CUSTOM
+    }
+}

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
@@ -12,7 +12,7 @@ enum class HomeAppSortMode(
     @param:StringRes override val labelRes: Int,
     @param:StringRes override val descriptionRes: Int
 ) : SortModeSpec {
-    CUSTOM(R.string.home_app_sort_custom, R.string.home_app_sort_custom_description),
+    CUSTOM(R.string.sources_sort_manual, R.string.home_app_sort_manual_description),
     RECOMMENDED(R.string.home_app_sort_recommended, R.string.home_app_sort_recommended_description),
     NAME_ASC(R.string.file_picker_sort_name_asc, R.string.home_app_sort_name_asc_description),
     NAME_DESC(R.string.file_picker_sort_name_desc, R.string.home_app_sort_name_desc_description),

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -22,19 +22,6 @@ import app.morphe.patcher.dex.BytecodeMode
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
-enum class SourceBundleSortMode {
-    MANUAL,
-    LAST_UPDATED,
-    NAME_ASC,
-    NAME_DESC,
-    ENABLED_FIRST;
-
-    companion object {
-        fun fromPreference(value: String?): SourceBundleSortMode =
-            entries.firstOrNull { it.name == value } ?: MANUAL
-    }
-}
-
 class PreferencesManager(
     context: Context
 ) : BasePreferencesManager(context, "settings") {

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -22,6 +22,19 @@ import app.morphe.patcher.dex.BytecodeMode
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
+enum class SourceBundleSortMode {
+    MANUAL,
+    LAST_UPDATED,
+    NAME_ASC,
+    NAME_DESC,
+    ENABLED_FIRST;
+
+    companion object {
+        fun fromPreference(value: String?): SourceBundleSortMode =
+            entries.firstOrNull { it.name == value } ?: MANUAL
+    }
+}
+
 class PreferencesManager(
     context: Context
 ) : BasePreferencesManager(context, "settings") {
@@ -109,8 +122,8 @@ class PreferencesManager(
     val lastFilePickerPath = stringPreference("last_file_picker_path", "")
     val filePickerSortMode = stringPreference("file_picker_sort_mode", "NAME_ASC")
 
-    // "MANUAL" (drag-drop order) or "LAST_UPDATED" (descending by updatedAt ?: createdAt)
-    val sourceBundleSortMode = stringPreference("source_bundle_sort_mode", "MANUAL")
+    // Patch source list ordering mode.
+    val sourceBundleSortMode = stringPreference("source_bundle_sort_mode", SourceBundleSortMode.MANUAL.name)
 
     /** Tracks whether the user has explicitly toggled the custom file picker preference. */
     val customFilePickerUserConfigured = booleanPreference("custom_file_picker_user_configured", false)

--- a/app/src/main/java/app/morphe/manager/domain/manager/SortModeSpec.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/SortModeSpec.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.manager
+
+import androidx.annotation.StringRes
+
+/**
+ * Enum values used as sort modes provide their own label/description string resources
+ * so shared UI can render them without a per-enum mapping helper.
+ */
+interface SortModeSpec {
+    @get:StringRes val labelRes: Int
+    @get:StringRes val descriptionRes: Int
+}

--- a/app/src/main/java/app/morphe/manager/domain/manager/SourceBundleSortMode.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/SourceBundleSortMode.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.manager
+
+import androidx.annotation.StringRes
+import app.morphe.manager.R
+
+enum class SourceBundleSortMode(
+    @param:StringRes override val labelRes: Int,
+    @param:StringRes override val descriptionRes: Int
+) : SortModeSpec {
+    MANUAL(R.string.sources_sort_manual, R.string.sources_sort_manual_hint),
+    LAST_UPDATED(R.string.sources_sort_last_updated, R.string.sources_sort_last_updated_description),
+    NAME_ASC(R.string.file_picker_sort_name_asc, R.string.home_app_sort_name_asc_description),
+    NAME_DESC(R.string.file_picker_sort_name_desc, R.string.home_app_sort_name_desc_description),
+    ENABLED_FIRST(R.string.sources_sort_enabled_first, R.string.sources_sort_enabled_first_description);
+
+    companion object {
+        fun fromPreference(value: String?): SourceBundleSortMode =
+            entries.firstOrNull { it.name == value } ?: MANUAL
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -259,6 +259,7 @@ fun HomeScreen(
                 ),
                 chromeFlags = HomeChromeFlags(
                     showSearchButton = showSearchButton,
+                    showSortButton = showSearchButton,
                     showOtherAppsButton = showOtherAppsButton,
                     isExpertModeEnabled = useExpertMode
                 ),

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -92,7 +92,7 @@ fun HomeScreen(
     val homeAppState by homeViewModel.homeAppState.collectAsStateWithLifecycle()
     val homeAppItems = homeAppState?.visible ?: emptyList()
     val hiddenAppItems = homeAppState?.hidden ?: emptyList()
-    val homeAppSortMode = homeAppState?.sortMode ?: HomeAppSortMode.CUSTOM
+    val homeAppSortMode = homeAppState?.sortMode ?: HomeAppSortMode.MANUAL
     val bundlePipelineLoading = homeAppState == null
     val showOtherAppsButton by homeViewModel.showOtherAppsButton.collectAsStateWithLifecycle()
     val showSearchButton by homeViewModel.showSearchButton.collectAsStateWithLifecycle()

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.model.HomeAppItem
@@ -91,6 +92,7 @@ fun HomeScreen(
     val homeAppState by homeViewModel.homeAppState.collectAsStateWithLifecycle()
     val homeAppItems = homeAppState?.visible ?: emptyList()
     val hiddenAppItems = homeAppState?.hidden ?: emptyList()
+    val homeAppSortMode = homeAppState?.sortMode ?: HomeAppSortMode.CUSTOM
     val bundlePipelineLoading = homeAppState == null
     val showOtherAppsButton by homeViewModel.showOtherAppsButton.collectAsStateWithLifecycle()
     val showSearchButton by homeViewModel.showSearchButton.collectAsStateWithLifecycle()
@@ -207,7 +209,8 @@ fun HomeScreen(
                     visible = homeAppItems,
                     hidden = hiddenAppItems,
                     installedAppsLoading = bundlePipelineLoading || homeViewModel.installedAppsLoading,
-                    showGestureHint = showGestureHint
+                    showGestureHint = showGestureHint,
+                    sortMode = homeAppSortMode
                 ),
                 appActions = HomeAppActions(
                     onAppClick = { item ->
@@ -236,7 +239,8 @@ fun HomeScreen(
                         }
                     },
                     onSaveOrder = { packageNames -> homeViewModel.saveAppOrder(packageNames) },
-                    onResetOrder = { homeViewModel.resetAppOrder() }
+                    onResetOrder = { homeViewModel.resetAppOrder() },
+                    onSortModeChange = { mode -> homeViewModel.setAppSortMode(mode) }
                 ),
                 chromeActions = HomeChromeActions(
                     onOtherAppsClick = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
@@ -121,7 +121,7 @@ fun HomeBottomActionBar(
                     icon = Icons.AutoMirrored.Outlined.Sort,
                     text = stringResource(R.string.sort),
                     showLabel = showLabels,
-                    stateDescription = homeAppSortModeLabel(sortMode),
+                    stateDescription = stringResource(sortMode.labelRes),
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
@@ -48,7 +48,7 @@ fun HomeBottomActionBar(
     isExpertModeEnabled: Boolean = false,
     showSearchButton: Boolean = false,
     showSortButton: Boolean = false,
-    sortMode: HomeAppSortMode = HomeAppSortMode.CUSTOM,
+    sortMode: HomeAppSortMode = HomeAppSortMode.MANUAL,
     searchActive: Boolean = false,
     onSearchClick: () -> Unit = {},
     onSortClick: () -> Unit = {},

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -33,12 +32,11 @@ import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
-import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.ui.screen.shared.*
 
 /**
  * Section 5: Bottom action bar.
- * Sources | Search (optional) | Sort (optional) | Settings.
+ * Sources | Search (optional) | Settings.
  */
 @Composable
 fun HomeBottomActionBar(
@@ -47,18 +45,14 @@ fun HomeBottomActionBar(
     onSettingsClick: () -> Unit,
     isExpertModeEnabled: Boolean = false,
     showSearchButton: Boolean = false,
-    showSortButton: Boolean = false,
-    sortMode: HomeAppSortMode = HomeAppSortMode.CUSTOM,
     searchActive: Boolean = false,
     onSearchClick: () -> Unit = {},
-    onSortClick: () -> Unit = {},
     onSourcesPositioned: ((Rect) -> Unit)? = null,
     onSettingsPositioned: ((Rect) -> Unit)? = null
 ) {
     // Show labels when there are 2 buttons, or on wider screens where 3 buttons still have room.
-    // Four actions stay icon-only to avoid cramped labels.
     val windowSize = rememberWindowSize()
-    val actionCount = 2 + (if (showSearchButton) 1 else 0) + (if (showSortButton) 1 else 0)
+    val actionCount = 2 + (if (showSearchButton) 1 else 0)
     val showLabels = actionCount <= 2 ||
             (actionCount <= 3 && windowSize.widthSizeClass != WindowWidthSizeClass.Compact)
 
@@ -105,23 +99,6 @@ fun HomeBottomActionBar(
                     text = stringResource(R.string.home_search_apps),
                     showLabel = showLabels,
                     stateDescription = if (searchActive) searchExpandedLabel else searchCollapsedLabel,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-
-            // Sort button
-            AnimatedVisibility(
-                visible = showSortButton,
-                modifier = Modifier.weight(1f),
-                enter = MorpheAnimations.expandHorizFadeIn,
-                exit = MorpheAnimations.shrinkHorizFadeOut
-            ) {
-                BottomActionButton(
-                    onClick = onSortClick,
-                    icon = Icons.AutoMirrored.Outlined.Sort,
-                    text = stringResource(R.string.sort),
-                    showLabel = showLabels,
-                    stateDescription = homeAppSortModeLabel(sortMode),
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -32,11 +33,12 @@ import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.ui.screen.shared.*
 
 /**
  * Section 5: Bottom action bar.
- * Sources | Search (optional) | Settings.
+ * Sources | Search (optional) | Sort (optional) | Settings.
  */
 @Composable
 fun HomeBottomActionBar(
@@ -45,14 +47,18 @@ fun HomeBottomActionBar(
     onSettingsClick: () -> Unit,
     isExpertModeEnabled: Boolean = false,
     showSearchButton: Boolean = false,
+    showSortButton: Boolean = false,
+    sortMode: HomeAppSortMode = HomeAppSortMode.CUSTOM,
     searchActive: Boolean = false,
     onSearchClick: () -> Unit = {},
+    onSortClick: () -> Unit = {},
     onSourcesPositioned: ((Rect) -> Unit)? = null,
     onSettingsPositioned: ((Rect) -> Unit)? = null
 ) {
     // Show labels when there are 2 buttons, or on wider screens where 3 buttons still have room.
+    // Four actions stay icon-only to avoid cramped labels.
     val windowSize = rememberWindowSize()
-    val actionCount = 2 + (if (showSearchButton) 1 else 0)
+    val actionCount = 2 + (if (showSearchButton) 1 else 0) + (if (showSortButton) 1 else 0)
     val showLabels = actionCount <= 2 ||
             (actionCount <= 3 && windowSize.widthSizeClass != WindowWidthSizeClass.Compact)
 
@@ -99,6 +105,23 @@ fun HomeBottomActionBar(
                     text = stringResource(R.string.home_search_apps),
                     showLabel = showLabels,
                     stateDescription = if (searchActive) searchExpandedLabel else searchCollapsedLabel,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            // Sort button
+            AnimatedVisibility(
+                visible = showSortButton,
+                modifier = Modifier.weight(1f),
+                enter = MorpheAnimations.expandHorizFadeIn,
+                exit = MorpheAnimations.shrinkHorizFadeOut
+            ) {
+                BottomActionButton(
+                    onClick = onSortClick,
+                    icon = Icons.AutoMirrored.Outlined.Sort,
+                    text = stringResource(R.string.sort),
+                    showLabel = showLabels,
+                    stateDescription = homeAppSortModeLabel(sortMode),
                     modifier = Modifier.fillMaxWidth()
                 )
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeBottomActionBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -32,11 +33,12 @@ import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.ui.screen.shared.*
 
 /**
  * Section 5: Bottom action bar.
- * Sources | Search (optional, center) | Settings.
+ * Sources | Search (optional) | Sort (optional) | Settings.
  */
 @Composable
 fun HomeBottomActionBar(
@@ -45,14 +47,20 @@ fun HomeBottomActionBar(
     onSettingsClick: () -> Unit,
     isExpertModeEnabled: Boolean = false,
     showSearchButton: Boolean = false,
+    showSortButton: Boolean = false,
+    sortMode: HomeAppSortMode = HomeAppSortMode.CUSTOM,
     searchActive: Boolean = false,
     onSearchClick: () -> Unit = {},
+    onSortClick: () -> Unit = {},
     onSourcesPositioned: ((Rect) -> Unit)? = null,
     onSettingsPositioned: ((Rect) -> Unit)? = null
 ) {
-    // Show labels when there are 2 buttons, or on wider screens where 3 buttons still have room
+    // Show labels when there are 2 buttons, or on wider screens where 3 buttons still have room.
+    // Four actions stay icon-only to avoid cramped labels.
     val windowSize = rememberWindowSize()
-    val showLabels = !showSearchButton || windowSize.widthSizeClass != WindowWidthSizeClass.Compact
+    val actionCount = 2 + (if (showSearchButton) 1 else 0) + (if (showSortButton) 1 else 0)
+    val showLabels = actionCount <= 2 ||
+            (actionCount <= 3 && windowSize.widthSizeClass != WindowWidthSizeClass.Compact)
 
     Box(
         modifier = modifier.fillMaxWidth(),
@@ -96,7 +104,24 @@ fun HomeBottomActionBar(
                     icon = if (searchActive) Icons.Outlined.SearchOff else Icons.Outlined.Search,
                     text = stringResource(R.string.home_search_apps),
                     showLabel = showLabels,
-                    searchStateDescription = if (searchActive) searchExpandedLabel else searchCollapsedLabel,
+                    stateDescription = if (searchActive) searchExpandedLabel else searchCollapsedLabel,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            // Sort button
+            AnimatedVisibility(
+                visible = showSortButton,
+                modifier = Modifier.weight(1f),
+                enter = MorpheAnimations.expandHorizFadeIn,
+                exit = MorpheAnimations.shrinkHorizFadeOut
+            ) {
+                BottomActionButton(
+                    onClick = onSortClick,
+                    icon = Icons.AutoMirrored.Outlined.Sort,
+                    text = stringResource(R.string.sort),
+                    showLabel = showLabels,
+                    stateDescription = homeAppSortModeLabel(sortMode),
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -136,7 +161,7 @@ fun BottomActionButton(
     enabled: Boolean = true,
     showProgress: Boolean = false,
     isExpertMode: Boolean = false,
-    searchStateDescription: String? = null
+    stateDescription: String? = null
 ) {
     val shape = RoundedCornerShape(MorpheDefaults.CardCornerRadius)
     val view = LocalView.current
@@ -185,8 +210,8 @@ fun BottomActionButton(
             .semantics {
                 role = Role.Button
                 this.contentDescription = contentDesc
-                if (searchStateDescription != null) {
-                    stateDescription = searchStateDescription
+                if (stateDescription != null) {
+                    this.stateDescription = stateDescription
                 }
                 if (showProgress) {
                     liveRegion = LiveRegionMode.Polite

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -60,6 +61,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
 import app.morphe.manager.data.room.apps.installed.InstalledApp
+import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.ui.model.HomeAppItem
@@ -98,7 +100,8 @@ data class HomeAppListUi(
     val visible: List<HomeAppItem>,
     val hidden: List<HomeAppItem>,
     val installedAppsLoading: Boolean,
-    val showGestureHint: Boolean
+    val showGestureHint: Boolean,
+    val sortMode: HomeAppSortMode
 )
 
 /** Callbacks fired from an app card. */
@@ -111,7 +114,8 @@ class HomeAppActions(
     val onShowPatches: (HomeAppItem) -> Unit,
     val onGestureHintShown: () -> Unit,
     val onSaveOrder: (List<String>) -> Unit,
-    val onResetOrder: () -> Unit
+    val onResetOrder: () -> Unit,
+    val onSortModeChange: (HomeAppSortMode) -> Unit
 )
 
 /** Callbacks for surrounding chrome elements. */
@@ -180,6 +184,20 @@ fun SectionsLayout(
         onToggle = { searchVisible.value = !searchVisible.value },
         onClose = { searchVisible.value = false }
     )
+    var showSortDialog by remember { mutableStateOf(false) }
+
+    if (showSortDialog) {
+        SortModeSelectionDialog(
+            title = stringResource(R.string.home_app_sort_title),
+            current = apps.sortMode,
+            options = homeAppSortOptions(),
+            onSelect = { mode ->
+                appActions.onSortModeChange(mode)
+                showSortDialog = false
+            },
+            onDismiss = { showSortDialog = false }
+        )
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Main layout structure
@@ -202,6 +220,7 @@ fun SectionsLayout(
                     searchState = searchState,
                     chromeActions = chromeActions,
                     chromeFlags = chromeFlags,
+                    onSortClick = { showSortDialog = true },
                     onboardingState = onboardingState
                 )
             }
@@ -213,8 +232,11 @@ fun SectionsLayout(
                     onSettingsClick = chromeActions.onSettingsClick,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
                     showSearchButton = chromeFlags.showSearchButton,
+                    showSortButton = apps.visible.isNotEmpty(),
+                    sortMode = apps.sortMode,
                     searchActive = searchState.visible,
                     onSearchClick = searchState.onToggle,
+                    onSortClick = { showSortDialog = true },
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
                     onSettingsPositioned = onboardingState?.let { s -> { b -> s.settingsButtonBounds = b } }
                 )
@@ -249,6 +271,7 @@ private fun AdaptiveContent(
     searchState: HomeSearchState,
     chromeActions: HomeChromeActions,
     chromeFlags: HomeChromeFlags,
+    onSortClick: () -> Unit,
     onboardingState: OnboardingState? = null
 ) {
     val contentPadding = windowSize.contentPadding
@@ -275,7 +298,10 @@ private fun AdaptiveContent(
                     showSearchButton = chromeFlags.showSearchButton && !isAppsEmpty,
                     searchActive = searchState.visible,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
+                    showSortButton = !isAppsEmpty,
+                    sortMode = apps.sortMode,
                     onSearchClick = searchState.onToggle,
+                    onSortClick = onSortClick,
                     onBundlesClick = chromeActions.onBundlesClick,
                     onSettingsClick = chromeActions.onSettingsClick,
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
@@ -1293,6 +1319,7 @@ fun MainAppsSection(
                         },
                         onResetOrder = {
                             appActions.onResetOrder()
+                            appActions.onSortModeChange(HomeAppSortMode.CUSTOM)
                             localOrder = homeAppItems.map { it.packageName }
                             isReorderMode.value = false
                         },
@@ -1423,6 +1450,36 @@ private fun HomeSearchTextField(
             modifier = modifier.focusRequester(focusRequester)
         )
     }
+}
+
+@Composable
+private fun homeAppSortOptions(): List<SortModeOption<HomeAppSortMode>> =
+    HomeAppSortMode.entries.map { mode ->
+        SortModeOption(
+            value = mode,
+            title = homeAppSortModeLabel(mode),
+            description = stringResource(mode.descriptionRes())
+        )
+    }
+
+@Composable
+internal fun homeAppSortModeLabel(mode: HomeAppSortMode): String =
+    stringResource(mode.labelRes())
+
+private fun HomeAppSortMode.labelRes(): Int = when (this) {
+    HomeAppSortMode.CUSTOM -> R.string.home_app_sort_custom
+    HomeAppSortMode.RECOMMENDED -> R.string.home_app_sort_recommended
+    HomeAppSortMode.NAME_ASC -> R.string.home_app_sort_name_asc
+    HomeAppSortMode.NAME_DESC -> R.string.home_app_sort_name_desc
+    HomeAppSortMode.UPDATES_FIRST -> R.string.home_app_sort_updates_first
+}
+
+private fun HomeAppSortMode.descriptionRes(): Int = when (this) {
+    HomeAppSortMode.CUSTOM -> R.string.home_app_sort_custom_description
+    HomeAppSortMode.RECOMMENDED -> R.string.home_app_sort_recommended_description
+    HomeAppSortMode.NAME_ASC -> R.string.home_app_sort_name_asc_description
+    HomeAppSortMode.NAME_DESC -> R.string.home_app_sort_name_desc_description
+    HomeAppSortMode.UPDATES_FIRST -> R.string.home_app_sort_updates_first_description
 }
 
 /**
@@ -3310,7 +3367,10 @@ private fun HomeSidebarPanel(
     showSearchButton: Boolean,
     searchActive: Boolean,
     isExpertModeEnabled: Boolean,
+    showSortButton: Boolean,
+    sortMode: HomeAppSortMode,
     onSearchClick: () -> Unit,
+    onSortClick: () -> Unit,
     onBundlesClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -3331,6 +3391,15 @@ private fun HomeSidebarPanel(
                 label = stringResource(R.string.home_search_apps),
                 isSelected = searchActive,
                 onClick = onSearchClick
+            )
+        }
+        if (showSortButton) {
+            HomeSidebarNavItem(
+                icon = Icons.AutoMirrored.Outlined.Sort,
+                label = stringResource(R.string.sort),
+                isSelected = sortMode != HomeAppSortMode.CUSTOM,
+                stateDescription = homeAppSortModeLabel(sortMode),
+                onClick = onSortClick
             )
         }
         HomeSidebarNavItem(
@@ -3367,7 +3436,8 @@ private fun HomeSidebarNavItem(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    stateDescription: String? = null
 ) {
     val containerColor by animateColorAsState(
         targetValue = if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent,
@@ -3383,7 +3453,11 @@ private fun HomeSidebarNavItem(
         modifier = modifier
             .fillMaxWidth()
             .height(52.dp)
-            .semantics { role = Role.Button; selected = isSelected },
+            .semantics {
+                role = Role.Button
+                selected = isSelected
+                if (stateDescription != null) this.stateDescription = stateDescription
+            },
         color = containerColor,
         shape = RoundedCornerShape(16.dp)
     ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1469,8 +1469,8 @@ internal fun homeAppSortModeLabel(mode: HomeAppSortMode): String =
 private fun HomeAppSortMode.labelRes(): Int = when (this) {
     HomeAppSortMode.CUSTOM -> R.string.home_app_sort_custom
     HomeAppSortMode.RECOMMENDED -> R.string.home_app_sort_recommended
-    HomeAppSortMode.NAME_ASC -> R.string.home_app_sort_name_asc
-    HomeAppSortMode.NAME_DESC -> R.string.home_app_sort_name_desc
+    HomeAppSortMode.NAME_ASC -> R.string.file_picker_sort_name_asc
+    HomeAppSortMode.NAME_DESC -> R.string.file_picker_sort_name_desc
     HomeAppSortMode.UPDATES_FIRST -> R.string.home_app_sort_updates_first
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -3367,7 +3367,7 @@ private fun HomeSidebarPanel(
             HomeSidebarNavItem(
                 icon = Icons.AutoMirrored.Outlined.Sort,
                 label = stringResource(R.string.sort),
-                isSelected = sortMode != HomeAppSortMode.CUSTOM,
+                isSelected = sortMode != HomeAppSortMode.MANUAL,
                 stateDescription = stringResource(sortMode.labelRes),
                 onClick = onSortClick
             )

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -190,7 +190,7 @@ fun SectionsLayout(
         SortModeSelectionDialog(
             title = stringResource(R.string.home_app_sort_title),
             current = apps.sortMode,
-            options = homeAppSortOptions(),
+            options = sortModeOptions<HomeAppSortMode>(),
             onSelect = { mode ->
                 appActions.onSortModeChange(mode)
                 showSortDialog = false
@@ -1449,36 +1449,6 @@ private fun HomeSearchTextField(
             modifier = modifier.focusRequester(focusRequester)
         )
     }
-}
-
-@Composable
-private fun homeAppSortOptions(): List<SortModeOption<HomeAppSortMode>> =
-    HomeAppSortMode.entries.map { mode ->
-        SortModeOption(
-            value = mode,
-            title = homeAppSortModeLabel(mode),
-            description = stringResource(mode.descriptionRes())
-        )
-    }
-
-@Composable
-internal fun homeAppSortModeLabel(mode: HomeAppSortMode): String =
-    stringResource(mode.labelRes())
-
-private fun HomeAppSortMode.labelRes(): Int = when (this) {
-    HomeAppSortMode.CUSTOM -> R.string.home_app_sort_custom
-    HomeAppSortMode.RECOMMENDED -> R.string.home_app_sort_recommended
-    HomeAppSortMode.NAME_ASC -> R.string.file_picker_sort_name_asc
-    HomeAppSortMode.NAME_DESC -> R.string.file_picker_sort_name_desc
-    HomeAppSortMode.UPDATES_FIRST -> R.string.home_app_sort_updates_first
-}
-
-private fun HomeAppSortMode.descriptionRes(): Int = when (this) {
-    HomeAppSortMode.CUSTOM -> R.string.home_app_sort_custom_description
-    HomeAppSortMode.RECOMMENDED -> R.string.home_app_sort_recommended_description
-    HomeAppSortMode.NAME_ASC -> R.string.home_app_sort_name_asc_description
-    HomeAppSortMode.NAME_DESC -> R.string.home_app_sort_name_desc_description
-    HomeAppSortMode.UPDATES_FIRST -> R.string.home_app_sort_updates_first_description
 }
 
 /**
@@ -3397,7 +3367,7 @@ private fun HomeSidebarPanel(
                 icon = Icons.AutoMirrored.Outlined.Sort,
                 label = stringResource(R.string.sort),
                 isSelected = sortMode != HomeAppSortMode.CUSTOM,
-                stateDescription = homeAppSortModeLabel(sortMode),
+                stateDescription = stringResource(sortMode.labelRes),
                 onClick = onSortClick
             )
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -232,8 +232,11 @@ fun SectionsLayout(
                     onSettingsClick = chromeActions.onSettingsClick,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
                     showSearchButton = chromeFlags.showSearchButton,
+                    showSortButton = apps.visible.isNotEmpty(),
+                    sortMode = apps.sortMode,
                     searchActive = searchState.visible,
                     onSearchClick = searchState.onToggle,
+                    onSortClick = { showSortDialog = true },
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
                     onSettingsPositioned = onboardingState?.let { s -> { b -> s.settingsButtonBounds = b } }
                 )
@@ -295,7 +298,10 @@ private fun AdaptiveContent(
                     showSearchButton = chromeFlags.showSearchButton && !isAppsEmpty,
                     searchActive = searchState.visible,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
+                    showSortButton = !isAppsEmpty,
+                    sortMode = apps.sortMode,
                     onSearchClick = searchState.onToggle,
+                    onSortClick = onSortClick,
                     onBundlesClick = chromeActions.onBundlesClick,
                     onSettingsClick = chromeActions.onSettingsClick,
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
@@ -324,7 +330,6 @@ private fun AdaptiveContent(
                             appActions = appActions,
                             searchState = searchState,
                             onBundlesClick = chromeActions.onBundlesClick,
-                            onSortClick = onSortClick,
                             itemSpacing = itemSpacing,
                             maxCardWidth = maxCardWidth,
                             onboardingState = onboardingState,
@@ -373,7 +378,6 @@ private fun AdaptiveContent(
                         appActions = appActions,
                         searchState = searchState,
                         onBundlesClick = chromeActions.onBundlesClick,
-                        onSortClick = onSortClick,
                         itemSpacing = itemSpacing,
                         horizontalPadding = contentPadding,
                         maxCardWidth = maxCardWidth,
@@ -806,7 +810,6 @@ fun MainAppsSection(
     appActions: HomeAppActions,
     searchState: HomeSearchState,
     onBundlesClick: () -> Unit,
-    onSortClick: () -> Unit,
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 16.dp,
     horizontalPadding: Dp = 0.dp,
@@ -1006,20 +1009,6 @@ fun MainAppsSection(
                         .fillMaxWidth()
                 ) {
                     Column(modifier = Modifier.fillMaxWidth()) {
-                        AnimatedVisibility(
-                            visible = homeAppItems.isNotEmpty(),
-                            enter = MorpheAnimations.expandFadeEnter,
-                            exit = MorpheAnimations.shrinkFadeExit
-                        ) {
-                            AppListActionRow(
-                                sortMode = apps.sortMode,
-                                onSortClick = onSortClick,
-                                modifier = Modifier
-                                    .padding(horizontal = horizontalPadding)
-                                    .padding(bottom = 8.dp)
-                            )
-                        }
-
                         // Search bar
                         AnimatedVisibility(
                             visible = searchState.visible,
@@ -1364,46 +1353,6 @@ private fun ShowHiddenAppsButton(
         icon = Icons.Outlined.Visibility,
         text = pluralStringResource(R.plurals.home_app_show_hidden_count, count, count.toString())
     )
-}
-
-/**
- * Compact app-list actions shown with the app cards rather than global navigation.
- */
-@Composable
-private fun AppListActionRow(
-    sortMode: HomeAppSortMode,
-    onSortClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val sortTitle = stringResource(R.string.home_app_sort_title)
-    val currentSortLabel = homeAppSortModeLabel(sortMode)
-    val selected = sortMode != HomeAppSortMode.CUSTOM
-    val colors = if (selected) {
-        IconButtonDefaults.filledTonalIconButtonColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-        )
-    } else {
-        IconButtonDefaults.filledTonalIconButtonColors()
-    }
-
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        ActionPillButton(
-            onClick = onSortClick,
-            icon = Icons.AutoMirrored.Outlined.Sort,
-            contentDescription = sortTitle,
-            label = stringResource(R.string.sort),
-            tooltip = sortTitle,
-            colors = colors,
-            modifier = Modifier.semantics {
-                stateDescription = currentSortLabel
-            }
-        )
-    }
 }
 
 /**
@@ -3418,7 +3367,10 @@ private fun HomeSidebarPanel(
     showSearchButton: Boolean,
     searchActive: Boolean,
     isExpertModeEnabled: Boolean,
+    showSortButton: Boolean,
+    sortMode: HomeAppSortMode,
     onSearchClick: () -> Unit,
+    onSortClick: () -> Unit,
     onBundlesClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -3439,6 +3391,15 @@ private fun HomeSidebarPanel(
                 label = stringResource(R.string.home_search_apps),
                 isSelected = searchActive,
                 onClick = onSearchClick
+            )
+        }
+        if (showSortButton) {
+            HomeSidebarNavItem(
+                icon = Icons.AutoMirrored.Outlined.Sort,
+                label = stringResource(R.string.sort),
+                isSelected = sortMode != HomeAppSortMode.CUSTOM,
+                stateDescription = homeAppSortModeLabel(sortMode),
+                onClick = onSortClick
             )
         }
         HomeSidebarNavItem(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -1319,7 +1319,6 @@ fun MainAppsSection(
                         },
                         onResetOrder = {
                             appActions.onResetOrder()
-                            appActions.onSortModeChange(HomeAppSortMode.CUSTOM)
                             localOrder = homeAppItems.map { it.packageName }
                             isReorderMode.value = false
                         },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -232,11 +232,8 @@ fun SectionsLayout(
                     onSettingsClick = chromeActions.onSettingsClick,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
                     showSearchButton = chromeFlags.showSearchButton,
-                    showSortButton = apps.visible.isNotEmpty(),
-                    sortMode = apps.sortMode,
                     searchActive = searchState.visible,
                     onSearchClick = searchState.onToggle,
-                    onSortClick = { showSortDialog = true },
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
                     onSettingsPositioned = onboardingState?.let { s -> { b -> s.settingsButtonBounds = b } }
                 )
@@ -298,10 +295,7 @@ private fun AdaptiveContent(
                     showSearchButton = chromeFlags.showSearchButton && !isAppsEmpty,
                     searchActive = searchState.visible,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
-                    showSortButton = !isAppsEmpty,
-                    sortMode = apps.sortMode,
                     onSearchClick = searchState.onToggle,
-                    onSortClick = onSortClick,
                     onBundlesClick = chromeActions.onBundlesClick,
                     onSettingsClick = chromeActions.onSettingsClick,
                     onSourcesPositioned = onboardingState?.let { s -> { b -> s.sourcesButtonBounds = b } },
@@ -330,6 +324,7 @@ private fun AdaptiveContent(
                             appActions = appActions,
                             searchState = searchState,
                             onBundlesClick = chromeActions.onBundlesClick,
+                            onSortClick = onSortClick,
                             itemSpacing = itemSpacing,
                             maxCardWidth = maxCardWidth,
                             onboardingState = onboardingState,
@@ -378,6 +373,7 @@ private fun AdaptiveContent(
                         appActions = appActions,
                         searchState = searchState,
                         onBundlesClick = chromeActions.onBundlesClick,
+                        onSortClick = onSortClick,
                         itemSpacing = itemSpacing,
                         horizontalPadding = contentPadding,
                         maxCardWidth = maxCardWidth,
@@ -810,6 +806,7 @@ fun MainAppsSection(
     appActions: HomeAppActions,
     searchState: HomeSearchState,
     onBundlesClick: () -> Unit,
+    onSortClick: () -> Unit,
     modifier: Modifier = Modifier,
     itemSpacing: Dp = 16.dp,
     horizontalPadding: Dp = 0.dp,
@@ -1009,6 +1006,20 @@ fun MainAppsSection(
                         .fillMaxWidth()
                 ) {
                     Column(modifier = Modifier.fillMaxWidth()) {
+                        AnimatedVisibility(
+                            visible = homeAppItems.isNotEmpty(),
+                            enter = MorpheAnimations.expandFadeEnter,
+                            exit = MorpheAnimations.shrinkFadeExit
+                        ) {
+                            AppListActionRow(
+                                sortMode = apps.sortMode,
+                                onSortClick = onSortClick,
+                                modifier = Modifier
+                                    .padding(horizontal = horizontalPadding)
+                                    .padding(bottom = 8.dp)
+                            )
+                        }
+
                         // Search bar
                         AnimatedVisibility(
                             visible = searchState.visible,
@@ -1353,6 +1364,46 @@ private fun ShowHiddenAppsButton(
         icon = Icons.Outlined.Visibility,
         text = pluralStringResource(R.plurals.home_app_show_hidden_count, count, count.toString())
     )
+}
+
+/**
+ * Compact app-list actions shown with the app cards rather than global navigation.
+ */
+@Composable
+private fun AppListActionRow(
+    sortMode: HomeAppSortMode,
+    onSortClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val sortTitle = stringResource(R.string.home_app_sort_title)
+    val currentSortLabel = homeAppSortModeLabel(sortMode)
+    val selected = sortMode != HomeAppSortMode.CUSTOM
+    val colors = if (selected) {
+        IconButtonDefaults.filledTonalIconButtonColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        )
+    } else {
+        IconButtonDefaults.filledTonalIconButtonColors()
+    }
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ActionPillButton(
+            onClick = onSortClick,
+            icon = Icons.AutoMirrored.Outlined.Sort,
+            contentDescription = sortTitle,
+            label = stringResource(R.string.sort),
+            tooltip = sortTitle,
+            colors = colors,
+            modifier = Modifier.semantics {
+                stateDescription = currentSortLabel
+            }
+        )
+    }
 }
 
 /**
@@ -3367,10 +3418,7 @@ private fun HomeSidebarPanel(
     showSearchButton: Boolean,
     searchActive: Boolean,
     isExpertModeEnabled: Boolean,
-    showSortButton: Boolean,
-    sortMode: HomeAppSortMode,
     onSearchClick: () -> Unit,
-    onSortClick: () -> Unit,
     onBundlesClick: () -> Unit,
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -3391,15 +3439,6 @@ private fun HomeSidebarPanel(
                 label = stringResource(R.string.home_search_apps),
                 isSelected = searchActive,
                 onClick = onSearchClick
-            )
-        }
-        if (showSortButton) {
-            HomeSidebarNavItem(
-                icon = Icons.AutoMirrored.Outlined.Sort,
-                label = stringResource(R.string.sort),
-                isSelected = sortMode != HomeAppSortMode.CUSTOM,
-                stateDescription = homeAppSortModeLabel(sortMode),
-                onClick = onSortClick
             )
         }
         HomeSidebarNavItem(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -131,6 +131,7 @@ class HomeChromeActions(
 @Immutable
 data class HomeChromeFlags(
     val showSearchButton: Boolean,
+    val showSortButton: Boolean,
     val showOtherAppsButton: Boolean,
     val isExpertModeEnabled: Boolean
 )
@@ -232,7 +233,7 @@ fun SectionsLayout(
                     onSettingsClick = chromeActions.onSettingsClick,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
                     showSearchButton = chromeFlags.showSearchButton,
-                    showSortButton = apps.visible.isNotEmpty(),
+                    showSortButton = chromeFlags.showSortButton,
                     sortMode = apps.sortMode,
                     searchActive = searchState.visible,
                     onSearchClick = searchState.onToggle,
@@ -298,7 +299,7 @@ private fun AdaptiveContent(
                     showSearchButton = chromeFlags.showSearchButton && !isAppsEmpty,
                     searchActive = searchState.visible,
                     isExpertModeEnabled = chromeFlags.isExpertModeEnabled,
-                    showSortButton = !isAppsEmpty,
+                    showSortButton = chromeFlags.showSortButton,
                     sortMode = apps.sortMode,
                     onSearchClick = searchState.onToggle,
                     onSortClick = onSortClick,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -63,6 +63,7 @@ import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.gitlabAvat
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.isDefault
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.domain.manager.SourceBundleSortMode
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.RemoteAvatar
@@ -70,6 +71,7 @@ import app.morphe.manager.util.SOURCE_REPO_URL
 import app.morphe.manager.util.getRelativeTimeString
 import app.morphe.manager.util.toast
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import java.util.Locale
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import sh.calvin.reorderable.ReorderableItem
@@ -105,6 +107,7 @@ fun BundleManagementSheet(
     val showSheetOnboarding = globalOnboardingState?.sheetOnboardingActive == true
 
     val bundleToDelete = remember { mutableStateOf<PatchBundleSource?>(null) }
+    var showSortDialog by remember { mutableStateOf(false) }
     // Expanded state lifted out of LazyColumn so it survives scroll-off-screen recomposition
     var expandedBundleUids by remember { mutableStateOf<Set<Int>>(emptySet()) }
 
@@ -133,14 +136,11 @@ fun BundleManagementSheet(
         val merged = existing + added
         if (merged != localOrder) localOrder = merged
     }
-    val sortMode by prefs.sourceBundleSortMode.getAsState()
-    val isLastUpdatedSort = sortMode == "LAST_UPDATED"
-    val orderedSources = remember(localOrder, sources, sortMode) {
-        if (sortMode == "LAST_UPDATED") {
-            sources.sortedByDescending { it.updatedAt ?: it.createdAt ?: 0L }
-        } else {
-            localOrder.mapNotNull { uid -> sources.find { it.uid == uid } }
-        }
+    val sortModePreference by prefs.sourceBundleSortMode.getAsState()
+    val sourceSortMode = SourceBundleSortMode.fromPreference(sortModePreference)
+    val isManualSort = sourceSortMode == SourceBundleSortMode.MANUAL
+    val orderedSources = remember(localOrder, sources, sourceSortMode) {
+        sources.sortedForSourceSort(sourceSortMode, localOrder)
     }
     val haptic = LocalHapticFeedback.current
     val reorderableState = rememberReorderableLazyListState(listState) { from, to ->
@@ -210,22 +210,12 @@ fun BundleManagementSheet(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val manualLabel = stringResource(R.string.sources_sort_manual)
-                            val manualHint = stringResource(R.string.sources_sort_manual_hint)
-                            val lastUpdatedLabel = stringResource(R.string.sources_sort_last_updated)
-                            val activeLabel = if (isLastUpdatedSort) lastUpdatedLabel else manualLabel
+                            val activeSortLabel = sourceBundleSortModeLabel(sourceSortMode)
                             FilledIconButton(
-                                onClick = {
-                                    val next = if (isLastUpdatedSort) "MANUAL" else "LAST_UPDATED"
-                                    scope.launch { prefs.sourceBundleSortMode.update(next) }
-                                    context.toast(
-                                        if (next == "LAST_UPDATED") lastUpdatedLabel
-                                        else "$manualLabel. $manualHint"
-                                    )
-                                },
+                                onClick = { showSortDialog = true },
                                 modifier = Modifier.semantics {
                                     role = Role.Button
-                                    stateDescription = activeLabel
+                                    stateDescription = activeSortLabel
                                 },
                                 colors = IconButtonDefaults.filledIconButtonColors(
                                     containerColor = MaterialTheme.colorScheme.primaryContainer
@@ -352,9 +342,7 @@ fun BundleManagementSheet(
                                     },
                                     forceExpanded = isSingleDefaultBundle,
                                     isDragging = itemIsDragging,
-                                    longPressModifier = if (isLastUpdatedSort) {
-                                        Modifier
-                                    } else {
+                                    longPressModifier = if (isManualSort) {
                                         Modifier.longPressDraggableHandle(
                                             onDragStarted = {
                                                 isDragging = true
@@ -365,6 +353,8 @@ fun BundleManagementSheet(
                                                 onReorder(localOrder)
                                             }
                                         )
+                                    } else {
+                                        Modifier
                                     },
                                     onPatchesBtnPositioned = if (isFirstCard) { b -> globalOnboardingState?.sourcesPatchesBounds = b } else null,
                                     onVersionPositioned = if (isFirstCard) { b -> globalOnboardingState?.sourcesVersionBounds = b } else null,
@@ -379,6 +369,17 @@ fun BundleManagementSheet(
                 }
             }
         }
+    }
+
+    if (showSortDialog) {
+        SourceBundleSortDialog(
+            current = sourceSortMode,
+            onSelect = { mode ->
+                scope.launch { prefs.sourceBundleSortMode.update(mode.name) }
+                showSortDialog = false
+            },
+            onDismiss = { showSortDialog = false }
+        )
     }
 
     // Delete confirmation dialog
@@ -411,6 +412,88 @@ fun BundleManagementSheet(
         }
     }
 }
+
+@Composable
+private fun SourceBundleSortDialog(
+    current: SourceBundleSortMode,
+    onSelect: (SourceBundleSortMode) -> Unit,
+    onDismiss: () -> Unit
+) {
+    SortModeSelectionDialog(
+        title = stringResource(R.string.sources_sort_title),
+        current = current,
+        options = sourceBundleSortOptions(),
+        onSelect = onSelect,
+        onDismiss = onDismiss
+    )
+}
+
+@Composable
+private fun sourceBundleSortOptions(): List<SortModeOption<SourceBundleSortMode>> =
+    SourceBundleSortMode.entries.map { mode ->
+        SortModeOption(
+            value = mode,
+            title = sourceBundleSortModeLabel(mode),
+            description = stringResource(mode.descriptionRes())
+        )
+    }
+
+@Composable
+private fun sourceBundleSortModeLabel(mode: SourceBundleSortMode): String =
+    stringResource(mode.labelRes())
+
+private fun SourceBundleSortMode.labelRes(): Int = when (this) {
+    SourceBundleSortMode.MANUAL -> R.string.sources_sort_manual
+    SourceBundleSortMode.LAST_UPDATED -> R.string.sources_sort_last_updated
+    SourceBundleSortMode.NAME_ASC -> R.string.sources_sort_name_asc
+    SourceBundleSortMode.NAME_DESC -> R.string.sources_sort_name_desc
+    SourceBundleSortMode.ENABLED_FIRST -> R.string.sources_sort_enabled_first
+}
+
+private fun SourceBundleSortMode.descriptionRes(): Int = when (this) {
+    SourceBundleSortMode.MANUAL -> R.string.sources_sort_manual_hint
+    SourceBundleSortMode.LAST_UPDATED -> R.string.sources_sort_last_updated_description
+    SourceBundleSortMode.NAME_ASC -> R.string.sources_sort_name_asc_description
+    SourceBundleSortMode.NAME_DESC -> R.string.sources_sort_name_desc_description
+    SourceBundleSortMode.ENABLED_FIRST -> R.string.sources_sort_enabled_first_description
+}
+
+private fun List<PatchBundleSource>.sortedForSourceSort(
+    sortMode: SourceBundleSortMode,
+    manualOrder: List<Int>
+): List<PatchBundleSource> = when (sortMode) {
+    SourceBundleSortMode.MANUAL -> {
+        val byUid = associateBy { it.uid }
+        val ordered = manualOrder.mapNotNull { uid -> byUid[uid] }
+        val orderedUids = ordered.map { it.uid }.toSet()
+        ordered + filter { it.uid !in orderedUids }
+    }
+
+    SourceBundleSortMode.LAST_UPDATED -> sortedWith(
+        compareByDescending<PatchBundleSource> { it.updatedAt ?: it.createdAt ?: 0L }
+            .thenBy { it.sourceSortTitle() }
+            .thenBy { it.uid }
+    )
+
+    SourceBundleSortMode.NAME_ASC -> sortedWith(
+        compareBy<PatchBundleSource> { it.sourceSortTitle() }
+            .thenBy { it.uid }
+    )
+
+    SourceBundleSortMode.NAME_DESC -> sortedWith(
+        compareByDescending<PatchBundleSource> { it.sourceSortTitle() }
+            .thenBy { it.uid }
+    )
+
+    SourceBundleSortMode.ENABLED_FIRST -> sortedWith(
+        compareByDescending<PatchBundleSource> { it.enabled }
+            .thenBy { it.sourceSortTitle() }
+            .thenBy { it.uid }
+    )
+}
+
+private fun PatchBundleSource.sourceSortTitle(): String =
+    displayTitle.lowercase(Locale.ROOT)
 
 /**
  * Card for individual bundle management.

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -210,21 +210,23 @@ fun BundleManagementSheet(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val activeSortLabel = stringResource(sourceSortMode.labelRes)
-                            FilledIconButton(
-                                onClick = { showSortDialog = true },
-                                modifier = Modifier.semantics {
-                                    role = Role.Button
-                                    stateDescription = activeSortLabel
-                                },
-                                colors = IconButtonDefaults.filledIconButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                                )
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Outlined.Sort,
-                                    contentDescription = stringResource(R.string.sort)
-                                )
+                            AnimatedVisibility(visible = sources.size >= 2) {
+                                val activeSortLabel = stringResource(sourceSortMode.labelRes)
+                                FilledIconButton(
+                                    onClick = { showSortDialog = true },
+                                    modifier = Modifier.semantics {
+                                        role = Role.Button
+                                        stateDescription = activeSortLabel
+                                    },
+                                    colors = IconButtonDefaults.filledIconButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                                    )
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Outlined.Sort,
+                                        contentDescription = stringResource(R.string.sort)
+                                    )
+                                }
                             }
                             FilledIconButton(
                                 onClick = onAddSource,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -445,8 +445,8 @@ private fun sourceBundleSortModeLabel(mode: SourceBundleSortMode): String =
 private fun SourceBundleSortMode.labelRes(): Int = when (this) {
     SourceBundleSortMode.MANUAL -> R.string.sources_sort_manual
     SourceBundleSortMode.LAST_UPDATED -> R.string.sources_sort_last_updated
-    SourceBundleSortMode.NAME_ASC -> R.string.sources_sort_name_asc
-    SourceBundleSortMode.NAME_DESC -> R.string.sources_sort_name_desc
+    SourceBundleSortMode.NAME_ASC -> R.string.file_picker_sort_name_asc
+    SourceBundleSortMode.NAME_DESC -> R.string.file_picker_sort_name_desc
     SourceBundleSortMode.ENABLED_FIRST -> R.string.sources_sort_enabled_first
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -71,11 +71,11 @@ import app.morphe.manager.util.SOURCE_REPO_URL
 import app.morphe.manager.util.getRelativeTimeString
 import app.morphe.manager.util.toast
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import java.util.Locale
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import java.util.Locale
 
 /**
  * Bottom sheet for managing patch bundles.
@@ -210,7 +210,7 @@ fun BundleManagementSheet(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val activeSortLabel = sourceBundleSortModeLabel(sourceSortMode)
+                            val activeSortLabel = stringResource(sourceSortMode.labelRes)
                             FilledIconButton(
                                 onClick = { showSortDialog = true },
                                 modifier = Modifier.semantics {
@@ -372,8 +372,10 @@ fun BundleManagementSheet(
     }
 
     if (showSortDialog) {
-        SourceBundleSortDialog(
+        SortModeSelectionDialog(
+            title = stringResource(R.string.sources_sort_title),
             current = sourceSortMode,
+            options = sortModeOptions<SourceBundleSortMode>(),
             onSelect = { mode ->
                 scope.launch { prefs.sourceBundleSortMode.update(mode.name) }
                 showSortDialog = false
@@ -411,51 +413,6 @@ fun BundleManagementSheet(
             )
         }
     }
-}
-
-@Composable
-private fun SourceBundleSortDialog(
-    current: SourceBundleSortMode,
-    onSelect: (SourceBundleSortMode) -> Unit,
-    onDismiss: () -> Unit
-) {
-    SortModeSelectionDialog(
-        title = stringResource(R.string.sources_sort_title),
-        current = current,
-        options = sourceBundleSortOptions(),
-        onSelect = onSelect,
-        onDismiss = onDismiss
-    )
-}
-
-@Composable
-private fun sourceBundleSortOptions(): List<SortModeOption<SourceBundleSortMode>> =
-    SourceBundleSortMode.entries.map { mode ->
-        SortModeOption(
-            value = mode,
-            title = sourceBundleSortModeLabel(mode),
-            description = stringResource(mode.descriptionRes())
-        )
-    }
-
-@Composable
-private fun sourceBundleSortModeLabel(mode: SourceBundleSortMode): String =
-    stringResource(mode.labelRes())
-
-private fun SourceBundleSortMode.labelRes(): Int = when (this) {
-    SourceBundleSortMode.MANUAL -> R.string.sources_sort_manual
-    SourceBundleSortMode.LAST_UPDATED -> R.string.sources_sort_last_updated
-    SourceBundleSortMode.NAME_ASC -> R.string.file_picker_sort_name_asc
-    SourceBundleSortMode.NAME_DESC -> R.string.file_picker_sort_name_desc
-    SourceBundleSortMode.ENABLED_FIRST -> R.string.sources_sort_enabled_first
-}
-
-private fun SourceBundleSortMode.descriptionRes(): Int = when (this) {
-    SourceBundleSortMode.MANUAL -> R.string.sources_sort_manual_hint
-    SourceBundleSortMode.LAST_UPDATED -> R.string.sources_sort_last_updated_description
-    SourceBundleSortMode.NAME_ASC -> R.string.sources_sort_name_asc_description
-    SourceBundleSortMode.NAME_DESC -> R.string.sources_sort_name_desc_description
-    SourceBundleSortMode.ENABLED_FIRST -> R.string.sources_sort_enabled_first_description
 }
 
 private fun List<PatchBundleSource>.sortedForSourceSort(

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+
+data class SortModeOption<T>(
+    val value: T,
+    val title: String,
+    val description: String
+)
+
+@Composable
+fun <T> SortModeSelectionDialog(
+    title: String,
+    current: T,
+    options: List<SortModeOption<T>>,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = title,
+        footer = {
+            MorpheDialogOutlinedButton(
+                text = stringResource(R.string.close),
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = MorpheDefaults.ContentPadding),
+            verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ItemSpacing)
+        ) {
+            options.forEach { option ->
+                SortModeOptionCard(
+                    option = option,
+                    selected = current == option.value,
+                    onSelect = { onSelect(option.value) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun <T> SortModeOptionCard(
+    option: SortModeOption<T>,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    SettingsItemCard(
+        onClick = onSelect,
+        borderWidth = 1.dp,
+        modifier = Modifier.semantics {
+            role = Role.RadioButton
+            this.selected = selected
+        }
+    ) {
+        IconTextRow(
+            modifier = Modifier.padding(MorpheDefaults.ContentPadding),
+            leadingContent = {
+                if (selected) {
+                    StatusCircleIcon(
+                        icon = Icons.Outlined.Check,
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                } else {
+                    StatusCirclePlaceholder()
+                }
+            },
+            title = option.title,
+            description = option.description,
+            trailingContent = null
+        )
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
@@ -21,12 +21,24 @@ import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.SortModeSpec
 
 data class SortModeOption<T>(
     val value: T,
     val title: String,
     val description: String
 )
+
+@Composable
+inline fun <reified T> sortModeOptions(): List<SortModeOption<T>>
+    where T : Enum<T>, T : SortModeSpec =
+    enumValues<T>().map { mode ->
+        SortModeOption(
+            value = mode,
+            title = stringResource(mode.labelRes),
+            description = stringResource(mode.descriptionRes)
+        )
+    }
 
 @Composable
 fun <T> SortModeSelectionDialog(

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1240,7 +1240,7 @@ class HomeViewModel(
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.packageName }
 
         return when (sortMode) {
-            HomeAppSortMode.CUSTOM -> {
+            HomeAppSortMode.MANUAL -> {
                 val defaultSorted = items.sortedWith(morpheComparator)
                 if (customOrder.isEmpty()) {
                     defaultSorted

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1255,8 +1255,9 @@ class HomeViewModel(
                     .thenBy(String.CASE_INSENSITIVE_ORDER) { it.packageName }
             )
             HomeAppSortMode.NAME_DESC -> items.sortedWith(
-                compareByDescending<HomeAppItem> { it.displayName.lowercase() }
-                    .thenByDescending { it.packageName.lowercase() }
+                compareBy<HomeAppItem, String>(String.CASE_INSENSITIVE_ORDER) { it.displayName }
+                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it.packageName }
+                    .reversed()
             )
             HomeAppSortMode.UPDATES_FIRST -> items.sortedWith(
                 compareByDescending<HomeAppItem> { it.hasUpdate }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -31,6 +31,7 @@ import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.asRemoteOr
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.manager.HomeAppButtonPreferences
+import app.morphe.manager.domain.manager.HomeAppSortMode
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.*
 import app.morphe.manager.domain.repository.PatchBundleRepository.Companion.DEFAULT_SOURCE_UID
@@ -157,7 +158,14 @@ data class InstalledAppPickerItem(
  */
 data class HomeAppState(
     val visible: List<HomeAppItem>,
-    val hidden: List<HomeAppItem>
+    val hidden: List<HomeAppItem>,
+    val sortMode: HomeAppSortMode
+)
+
+private data class HomePrefs(
+    val hiddenPackages: Set<String>,
+    val customOrder: List<String>,
+    val sortMode: HomeAppSortMode
 )
 
 /**
@@ -1105,17 +1113,16 @@ class HomeViewModel(
     private val _homePrefsFlow = combine(
         homeAppButtonPrefs.hiddenPackages,
         homeAppButtonPrefs.customOrder,
-    ) { hidden, order -> Pair(hidden, order) }
+        homeAppButtonPrefs.sortMode,
+    ) { hidden, order, sortMode ->
+        HomePrefs(hiddenPackages = hidden, customOrder = order, sortMode = sortMode)
+    }
 
     /**
     * Sorted list of visible and hidden home app items.
     *
-    * Default sort order:
-    * 1. Patched (installed) apps first
-    * 2. Apps with isPinnedByDefault = true
-    * 3. All other apps, alphabetical
-    *
-    * If the user has saved a custom order it is applied on top of the default sort.
+    * Sort mode is persisted with the home app button preferences. Custom mode applies
+    * the user's saved manual order and falls back to Morphe ordering when no saved order exists.
     * Hidden apps are excluded from [HomeAppState.visible].
     */
     val homeAppState: StateFlow<HomeAppState?> = combine(
@@ -1139,7 +1146,7 @@ class HomeViewModel(
         },
         _appUpdatesAvailable,
         _appStateTicker,
-    ) { bundleState, (hiddenPackages, customOrder), installedApps, updatesMap, _ ->
+    ) { bundleState, homePrefs, installedApps, updatesMap, _ ->
         val ready = bundleState as? PatchBundleRepository.BundleState.Ready
             ?: return@combine null
 
@@ -1197,31 +1204,66 @@ class HomeViewModel(
         val allPackages = packages + universalOnlyPackages
 
         // Active bundle packages filtered to those in patchablePackages
-        val activeHidden = hiddenPackages.filter { it in allPackages }
+        val activeHidden = homePrefs.hiddenPackages.filter { it in allPackages }
 
-        val visiblePackages = allPackages.filter { it !in hiddenPackages }
+        val visiblePackages = allPackages.filter { it !in homePrefs.hiddenPackages }
         val visibleItems = ArrayList<HomeAppItem>(visiblePackages.size)
         for (pkg in visiblePackages) visibleItems.add(buildItem(pkg))
-        val defaultSorted = visibleItems.sortedWith(
-            compareByDescending<HomeAppItem> { it.installedApp != null }
-                .thenByDescending { it.isPinnedByDefault }
-                .thenByDescending { it.packageInfo != null }
-                .thenBy(String.CASE_INSENSITIVE_ORDER) { it.displayName }
+        val visible = sortHomeAppItems(
+            items = visibleItems,
+            sortMode = homePrefs.sortMode,
+            customOrder = homePrefs.customOrder
         )
-        val visible = if (customOrder.isEmpty()) {
-            defaultSorted
-        } else {
-            val indexMap = customOrder.mapIndexed { i, pkg -> pkg to i }.toMap()
-            defaultSorted.sortedBy { indexMap[it.packageName] ?: Int.MAX_VALUE }
-        }
 
         val hiddenItems = ArrayList<HomeAppItem>(activeHidden.size)
         for (pkg in activeHidden) hiddenItems.add(buildItem(pkg))
+        val hidden = sortHomeAppItems(
+            items = hiddenItems,
+            sortMode = homePrefs.sortMode,
+            customOrder = homePrefs.customOrder
+        )
 
-        HomeAppState(visible = visible, hidden = hiddenItems)
+        HomeAppState(visible = visible, hidden = hidden, sortMode = homePrefs.sortMode)
     }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    private fun sortHomeAppItems(
+        items: List<HomeAppItem>,
+        sortMode: HomeAppSortMode,
+        customOrder: List<String>
+    ): List<HomeAppItem> {
+        val morpheComparator = compareByDescending<HomeAppItem> { it.installedApp != null }
+            .thenByDescending { it.isPinnedByDefault }
+            .thenByDescending { it.packageInfo != null }
+            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.displayName }
+            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.packageName }
+
+        return when (sortMode) {
+            HomeAppSortMode.CUSTOM -> {
+                val defaultSorted = items.sortedWith(morpheComparator)
+                if (customOrder.isEmpty()) {
+                    defaultSorted
+                } else {
+                    val indexMap = customOrder.mapIndexed { index, packageName -> packageName to index }.toMap()
+                    defaultSorted.sortedBy { indexMap[it.packageName] ?: Int.MAX_VALUE }
+                }
+            }
+            HomeAppSortMode.RECOMMENDED -> items.sortedWith(morpheComparator)
+            HomeAppSortMode.NAME_ASC -> items.sortedWith(
+                compareBy<HomeAppItem, String>(String.CASE_INSENSITIVE_ORDER) { it.displayName }
+                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it.packageName }
+            )
+            HomeAppSortMode.NAME_DESC -> items.sortedWith(
+                compareByDescending<HomeAppItem> { it.displayName.lowercase() }
+                    .thenByDescending { it.packageName.lowercase() }
+            )
+            HomeAppSortMode.UPDATES_FIRST -> items.sortedWith(
+                compareByDescending<HomeAppItem> { it.hasUpdate }
+                    .then(morpheComparator)
+            )
+        }
+    }
 
     /**
      * Resets the swipe gesture hint after it has been shown.
@@ -1303,6 +1345,10 @@ class HomeViewModel(
 
     fun resetAppOrder() {
         homeAppButtonPrefs.resetOrder()
+    }
+
+    fun setAppSortMode(sortMode: HomeAppSortMode) {
+        homeAppButtonPrefs.setSortMode(sortMode)
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1396,8 +1396,9 @@ class HomeViewModel(
         }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     /**
-     * Whether the search button should be visible.
-     * Shown when there are more than 4 app buttons or a third-party source is active.
+     * Whether the search and sort buttons should be visible.
+     * Shown when there are more than 4 app buttons or a third-party source is active: fewer
+     * apps than that fit on screen at a glance, so both search and reordering are noise.
      */
     val showSearchButton: StateFlow<Boolean> =
         combine(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,17 @@
     <string name="home_update_success_subtitle">Your sources are up to date</string>
     <string name="home_sources_are_loading">Sources are loading, please wait…</string>
     <string name="home_search_apps">Search apps</string>
+    <string name="home_app_sort_title">Sort apps</string>
+    <string name="home_app_sort_custom">Custom order</string>
+    <string name="home_app_sort_custom_description">Use your saved manual order</string>
+    <string name="home_app_sort_recommended">Recommended order</string>
+    <string name="home_app_sort_recommended_description">Installed and pinned apps first</string>
+    <string name="home_app_sort_name_asc">Name (A-Z)</string>
+    <string name="home_app_sort_name_asc_description">Sort app names from A to Z</string>
+    <string name="home_app_sort_name_desc">Name (Z-A)</string>
+    <string name="home_app_sort_name_desc_description">Sort app names from Z to A</string>
+    <string name="home_app_sort_updates_first">Patch updates first</string>
+    <string name="home_app_sort_updates_first_description">Apps with update badges first, then recommended order</string>
     <string name="home_no_apps_title">No apps available</string>
     <string name="home_no_apps_subtitle">Add a patch source or enable an existing one in %s</string>
     <string name="home_no_apps_search_subtitle">No apps match \"%s\"</string>
@@ -82,9 +93,17 @@
 
     <!-- Home Screen - Sources Management -->
     <string name="sources_management_title">Patch sources</string>
+    <string name="sources_sort_title">Sort patch sources</string>
     <string name="sources_sort_manual">Manual order</string>
     <string name="sources_sort_manual_hint">Long-press a source to reorder</string>
     <string name="sources_sort_last_updated">Last updated</string>
+    <string name="sources_sort_last_updated_description">Newest source updates first</string>
+    <string name="sources_sort_name_asc">Name (A-Z)</string>
+    <string name="sources_sort_name_asc_description">Source display names from A to Z</string>
+    <string name="sources_sort_name_desc">Name (Z-A)</string>
+    <string name="sources_sort_name_desc_description">Source display names from Z to A</string>
+    <string name="sources_sort_enabled_first">Enabled first</string>
+    <string name="sources_sort_enabled_first_description">Show active sources before disabled sources</string>
     <string name="sources_management_open_in_browser">Open in browser</string>
     <string name="sources_management_failed_to_open_url">Failed to open URL</string>
     <string name="sources_management_prerelease_toggle">Pre-release patches</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,11 +34,11 @@
     <string name="home_search_apps">Search apps</string>
     <string name="home_app_sort_title">Sort apps</string>
     <string name="home_app_sort_custom">Custom order</string>
-    <string name="home_app_sort_custom_description">Use your saved manual order</string>
+    <string name="home_app_sort_custom_description">Long-press an app, then tap reorder button</string>
     <string name="home_app_sort_recommended">Recommended order</string>
     <string name="home_app_sort_recommended_description">Installed and pinned apps first</string>
-    <string name="home_app_sort_name_asc_description">Sort app names from A to Z</string>
-    <string name="home_app_sort_name_desc_description">Sort app names from Z to A</string>
+    <string name="home_app_sort_name_asc_description">Alphabetical, A to Z</string>
+    <string name="home_app_sort_name_desc_description">Reverse alphabetical, Z to A</string>
     <string name="home_app_sort_updates_first">Patch updates first</string>
     <string name="home_app_sort_updates_first_description">Apps with update badges first, then recommended order</string>
     <string name="home_no_apps_title">No apps available</string>
@@ -96,8 +96,6 @@
     <string name="sources_sort_manual_hint">Long-press a source to reorder</string>
     <string name="sources_sort_last_updated">Last updated</string>
     <string name="sources_sort_last_updated_description">Newest source updates first</string>
-    <string name="sources_sort_name_asc_description">Source display names from A to Z</string>
-    <string name="sources_sort_name_desc_description">Source display names from Z to A</string>
     <string name="sources_sort_enabled_first">Enabled first</string>
     <string name="sources_sort_enabled_first_description">Show active sources before disabled sources</string>
     <string name="sources_management_open_in_browser">Open in browser</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,8 +33,7 @@
     <string name="home_sources_are_loading">Sources are loading, please wait…</string>
     <string name="home_search_apps">Search apps</string>
     <string name="home_app_sort_title">Sort apps</string>
-    <string name="home_app_sort_custom">Custom order</string>
-    <string name="home_app_sort_custom_description">Long-press an app, then tap reorder button</string>
+    <string name="home_app_sort_manual_description">Long-press an app, then tap reorder button</string>
     <string name="home_app_sort_recommended">Recommended order</string>
     <string name="home_app_sort_recommended_description">Installed and pinned apps first</string>
     <string name="home_app_sort_name_asc_description">Alphabetical, A to Z</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,9 +37,7 @@
     <string name="home_app_sort_custom_description">Use your saved manual order</string>
     <string name="home_app_sort_recommended">Recommended order</string>
     <string name="home_app_sort_recommended_description">Installed and pinned apps first</string>
-    <string name="home_app_sort_name_asc">Name (A-Z)</string>
     <string name="home_app_sort_name_asc_description">Sort app names from A to Z</string>
-    <string name="home_app_sort_name_desc">Name (Z-A)</string>
     <string name="home_app_sort_name_desc_description">Sort app names from Z to A</string>
     <string name="home_app_sort_updates_first">Patch updates first</string>
     <string name="home_app_sort_updates_first_description">Apps with update badges first, then recommended order</string>
@@ -98,9 +96,7 @@
     <string name="sources_sort_manual_hint">Long-press a source to reorder</string>
     <string name="sources_sort_last_updated">Last updated</string>
     <string name="sources_sort_last_updated_description">Newest source updates first</string>
-    <string name="sources_sort_name_asc">Name (A-Z)</string>
     <string name="sources_sort_name_asc_description">Source display names from A to Z</string>
-    <string name="sources_sort_name_desc">Name (Z-A)</string>
     <string name="sources_sort_name_desc_description">Source display names from Z to A</string>
     <string name="sources_sort_enabled_first">Enabled first</string>
     <string name="sources_sort_enabled_first_description">Show active sources before disabled sources</string>


### PR DESCRIPTION
Add selectable sort modes for the home app list and patch source manager, preserving manual ordering where drag-and-drop applies.

Share the sort selection dialog UI between both surfaces so the picker style and selection state stay consistent.