### PR TITLE
feat: Add storage and cache management dialog

### DIFF
--- a/app/src/main/java/app/morphe/manager/data/platform/Filesystem.kt
+++ b/app/src/main/java/app/morphe/manager/data/platform/Filesystem.kt
@@ -9,6 +9,7 @@ import android.os.Environment
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
+import app.morphe.manager.BuildConfig
 import app.morphe.manager.util.FilenameUtils
 import app.morphe.manager.util.RequestManageStorageContract
 import app.morphe.manager.util.formatBytes
@@ -17,6 +18,10 @@ import java.io.File
 private const val TAG = "Morphe Filesystem"
 
 class Filesystem(private val app: Application) {
+    init {
+        invalidatePatcherWorkspaceOnUpgrade()
+    }
+
     /**
      * A directory that gets cleared when the app restarts.
      * Do not store paths to this directory in a parcel.
@@ -60,6 +65,30 @@ class Filesystem(private val app: Application) {
         val safePackage = FilenameUtils.sanitize(packageName)
         val safeVersion = FilenameUtils.sanitize(version.ifBlank { "unspecified" })
         return patchedAppsDir.resolve("${safePackage}_${safeVersion}.apk")
+    }
+
+    /**
+     * Wipes `cacheDir/framework` and `cacheDir/patcher` when the persisted manager version code
+     * differs from the running one. These caches hold dex/framework files tied to the patcher
+     * module bundled with the manager, so stale entries from a previous version can cause
+     * ClassNotFoundError or ABI mismatches during patching.
+     *
+     * The version marker is kept in `noBackupFilesDir` so neither an OS cache wipe nor the
+     * user-initiated "Clear patcher workspace" action removes it.
+     */
+    private fun invalidatePatcherWorkspaceOnUpgrade() {
+        val marker = app.noBackupFilesDir.resolve(".manager_version")
+        val current = BuildConfig.VERSION_CODE
+        val stored = runCatching {
+            marker.takeIf { it.exists() }?.readText()?.trim()?.toIntOrNull()
+        }.getOrNull()
+        if (stored != null && stored != current) {
+            listOf("framework", "patcher").forEach { name ->
+                runCatching { app.cacheDir.resolve(name).deleteRecursively() }
+            }
+            Log.i(TAG, "Manager version changed ($stored -> $current), wiped patcher workspace")
+        }
+        runCatching { marker.writeText(current.toString()) }
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/di/RepositoryModule.kt
+++ b/app/src/main/java/app/morphe/manager/di/RepositoryModule.kt
@@ -25,5 +25,6 @@ val repositoryModule = module {
     singleOf(::WorkerRepository)
     singleOf(::InstalledAppRepository)
     singleOf(::OriginalApkRepository)
+    singleOf(::StorageStatsRepository)
     singleOf(::AppDataResolver)
 }

--- a/app/src/main/java/app/morphe/manager/di/ViewModelModule.kt
+++ b/app/src/main/java/app/morphe/manager/di/ViewModelModule.kt
@@ -16,4 +16,5 @@ val viewModelModule = module {
     viewModelOf(::AboutViewModel)
     viewModelOf(::InstalledAppInfoViewModel)
     viewModelOf(::PatchOptionsViewModel)
+    viewModelOf(::StorageManagementViewModel)
 }

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -110,7 +110,7 @@ class PreferencesManager(
     val filePickerSortMode = stringPreference("file_picker_sort_mode", "NAME_ASC")
     val filePickerShowHiddenFiles = booleanPreference("file_picker_show_hidden_files", false)
 
-    // Patch source list ordering mode.
+    /** Patch source list ordering mode */
     val sourceBundleSortMode = stringPreference("source_bundle_sort_mode", SourceBundleSortMode.MANUAL.name)
 
     /** Tracks whether the user has explicitly toggled the custom file picker preference. */

--- a/app/src/main/java/app/morphe/manager/domain/repository/StorageStatsRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/StorageStatsRepository.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.repository
+
+import android.app.Application
+import android.content.Context
+import android.os.StatFs
+import app.morphe.manager.data.platform.Filesystem
+import app.morphe.manager.domain.installer.InstallerFileProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/** Aggregated storage and cache footprint of the app. */
+data class StorageStats(
+    val originalApksBytes: Long,
+    val patchedApksBytes: Long,
+    val patchBundlesBytes: Long,
+    val keystoreBytes: Long,
+    val appDataBytes: Long,
+    val httpCacheBytes: Long,
+    val installerShareBytes: Long,
+    val patcherWorkspaceBytes: Long,
+    val temporaryBytes: Long,
+    val deviceFreeBytes: Long
+) {
+    val totalCacheBytes: Long
+        get() = httpCacheBytes + installerShareBytes + patcherWorkspaceBytes + temporaryBytes
+
+    val appUsedBytes: Long
+        get() = originalApksBytes + patchedApksBytes + patchBundlesBytes +
+                keystoreBytes + appDataBytes + totalCacheBytes
+
+    companion object {
+        val Empty = StorageStats(
+            originalApksBytes = 0L,
+            patchedApksBytes = 0L,
+            patchBundlesBytes = 0L,
+            keystoreBytes = 0L,
+            appDataBytes = 0L,
+            httpCacheBytes = 0L,
+            installerShareBytes = 0L,
+            patcherWorkspaceBytes = 0L,
+            temporaryBytes = 0L,
+            deviceFreeBytes = 0L
+        )
+    }
+}
+
+/**
+ * Computes on-disk usage of app-managed directories (APKs, caches, bundles, keystore).
+ * Consumers observe [stats]; call [refresh] to force a rescan after mutations.
+ */
+class StorageStatsRepository(
+    private val app: Application,
+    private val filesystem: Filesystem
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _stats = MutableStateFlow(StorageStats.Empty)
+    val stats: StateFlow<StorageStats> = _stats.asStateFlow()
+
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1).apply { tryEmit(Unit) }
+
+    init {
+        scope.launch {
+            refreshTrigger.collect { _stats.value = computeStats() }
+        }
+    }
+
+    fun refresh() {
+        refreshTrigger.tryEmit(Unit)
+    }
+
+    /** Deletes the OkHttp on-disk cache. Safe: the client rebuilds it on demand. */
+    suspend fun clearHttpCache(): Long = withContext(Dispatchers.IO) {
+        val dir = File(app.cacheDir, HTTP_CACHE_DIR)
+        val freed = dir.totalBytes()
+        dir.wipeContents()
+        refresh()
+        freed
+    }
+
+    suspend fun clearInstallerShareCache(): Long = withContext(Dispatchers.IO) {
+        val dir = File(app.cacheDir, InstallerFileProvider.SHARE_DIR)
+        val freed = dir.totalBytes()
+        dir.wipeContents()
+        refresh()
+        freed
+    }
+
+    suspend fun clearTemporary(): Long = withContext(Dispatchers.IO) {
+        val freed = filesystem.tempDir.totalBytes() + filesystem.uiTempDir.totalBytes()
+        filesystem.tempDir.wipeContents()
+        filesystem.uiTempDir.wipeContents()
+        refresh()
+        freed
+    }
+
+    /**
+     * Deletes patcher runtime files under `cacheDir`: the persistent `framework/` and `patcher/`
+     * subdirectories plus any orphaned scratch files at `cacheDir` root left behind by aborted
+     * bundle imports, keystore imports, or process-runtime merges.
+     */
+    suspend fun clearPatcherWorkspace(): Long = withContext(Dispatchers.IO) {
+        val entries = collectPatcherWorkspaceEntries()
+        val freed = entries.sumOf { it.totalBytes() }
+        entries.forEach { it.deleteRecursively() }
+        refresh()
+        freed
+    }
+
+    /** Wipes everything considered safe to drop (http, installer share, patcher workspace, ephemeral). */
+    suspend fun clearAllCaches(): Long = withContext(Dispatchers.IO) {
+        clearHttpCache() +
+            clearInstallerShareCache() +
+            clearPatcherWorkspace() +
+            clearTemporary()
+    }
+
+    private suspend fun computeStats(): StorageStats = withContext(Dispatchers.IO) {
+        StorageStats(
+            originalApksBytes = filesystem.originalApksDir.totalBytes(),
+            patchedApksBytes = app.getDir(PATCHED_APPS_DIR, Context.MODE_PRIVATE).totalBytes(),
+            patchBundlesBytes = app.getDir(PATCH_BUNDLES_DIR, Context.MODE_PRIVATE).totalBytes(),
+            keystoreBytes = app.getDir(SIGNING_DIR, Context.MODE_PRIVATE)
+                .resolve(KEYSTORE_FILE).length().coerceAtLeast(0),
+            appDataBytes = readAppDataBytes(),
+            httpCacheBytes = File(app.cacheDir, HTTP_CACHE_DIR).totalBytes(),
+            installerShareBytes = File(app.cacheDir, InstallerFileProvider.SHARE_DIR).totalBytes(),
+            patcherWorkspaceBytes = collectPatcherWorkspaceEntries().sumOf { it.totalBytes() },
+            temporaryBytes = filesystem.tempDir.totalBytes() + filesystem.uiTempDir.totalBytes(),
+            deviceFreeBytes = readDeviceFreeBytes()
+        )
+    }
+
+    /**
+     * Size of Room database files, DataStore preferences, and no-backup files. Not clearable from
+     * the UI (removing these would wipe patch history and user settings); reported as an
+     * informational bucket so the histogram total matches Android's app-info more closely.
+     */
+    private fun readAppDataBytes(): Long {
+        val databases = File(app.dataDir, "databases").totalBytes()
+        val dataStore = File(app.filesDir, "datastore").totalBytes()
+        val noBackup = runCatching { app.noBackupFilesDir.totalBytes() }.getOrDefault(0L)
+        return databases + dataStore + noBackup
+    }
+
+    private fun readDeviceFreeBytes(): Long = runCatching {
+        StatFs(app.filesDir.absolutePath).availableBytes
+    }.getOrDefault(0L)
+
+    /**
+     * Entries under [Application.getCacheDir] that belong to the patcher workspace:
+     * everything except the buckets accounted for by other stats fields ([HTTP_CACHE_DIR] and
+     * [InstallerFileProvider.SHARE_DIR]).
+     */
+    private fun collectPatcherWorkspaceEntries(): List<File> {
+        val cacheDir = app.cacheDir
+        if (!cacheDir.exists()) return emptyList()
+        return cacheDir.listFiles()?.filter { entry ->
+            entry.name != HTTP_CACHE_DIR && entry.name != InstallerFileProvider.SHARE_DIR
+        } ?: emptyList()
+    }
+
+    companion object {
+        const val HTTP_CACHE_DIR = "cache"
+        private const val PATCHED_APPS_DIR = "patched-apps"
+        private const val PATCH_BUNDLES_DIR = "patch_bundles"
+        private const val SIGNING_DIR = "signing"
+        private const val KEYSTORE_FILE = "morphe.keystore"
+    }
+}
+
+private fun File.totalBytes(): Long =
+    if (!exists()) 0L else walkBottomUp().filter { it.isFile }.sumOf { it.length() }
+
+private fun File.wipeContents() {
+    if (!exists()) return
+    listFiles()?.forEach { it.deleteRecursively() }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -100,6 +101,7 @@ private data class OriginalApkEntry(
 data class ApkListMeta(
     val title: String,
     val icon: ImageVector,
+    val accentColor: Color,
     val count: Int,
     val totalSize: Long,
     val isLoading: Boolean,
@@ -220,6 +222,7 @@ private fun PatchedApksContent(
         meta = ApkListMeta(
             title = stringResource(R.string.settings_system_patched_apks_title),
             icon = Icons.Outlined.Apps,
+            accentColor = StorageColors.PatchedApks,
             count = displayItems.size,
             totalSize = totalSize,
             isLoading = isLoading,
@@ -389,6 +392,7 @@ private fun OriginalApksContent(
         meta = ApkListMeta(
             title = stringResource(R.string.settings_system_original_apks_title),
             icon = Icons.Outlined.Storage,
+            accentColor = StorageColors.OriginalApks,
             count = apkItems.size,
             totalSize = totalSize,
             isLoading = isLoading,
@@ -603,8 +607,9 @@ private fun ApkManagementDialogContent(
                             meta.count,
                             meta.count
                         ),
-                        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f),
-                        titleColor = MaterialTheme.colorScheme.primary,
+                        containerColor = meta.accentColor.copy(alpha = 0.15f),
+                        titleColor = meta.accentColor,
+                        iconTint = meta.accentColor,
                         icon = meta.icon
                     ) {
                         Text(

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
@@ -7,14 +7,12 @@ package app.morphe.manager.ui.screen.settings.system
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
@@ -23,8 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.ImportExportViewModel
@@ -32,7 +28,8 @@ import app.morphe.manager.ui.viewmodel.SettingsViewModel
 import app.morphe.manager.util.isAndroidTv
 
 /**
- * Storage management section.
+ * Files & storage settings section. Owns the entry into the full storage-management screen,
+ * the expert-mode patch selection dialog, and the custom file picker toggle.
  */
 @Composable
 fun FilesAndStorageSection(
@@ -47,23 +44,13 @@ fun FilesAndStorageSection(
     val enabledState = stringResource(R.string.enabled)
     val disabledState = stringResource(R.string.disabled)
 
-    // Storage counts
-    val originalApkCount by settingsViewModel.originalApkCount.collectAsStateWithLifecycle()
-    val patchedApkCount by settingsViewModel.patchedApkCount.collectAsStateWithLifecycle()
-    val patchedPackagesCount by settingsViewModel.patchedPackagesCount.collectAsStateWithLifecycle()
-
-    val showApkManagementDialog = remember { mutableStateOf<ApkManagementType?>(null) }
+    val showStorageDialog = remember { mutableStateOf(false) }
     val showPatchSelectionDialog = remember { mutableStateOf(false) }
 
-    // APK management dialog
-    showApkManagementDialog.value?.let { type ->
-        ApkManagementDialog(
-            type = type,
-            onDismissRequest = { showApkManagementDialog.value = null }
-        )
+    if (showStorageDialog.value) {
+        StorageManagementDialog(onDismissRequest = { showStorageDialog.value = false })
     }
 
-    // Patch selection management dialog
     if (showPatchSelectionDialog.value) {
         PatchSelectionManagementDialog(
             settingsViewModel = settingsViewModel,
@@ -79,59 +66,14 @@ fun FilesAndStorageSection(
         )
 
         SettingsGroup {
-            // Original APKs management
             SettingsItem(
-                onClick = { showApkManagementDialog.value = ApkManagementType.ORIGINAL },
-                title = stringResource(R.string.settings_system_original_apks_title),
-                subtitle = stringResource(R.string.settings_system_original_apks_description),
-                leadingContent = {
-                    MorpheIcon(icon = Icons.Outlined.Storage)
-                },
-                trailingContent = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (originalApkCount > 0) {
-                            InfoBadge(
-                                text = originalApkCount.toString(),
-                                style = InfoBadgeStyle.Default,
-                                isCompact = true
-                            )
-                        }
-                        MorpheIcon(icon = Icons.Outlined.ChevronRight)
-                    }
-                }
+                onClick = { showStorageDialog.value = true },
+                title = stringResource(R.string.settings_system_storage_management_title),
+                subtitle = stringResource(R.string.settings_system_storage_management_description),
+                leadingContent = { MorpheIcon(icon = Icons.Outlined.Storage) }
             )
 
-            MorpheSettingsDivider()
-
-            // Patched APKs management
-            SettingsItem(
-                onClick = { showApkManagementDialog.value = ApkManagementType.PATCHED },
-                title = stringResource(R.string.settings_system_patched_apks_title),
-                subtitle = stringResource(R.string.settings_system_patched_apks_description),
-                leadingContent = {
-                    MorpheIcon(icon = Icons.Outlined.Apps)
-                },
-                trailingContent = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        if (patchedApkCount > 0) {
-                            InfoBadge(
-                                text = patchedApkCount.toString(),
-                                style = InfoBadgeStyle.Default,
-                                isCompact = true
-                            )
-                        }
-                        MorpheIcon(icon = Icons.Outlined.ChevronRight)
-                    }
-                }
-            )
-
-            // Patch Selections management (Expert mode only)
+            // Patch Selections (Expert mode only)
             if (useExpertMode) {
                 MorpheSettingsDivider()
 
@@ -139,24 +81,7 @@ fun FilesAndStorageSection(
                     onClick = { showPatchSelectionDialog.value = true },
                     title = stringResource(R.string.settings_system_patch_selections_title),
                     subtitle = stringResource(R.string.settings_system_patch_selections_description),
-                    leadingContent = {
-                        MorpheIcon(icon = Icons.Outlined.Tune)
-                    },
-                    trailingContent = {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            if (patchedPackagesCount > 0) {
-                                InfoBadge(
-                                    text = patchedPackagesCount.toString(),
-                                    style = InfoBadgeStyle.Default,
-                                    isCompact = true
-                                )
-                            }
-                            MorpheIcon(icon = Icons.Outlined.ChevronRight)
-                        }
-                    }
+                    leadingContent = { MorpheIcon(icon = Icons.Outlined.Tune) }
                 )
             }
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageHistogram.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageHistogram.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.manager.ui.screen.settings.system
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.EaseOutCubic
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -20,7 +21,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.ui.screen.shared.LocalDialogSecondaryTextColor
 import app.morphe.manager.ui.screen.shared.LocalDialogTextColor
@@ -36,16 +42,14 @@ data class StorageSegment(
 )
 
 private const val SEGMENT_ANIMATION_MS = 700
-private val BAR_HEIGHT = 300.dp
+private val BAR_MIN_HEIGHT = 200.dp
 private val BAR_WIDTH = 56.dp
+private val BAR_LEGEND_SPACING = 20.dp
 
 /**
- * Vertical stacked bar with a legend column on the right. Segments animate up from zero
- * on first composition, and animate smoothly whenever their byte size changes.
- *
- * The bar always fills its full height with the composition of [segments] (proportional to
- * the sum of their bytes). [deviceFreeBytes] is only used to render the free-space subtitle
- * above the bar for context.
+ * Stacked vertical bar of [segments] (proportional to their byte sum) with a legend on the
+ * right. Segments animate up from zero on first composition and animate smoothly when their
+ * byte size changes. [deviceFreeBytes] renders as a subtitle above the bar for context only.
  */
 @Composable
 fun StorageHistogram(
@@ -70,23 +74,67 @@ fun StorageHistogram(
             color = LocalDialogTextColor.current
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(20.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            HistogramBar(
-                segments = segments,
-                safeTotal = segmentsSum,
-                modifier = Modifier.width(BAR_WIDTH).height(BAR_HEIGHT)
+        HistogramLayout(
+            bar = {
+                HistogramBar(
+                    segments = segments,
+                    safeTotal = segmentsSum,
+                    modifier = Modifier.fillMaxSize()
+                )
+            },
+            legend = { HistogramLegend(visibleSegments = visibleLegend) }
+        )
+    }
+}
+
+/**
+ * Places [bar] on the left and [legend] on the right, sizing the bar to match the legend's
+ * natural height with a floor of [BAR_MIN_HEIGHT]. Height propagates one way: legend measures
+ * first at unbounded height, then the bar fits into it. A plain `Row(IntrinsicSize.Max)` would
+ * feedback-loop because the animated segment stack reports its current height as its intrinsic
+ * max, preventing the row from ever shrinking.
+ */
+@Composable
+private fun HistogramLayout(
+    bar: @Composable () -> Unit,
+    legend: @Composable () -> Unit
+) {
+    SubcomposeLayout(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize()
+    ) { constraints ->
+        val barWidthPx = BAR_WIDTH.roundToPx()
+        val spacingPx = BAR_LEGEND_SPACING.roundToPx()
+        val minHeightPx = BAR_MIN_HEIGHT.roundToPx()
+        val legendWidthPx = (constraints.maxWidth - barWidthPx - spacingPx).coerceAtLeast(0)
+
+        val legendPlaceable = subcompose(SlotId.Legend, legend).first().measure(
+            Constraints(
+                minWidth = legendWidthPx,
+                maxWidth = legendWidthPx,
+                minHeight = 0,
+                maxHeight = Constraints.Infinity
             )
-            HistogramLegend(
-                visibleSegments = visibleLegend,
-                modifier = Modifier.weight(1f)
+        )
+
+        val rowHeightPx = maxOf(legendPlaceable.height, minHeightPx)
+
+        val barPlaceable = subcompose(SlotId.Bar, bar).first().measure(
+            Constraints.fixed(barWidthPx, rowHeightPx)
+        )
+
+        layout(constraints.maxWidth, rowHeightPx) {
+            barPlaceable.place(0, 0)
+            legendPlaceable.place(
+                x = barWidthPx + spacingPx,
+                y = (rowHeightPx - legendPlaceable.height) / 2
             )
         }
     }
 }
+
+private enum class SlotId { Bar, Legend }
 
 @Composable
 private fun HistogramBar(
@@ -96,21 +144,26 @@ private fun HistogramBar(
 ) {
     val trackColor = LocalDialogSecondaryTextColor.current.copy(alpha = 0.12f)
 
+    // Captures the height assigned by [HistogramLayout] so segments can use absolute Dp values
+    var barHeightPx by remember { mutableIntStateOf(0) }
+    val barHeightDp = with(LocalDensity.current) { barHeightPx.toDp() }
+
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(percent = 50))
             .background(trackColor)
+            .onSizeChanged { barHeightPx = it.height }
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.Bottom
         ) {
-            // Render all segments (including zero-byte ones) so per-segment animation state
-            // is remembered by position, not by presence
+            // Render every segment (even zero-byte) so animation state stays keyed by position
             segments.forEach { segment ->
                 key(segment.key) {
                     AnimatedSegment(
                         targetFraction = (segment.bytes.toFloat() / safeTotal.toFloat()).coerceIn(0f, 1f),
+                        barHeight = barHeightDp,
                         color = segment.color
                     )
                 }
@@ -120,8 +173,8 @@ private fun HistogramBar(
 }
 
 @Composable
-private fun AnimatedSegment(targetFraction: Float, color: Color) {
-    // Start at zero so the first frame draws nothing, then animate to the real value
+private fun AnimatedSegment(targetFraction: Float, barHeight: Dp, color: Color) {
+    // `animate` flag drives the entry animation: target is 0 on first frame, real value after
     var animate by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) { animate = true }
 
@@ -132,12 +185,11 @@ private fun AnimatedSegment(targetFraction: Float, color: Color) {
     )
 
     if (fraction <= 0f) return
-    // Use an absolute Dp height so the parent Column's `Arrangement.Bottom` does not shrink
-    // subsequent segments proportionally to the remaining space
+    // Absolute Dp: `fillMaxHeight(fraction)` compounds under `Arrangement.Bottom` in Column
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(BAR_HEIGHT * fraction)
+            .height(barHeight * fraction)
             .background(
                 Brush.verticalGradient(
                     colors = listOf(color, color.copy(alpha = 0.82f))

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageHistogram.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageHistogram.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.settings.system
+
+import androidx.compose.animation.core.EaseOutCubic
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.ui.screen.shared.LocalDialogSecondaryTextColor
+import app.morphe.manager.ui.screen.shared.LocalDialogTextColor
+import app.morphe.manager.util.formatBytes
+import app.morphe.manager.util.formatUsedFree
+
+/** A single stacked-bar segment. Order in the caller-provided list determines stacking order. */
+data class StorageSegment(
+    val key: String,
+    val label: String,
+    val bytes: Long,
+    val color: Color
+)
+
+private const val SEGMENT_ANIMATION_MS = 700
+private val BAR_HEIGHT = 300.dp
+private val BAR_WIDTH = 56.dp
+
+/**
+ * Vertical stacked bar with a legend column on the right. Segments animate up from zero
+ * on first composition, and animate smoothly whenever their byte size changes.
+ *
+ * The bar always fills its full height with the composition of [segments] (proportional to
+ * the sum of their bytes). [deviceFreeBytes] is only used to render the free-space subtitle
+ * above the bar for context.
+ */
+@Composable
+fun StorageHistogram(
+    used: Long,
+    deviceFreeBytes: Long,
+    segments: List<StorageSegment>,
+    modifier: Modifier = Modifier
+) {
+    val segmentsSum = remember(segments) { segments.sumOf { it.bytes }.coerceAtLeast(1L) }
+    val visibleLegend = remember(segments) { segments.filter { it.bytes > 0 } }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = formatUsedFree(used = used, free = deviceFreeBytes),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            color = LocalDialogTextColor.current
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HistogramBar(
+                segments = segments,
+                safeTotal = segmentsSum,
+                modifier = Modifier.width(BAR_WIDTH).height(BAR_HEIGHT)
+            )
+            HistogramLegend(
+                visibleSegments = visibleLegend,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HistogramBar(
+    segments: List<StorageSegment>,
+    safeTotal: Long,
+    modifier: Modifier = Modifier
+) {
+    val trackColor = LocalDialogSecondaryTextColor.current.copy(alpha = 0.12f)
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(trackColor)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Bottom
+        ) {
+            // Render all segments (including zero-byte ones) so per-segment animation state
+            // is remembered by position, not by presence
+            segments.forEach { segment ->
+                key(segment.key) {
+                    AnimatedSegment(
+                        targetFraction = (segment.bytes.toFloat() / safeTotal.toFloat()).coerceIn(0f, 1f),
+                        color = segment.color
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnimatedSegment(targetFraction: Float, color: Color) {
+    // Start at zero so the first frame draws nothing, then animate to the real value
+    var animate by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { animate = true }
+
+    val fraction by animateFloatAsState(
+        targetValue = if (animate) targetFraction else 0f,
+        animationSpec = tween(durationMillis = SEGMENT_ANIMATION_MS, easing = EaseOutCubic),
+        label = "storageSegmentFraction"
+    )
+
+    if (fraction <= 0f) return
+    // Use an absolute Dp height so the parent Column's `Arrangement.Bottom` does not shrink
+    // subsequent segments proportionally to the remaining space
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BAR_HEIGHT * fraction)
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(color, color.copy(alpha = 0.82f))
+                )
+            )
+    )
+}
+
+@Composable
+private fun HistogramLegend(
+    visibleSegments: List<StorageSegment>,
+    modifier: Modifier = Modifier
+) {
+    if (visibleSegments.isEmpty()) return
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        visibleSegments.forEach { segment ->
+            LegendItem(segment)
+        }
+    }
+}
+
+@Composable
+private fun LegendItem(segment: StorageSegment) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(segment.color)
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = segment.label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalDialogTextColor.current,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = formatBytes(segment.bytes),
+                style = MaterialTheme.typography.bodySmall,
+                color = LocalDialogSecondaryTextColor.current
+            )
+        }
+    }
+}
+
+/** Fixed palette used for storage categories. Kept distinct across theme variants. */
+object StorageColors {
+    val OriginalApks = Color(0xFF4285F4)
+    val PatchedApks = Color(0xFFAB47BC)
+    val PatchBundles = Color(0xFF66BB6A)
+    val Keystore = Color(0xFFFFB300)
+    val AppData = Color(0xFF5C6BC0)
+    val HttpCache = Color(0xFFFF7043)
+    val InstallerShare = Color(0xFFEF5350)
+    val PatcherWorkspace = Color(0xFF26C6DA)
+    val Temporary = Color(0xFF78909C)
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementDialog.kt
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.settings.system
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Launch
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.morphe.manager.R
+import app.morphe.manager.domain.repository.StorageStats
+import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.ui.viewmodel.StorageManagementViewModel
+import app.morphe.manager.util.formatBytes
+import app.morphe.manager.util.toast
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun StorageManagementDialog(
+    onDismissRequest: () -> Unit,
+    viewModel: StorageManagementViewModel = koinViewModel()
+) {
+    val context = LocalContext.current
+    val stats by viewModel.stats.collectAsStateWithLifecycle()
+
+    val nothingToClearText = stringResource(R.string.settings_system_storage_nothing_to_clear)
+    val clearedTemplate = stringResource(R.string.settings_system_storage_cleared)
+
+    val onCleared: (Long) -> Unit = { freed ->
+        val message = if (freed <= 0L) nothingToClearText
+        else clearedTemplate.format(formatBytes(freed))
+        context.toast(message)
+    }
+
+    var apkDialog by remember { mutableStateOf<ApkManagementType?>(null) }
+    var showClearAllConfirm by remember { mutableStateOf(false) }
+    // Incremented on manual refresh to re-key the histogram and replay its entry animation.
+    var histogramNonce by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) { viewModel.refresh() }
+
+    apkDialog?.let { type ->
+        ApkManagementDialog(
+            type = type,
+            onDismissRequest = {
+                apkDialog = null
+                viewModel.refresh()
+            }
+        )
+    }
+
+    if (showClearAllConfirm) {
+        ClearCachesConfirmationDialog(
+            totalBytes = stats.totalCacheBytes,
+            onDismiss = { showClearAllConfirm = false },
+            onConfirm = {
+                showClearAllConfirm = false
+                viewModel.clearAllCaches(onCleared)
+            }
+        )
+    }
+
+    MorpheDialog(
+        onDismissRequest = onDismissRequest,
+        title = stringResource(R.string.settings_system_storage_management_title),
+        compactPadding = true,
+        titleTrailingContent = {
+            DialogTitleAction(
+                icon = Icons.Outlined.Refresh,
+                contentDescription = stringResource(R.string.refresh),
+                onClick = {
+                    viewModel.refresh()
+                    histogramNonce++
+                }
+            )
+        },
+        footer = {
+            MorpheDialogOutlinedButton(
+                text = stringResource(R.string.close),
+                onClick = onDismissRequest,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
+            key(histogramNonce) {
+                StorageHistogram(
+                    used = stats.appUsedBytes,
+                    deviceFreeBytes = stats.deviceFreeBytes,
+                    segments = stats.toSegments()
+                )
+            }
+
+            SettingsGroup {
+                DataRow(
+                    icon = Icons.Outlined.Storage,
+                    accentColor = StorageColors.OriginalApks,
+                    title = stringResource(R.string.settings_system_original_apks_title),
+                    description = stringResource(R.string.settings_system_original_apks_description),
+                    onClick = { apkDialog = ApkManagementType.ORIGINAL }
+                )
+                MorpheSettingsDivider()
+                DataRow(
+                    icon = Icons.Outlined.Apps,
+                    accentColor = StorageColors.PatchedApks,
+                    title = stringResource(R.string.settings_system_patched_apks_title),
+                    description = stringResource(R.string.settings_system_patched_apks_description),
+                    onClick = { apkDialog = ApkManagementType.PATCHED }
+                )
+            }
+
+            SettingsGroup {
+                CacheActionRow(
+                    icon = Icons.Outlined.CloudDownload,
+                    accentColor = StorageColors.HttpCache,
+                    title = stringResource(R.string.settings_system_storage_http_cache_title),
+                    description = stringResource(R.string.settings_system_storage_http_cache_description),
+                    enabled = stats.httpCacheBytes > 0L,
+                    onClear = { viewModel.clearHttpCache(onCleared) }
+                )
+                MorpheSettingsDivider()
+                CacheActionRow(
+                    icon = Icons.Outlined.Share,
+                    accentColor = StorageColors.InstallerShare,
+                    title = stringResource(R.string.settings_system_storage_installer_cache_title),
+                    description = stringResource(R.string.settings_system_storage_installer_cache_description),
+                    enabled = stats.installerShareBytes > 0L,
+                    onClear = { viewModel.clearInstallerShareCache(onCleared) }
+                )
+                MorpheSettingsDivider()
+                CacheActionRow(
+                    icon = Icons.Outlined.Build,
+                    accentColor = StorageColors.PatcherWorkspace,
+                    title = stringResource(R.string.settings_system_storage_patcher_workspace_title),
+                    description = stringResource(R.string.settings_system_storage_patcher_workspace_description),
+                    enabled = stats.patcherWorkspaceBytes > 0L,
+                    onClear = { viewModel.clearPatcherWorkspace(onCleared) }
+                )
+                MorpheSettingsDivider()
+                CacheActionRow(
+                    icon = Icons.Outlined.HourglassEmpty,
+                    accentColor = StorageColors.Temporary,
+                    title = stringResource(R.string.settings_system_storage_temporary_title),
+                    description = stringResource(R.string.settings_system_storage_temporary_description),
+                    enabled = stats.temporaryBytes > 0L,
+                    onClear = { viewModel.clearTemporary(onCleared) }
+                )
+                MorpheSettingsDivider()
+                CacheActionRow(
+                    icon = Icons.Outlined.DeleteSweep,
+                    accentColor = MaterialTheme.colorScheme.error,
+                    title = stringResource(R.string.settings_system_storage_clear_all),
+                    description = stringResource(R.string.settings_system_storage_clear_all_description),
+                    enabled = stats.totalCacheBytes > 0L,
+                    onClear = { showClearAllConfirm = true }
+                )
+            }
+
+            SettingsGroup {
+                SettingsItem(
+                    onClick = { openAndroidAppStorage(context) },
+                    title = stringResource(R.string.settings_system_storage_open_app_info_title),
+                    subtitle = stringResource(R.string.settings_system_storage_open_app_info_description),
+                    leadingContent = { MorpheIcon(icon = Icons.AutoMirrored.Outlined.Launch) }
+                )
+            }
+        }
+    }
+}
+
+private fun openAndroidAppStorage(context: Context) {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", context.packageName, null)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (_: ActivityNotFoundException) { /* OEM without the standard app info screen */ }
+}
+
+@Composable
+private fun DataRow(
+    icon: ImageVector,
+    accentColor: Color,
+    title: String,
+    description: String,
+    onClick: () -> Unit
+) {
+    SettingsItem(
+        onClick = onClick,
+        title = title,
+        subtitle = description,
+        leadingContent = { MorpheIcon(icon = icon, tint = accentColor) }
+    )
+}
+
+@Composable
+private fun CacheActionRow(
+    icon: ImageVector,
+    accentColor: Color,
+    title: String,
+    description: String,
+    enabled: Boolean,
+    onClear: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(MorpheDefaults.ContentPadding),
+        verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)
+    ) {
+        IconTextRow(
+            leadingContent = { MorpheIcon(icon = icon, tint = accentColor) },
+            title = title,
+            description = description
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            ActionPillButton(
+                onClick = onClear,
+                icon = Icons.Outlined.DeleteSweep,
+                contentDescription = stringResource(R.string.clear),
+                label = stringResource(R.string.clear),
+                enabled = enabled,
+                large = true,
+                modifier = Modifier.fillMaxWidth(0.5f),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun ClearCachesConfirmationDialog(
+    totalBytes: Long,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.settings_system_storage_clear_all),
+        footer = {
+            MorpheDialogButtonRow(
+                primaryText = stringResource(R.string.settings_system_storage_clear_all),
+                onPrimaryClick = onConfirm,
+                isPrimaryDestructive = true,
+                secondaryText = stringResource(android.R.string.cancel),
+                onSecondaryClick = onDismiss
+            )
+        }
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPadding)) {
+            Text(
+                text = stringResource(R.string.settings_system_storage_clear_all_confirm),
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalDialogTextColor.current
+            )
+            DeletionWarningBox(
+                warningText = stringResource(R.string.settings_system_apks_size, formatBytes(totalBytes))
+            ) {
+                DeleteListItem(
+                    icon = Icons.Outlined.CloudDownload,
+                    text = stringResource(R.string.settings_system_storage_http_cache_title)
+                )
+                DeleteListItem(
+                    icon = Icons.Outlined.Share,
+                    text = stringResource(R.string.settings_system_storage_installer_cache_title)
+                )
+                DeleteListItem(
+                    icon = Icons.Outlined.Build,
+                    text = stringResource(R.string.settings_system_storage_patcher_workspace_title)
+                )
+                DeleteListItem(
+                    icon = Icons.Outlined.HourglassEmpty,
+                    text = stringResource(R.string.settings_system_storage_temporary_title)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StorageStats.toSegments(): List<StorageSegment> {
+    val originalLabel = stringResource(R.string.settings_system_original_apks_title)
+    val patchedLabel = stringResource(R.string.settings_system_patched_apks_title)
+    val bundlesLabel = stringResource(R.string.settings_system_storage_patch_bundles_title)
+    val keystoreLabel = stringResource(R.string.settings_system_storage_keystore_title)
+    val appDataLabel = stringResource(R.string.settings_system_storage_app_data_title)
+    val httpLabel = stringResource(R.string.settings_system_storage_http_cache_title)
+    val shareLabel = stringResource(R.string.settings_system_storage_installer_cache_title)
+    val patcherLabel = stringResource(R.string.settings_system_storage_patcher_workspace_title)
+    val tempLabel = stringResource(R.string.settings_system_storage_temporary_title)
+    return listOf(
+        StorageSegment("original", originalLabel, originalApksBytes, StorageColors.OriginalApks),
+        StorageSegment("patched", patchedLabel, patchedApksBytes, StorageColors.PatchedApks),
+        StorageSegment("bundles", bundlesLabel, patchBundlesBytes, StorageColors.PatchBundles),
+        StorageSegment("keystore", keystoreLabel, keystoreBytes, StorageColors.Keystore),
+        StorageSegment("appdata", appDataLabel, appDataBytes, StorageColors.AppData),
+        StorageSegment("http", httpLabel, httpCacheBytes, StorageColors.HttpCache),
+        StorageSegment("share", shareLabel, installerShareBytes, StorageColors.InstallerShare),
+        StorageSegment("patcher", patcherLabel, patcherWorkspaceBytes, StorageColors.PatcherWorkspace),
+        StorageSegment("temp", tempLabel, temporaryBytes, StorageColors.Temporary)
+    )
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheSettingComponents.kt
@@ -564,6 +564,7 @@ fun InfoBox(
     containerColor: Color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
     titleColor: Color = MaterialTheme.colorScheme.onSurface,
     icon: ImageVector? = null,
+    iconTint: Color = MaterialTheme.colorScheme.primary,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Surface(
@@ -597,7 +598,7 @@ fun InfoBox(
                     imageVector = it,
                     contentDescription = null,
                     modifier = Modifier.size(32.dp),
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = iconTint
                 )
             }
         }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/StorageManagementViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/StorageManagementViewModel.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.morphe.manager.domain.repository.StorageStats
+import app.morphe.manager.domain.repository.StorageStatsRepository
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class StorageManagementViewModel(
+    private val storageStatsRepository: StorageStatsRepository
+) : ViewModel() {
+
+    val stats: StateFlow<StorageStats> = storageStatsRepository.stats
+
+    fun refresh() = storageStatsRepository.refresh()
+
+    fun clearHttpCache(onDone: (Long) -> Unit = {}) = viewModelScope.launch {
+        onDone(storageStatsRepository.clearHttpCache())
+    }
+
+    fun clearInstallerShareCache(onDone: (Long) -> Unit = {}) = viewModelScope.launch {
+        onDone(storageStatsRepository.clearInstallerShareCache())
+    }
+
+    fun clearPatcherWorkspace(onDone: (Long) -> Unit = {}) = viewModelScope.launch {
+        onDone(storageStatsRepository.clearPatcherWorkspace())
+    }
+
+    fun clearTemporary(onDone: (Long) -> Unit = {}) = viewModelScope.launch {
+        onDone(storageStatsRepository.clearTemporary())
+    }
+
+    fun clearAllCaches(onDone: (Long) -> Unit = {}) = viewModelScope.launch {
+        onDone(storageStatsRepository.clearAllCaches())
+    }
+}

--- a/app/src/main/java/app/morphe/manager/util/FormatUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/FormatUtils.kt
@@ -3,6 +3,13 @@ package app.morphe.manager.util
 import android.text.format.DateUtils
 
 /**
+ * Format a "used / free" pair as `"{used} / {free}"`. If [free] is zero or negative,
+ * returns just [used] so callers do not have to guard against unavailable device stats.
+ */
+fun formatUsedFree(used: Long, free: Long): String =
+    if (free <= 0L) formatBytes(used) else "${formatBytes(used)} / ${formatBytes(free)}"
+
+/**
  * Format bytes into readable format (B, KB, MB, GB)
  */
 fun formatBytes(bytes: Long): String {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -781,6 +781,28 @@ The image dimensions must be as follows:
     <string name="settings_system_apks_export_zip_failed">Failed to export selected APKs</string>
     <string name="settings_system_apk_item_info" translatable="false">v%s • %s</string>
 
+    <!-- Settings - System Tab - Storage Management screen -->
+    <string name="settings_system_storage_management_title">Storage management</string>
+    <string name="settings_system_storage_management_description">Review disk usage and clear cached files</string>
+    <string name="settings_system_storage_keystore_title">Signing keystore</string>
+    <string name="settings_system_storage_app_data_title">App data</string>
+    <string name="settings_system_storage_patch_bundles_title">Patch bundles</string>
+    <string name="settings_system_storage_http_cache_title">Network cache</string>
+    <string name="settings_system_storage_http_cache_description">HTTP responses cached to speed up updates</string>
+    <string name="settings_system_storage_installer_cache_title">External installer cache</string>
+    <string name="settings_system_storage_installer_cache_description">APK copies passed to third-party installers</string>
+    <string name="settings_system_storage_patcher_workspace_title">Patcher workspace</string>
+    <string name="settings_system_storage_patcher_workspace_description">Patcher runtime files and orphaned scratch data</string>
+    <string name="settings_system_storage_temporary_title">Temporary files</string>
+    <string name="settings_system_storage_temporary_description">Working files created during patching</string>
+    <string name="settings_system_storage_clear_all">Clear all caches</string>
+    <string name="settings_system_storage_clear_all_description">Frees all reclaimable cache space at once</string>
+    <string name="settings_system_storage_clear_all_confirm">This clears cached network responses, staged installer copies, and temporary files. Original and patched APKs are kept</string>
+    <string name="settings_system_storage_cleared">Freed %s</string>
+    <string name="settings_system_storage_nothing_to_clear">Nothing to clear</string>
+    <string name="settings_system_storage_open_app_info_title">Open Android app storage</string>
+    <string name="settings_system_storage_open_app_info_description">Manage or clear all Morphe data through system settings</string>
+
     <!-- Settings - System Tab - Storage Management - Patched APKs Management -->
     <string name="settings_system_patched_apks_title">Patched APKs</string>
     <string name="settings_system_patched_apks_description">Manages saved patched application files</string>


### PR DESCRIPTION
Adds a `Storage management` dialog under `System settings` that visualizes Morphe's on-disk usage with an animated stacked bar and per-category legend, original and patched APKs, patch bundles, keystore, app data, and cache buckets.
The patcher framework cache is now also auto-invalidated after a manager upgrade so stale dex files can't cause runtime errors during patching.
___
![Screenshot_2026-07-12-17-41-23-106_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/51f0c5d0-02dc-4366-9bcd-adfeddf0734a)
![Screenshot_2026-07-12-17-41-47-932_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/33c38068-2247-42a5-b173-dd87f86992c6)
![Screenshot_2026-07-12-21-23-40-765_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/2eb2f01b-9105-49c9-b25d-fef0551ceb40)

