### PR TITLE
fix(ru): use verb form for "mount" button label

### DIFF
--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -803,7 +803,7 @@ morphe_header_custom_dark.png
     <string name="patch">Патч</string>
     <string name="repatch">Применить патч</string>
     <string name="open">Открыть</string>
-    <string name="mount">Смонтировано</string>
+    <string name="mount">Смонтировать</string>
     <string name="mounted">Смонтировано</string>
     <string name="unmount">Демонтировать</string>
     <string name="unmounted">Размонтировано</string>


### PR DESCRIPTION
In Russian, `mount` and `mounted` are both translated as "Смонтировано" the past participle, meaning "Mounted".