### PR TITLE
feat: Route add-source through the website and enforce a remote blocklist

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -112,8 +112,8 @@
                 <data android:mimeType="application/apks" />
             </intent-filter>
 
-            <!-- Deep link: App Links (https://morphe.software/add-source?github=...) -->
-            <intent-filter android:autoVerify="true">
+            <!-- Add-source deep link. Website acts as the gateway for repo validation -->
+            <intent-filter android:autoVerify="false">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/java/app/morphe/manager/MainActivity.kt
+++ b/app/src/main/java/app/morphe/manager/MainActivity.kt
@@ -124,13 +124,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Handles deep links for adding patch sources.
-     * Format: https://morphe.software/add-source?github=owner/repo(&name=Display+Name)
-     *         https://morphe.software/add-source?gitlab=owner/repo(&name=Display+Name)
-     * Only GitHub and GitLab URLs are accepted for safety.
+     * Handles add-source deep links from an explicit-package `intent://` fired by the website.
+     * Format: https://morphe.software/add-source?<github|gitlab>=owner/repo(&name=…)
+     * Only GitHub and GitLab URLs are accepted.
      */
     private fun handleDeepLinkIntent(intent: Intent?, vm: MainViewModel) {
-        // Handle APK-family file shared via system share sheet (.apk/.apks/.xapk/.apkm).
+        // Handle APK-family file shared via system share sheet (.apk/.apks/.xapk/.apkm)
         if (intent?.action == Intent.ACTION_SEND) {
             val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)

--- a/app/src/main/java/app/morphe/manager/ManagerApplication.kt
+++ b/app/src/main/java/app/morphe/manager/ManagerApplication.kt
@@ -129,12 +129,13 @@ class ManagerApplication : Application() {
             }
         }
 
-        // Cache first for offline launches, then refresh from the network. Notify the user
-        // if any of their existing sources appeared on the blocklist since the last launch
+        // Cache first for offline launches, then refresh from the network. Any matches are
+        // logged for support diagnostics; the in-app snackbar is state-driven so it updates
+        // automatically without a callback here
         scope.launch(Dispatchers.Default) {
             blocklistRepository.loadFromCache()
             blocklistRepository.refresh()
-            patchBundleRepository.notifyBlockedSources()
+            patchBundleRepository.logBlockedSources()
         }
 
         // Preload bundle avatar images into AvatarCache while the user hasn't opened the sheet yet.

--- a/app/src/main/java/app/morphe/manager/ManagerApplication.kt
+++ b/app/src/main/java/app/morphe/manager/ManagerApplication.kt
@@ -12,6 +12,7 @@ import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.bundleAvat
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.githubAvatarUrl
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.gitlabAvatarUrl
 import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.domain.repository.BlocklistRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository.Companion.DEFAULT_SOURCE_UID
 import app.morphe.manager.util.*
@@ -42,6 +43,7 @@ class ManagerApplication : Application() {
     private val scope = MainScope()
     private val prefs: PreferencesManager by inject()
     private val patchBundleRepository: PatchBundleRepository by inject()
+    private val blocklistRepository: BlocklistRepository by inject()
     private val fs: Filesystem by inject()
     private val updateNotificationManager: UpdateNotificationManager by inject()
 
@@ -127,8 +129,16 @@ class ManagerApplication : Application() {
             }
         }
 
+        // Cache first for offline launches, then refresh from the network. Notify the user
+        // if any of their existing sources appeared on the blocklist since the last launch
+        scope.launch(Dispatchers.Default) {
+            blocklistRepository.loadFromCache()
+            blocklistRepository.refresh()
+            patchBundleRepository.notifyBlockedSources()
+        }
+
         // Preload bundle avatar images into AvatarCache while the user hasn't opened the sheet yet.
-        // Suspends until sources are ready, then fetches all URLs in parallel on IO threads.
+        // Suspends until sources are ready, then fetches all URLs in parallel on IO threads
         scope.launch(Dispatchers.IO) {
             patchBundleRepository.sources.first { it.isNotEmpty() }.forEach { bundle ->
                 launch {

--- a/app/src/main/java/app/morphe/manager/di/RepositoryModule.kt
+++ b/app/src/main/java/app/morphe/manager/di/RepositoryModule.kt
@@ -18,6 +18,7 @@ val repositoryModule = module {
     singleOf(::NetworkInfo)
     singleOf(::PatchSelectionRepository)
     singleOf(::PatchOptionsRepository)
+    singleOf(::BlocklistRepository)
     singleOf(::PatchBundleRepository) {
         // It is best to load patch bundles ASAP
         createdAtStart()

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -113,6 +113,9 @@ class PreferencesManager(
     // Patch source list ordering mode.
     val sourceBundleSortMode = stringPreference("source_bundle_sort_mode", SourceBundleSortMode.MANUAL.name)
 
+    /** On-disk cache of the remote source blocklist (JSON), so offline launches still enforce it. */
+    val blocklistCache = stringPreference("blocklist_cache", "")
+
     /** Tracks whether the user has explicitly toggled the custom file picker preference. */
     val customFilePickerUserConfigured = booleanPreference("custom_file_picker_user_configured", false)
 

--- a/app/src/main/java/app/morphe/manager/domain/repository/BlocklistRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/BlocklistRepository.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.repository
+
+import android.util.Log
+import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.util.BLOCKED_SOURCES_URL
+import app.morphe.manager.util.tag
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.util.Locale
+
+/**
+ * Remote blocklist of patch sources, cached to DataStore so offline launches still
+ * enforce the last known state. Entries are keyed by `provider=owner/repo` (lower-case)
+ * and carry an optional reason for display.
+ */
+class BlocklistRepository(
+    private val http: HttpClient,
+    private val prefs: PreferencesManager,
+    private val json: Json
+) {
+    private val _entries = MutableStateFlow<Map<String, BlockedEntry>>(emptyMap())
+    val entries: StateFlow<Map<String, BlockedEntry>> = _entries
+
+    suspend fun loadFromCache() {
+        _entries.value = decode(prefs.blocklistCache.get())
+    }
+
+    /** Keeps the previous value on failure so offline callers keep working. */
+    suspend fun refresh() {
+        val response: BlocklistResponse = try {
+            http.get(BLOCKED_SOURCES_URL).body()
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to refresh source blocklist", e)
+            return
+        }
+        val fresh = response.blocked
+            .asSequence()
+            .filter { it.provider.isNotBlank() && it.repo.isNotBlank() }
+            .associateBy { key(it.provider, it.repo) }
+        _entries.value = fresh
+        prefs.blocklistCache.update(json.encodeToString(fresh.values.toList()))
+    }
+
+    fun isBlocked(key: String): Boolean =
+        _entries.value.containsKey(key.lowercase(Locale.US))
+
+    private fun decode(cached: String): Map<String, BlockedEntry> {
+        if (cached.isBlank()) return emptyMap()
+        return try {
+            json.decodeFromString<List<BlockedEntry>>(cached)
+                .filter { it.provider.isNotBlank() && it.repo.isNotBlank() }
+                .associateBy { key(it.provider, it.repo) }
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to decode cached blocklist", e)
+            emptyMap()
+        }
+    }
+
+    private fun key(provider: String, repo: String): String =
+        "$provider=$repo".lowercase(Locale.US)
+
+    @Serializable
+    private data class BlocklistResponse(
+        val version: Int = 1,
+        val blocked: List<BlockedEntry> = emptyList(),
+    )
+
+    @Serializable
+    data class BlockedEntry(
+        val provider: String,
+        val repo: String,
+        val reason: String? = null,
+    )
+}

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -52,6 +52,7 @@ class PatchBundleRepository(
     private val app: Application,
     private val networkInfo: NetworkInfo,
     private val prefs: PreferencesManager,
+    private val blocklistRepository: BlocklistRepository,
     db: AppDatabase,
 ) {
     private val dao = db.patchBundleDao()
@@ -70,8 +71,26 @@ class PatchBundleRepository(
         }?.toMap() ?: emptyMap()
     }
     val allBundlesInfoFlow = store.state.map { (it as? BundleState.Ready)?.info ?: persistentMapOf() }
-    val enabledBundlesInfoFlow = allBundlesInfoFlow.map { info ->
-        info.filter { (_, bundleInfo) -> bundleInfo.enabled }
+
+    /**
+     * Sources that appear on the remote blocklist, keyed by source uid.
+     * Combines the current source list with [BlocklistRepository.entries] so the map stays in
+     * sync as either side changes. Blocked sources are removed from [enabledBundlesInfoFlow] and
+     * skipped by update predicates, and the UI can render a badge from this map.
+     */
+    val blockedSources: StateFlow<Map<Int, BlocklistRepository.BlockedEntry>> =
+        combine(sources, blocklistRepository.entries) { srcs, blocked ->
+            srcs.asSequence()
+                .filterIsInstance<RemotePatchBundle>()
+                .mapNotNull { src ->
+                    val key = toBlocklistKey(src.endpoint) ?: return@mapNotNull null
+                    blocked[key]?.let { entry -> src.uid to entry }
+                }
+                .toMap()
+        }.stateIn(scope, SharingStarted.Eagerly, emptyMap())
+
+    val enabledBundlesInfoFlow = combine(allBundlesInfoFlow, blockedSources) { info, blocked ->
+        info.filter { (uid, bundleInfo) -> bundleInfo.enabled && uid !in blocked }
     }
     val bundleInfoFlow = enabledBundlesInfoFlow
 
@@ -1053,16 +1072,15 @@ class PatchBundleRepository(
                 return@dispatchAction state
             }
 
-            // Block adding official Morphe repository
-//            val isOfficialRepo = normalizedUrl.contains(SOURCE_REPO_URL, ignoreCase = true) ||
-//                    normalizedUrl.contains(SOURCE_REPO_URL_RAW, ignoreCase = true)
-//            if (isOfficialRepo) {
-//                withContext(Dispatchers.Main) {
-//                    app.toast(app.getString("This source cannot be added because it is already built-in"))
-//                }
-//                return@dispatchAction state
-//            }
-
+            // Website gate is UX-only, so enforce the blocklist here for every code path.
+            val blocklistKey = toBlocklistKey(normalizedUrl)
+            if (blocklistKey != null && blocklistRepository.isBlocked(blocklistKey)) {
+                Log.i(tag, "Refused blocked source: $blocklistKey")
+                withContext(Dispatchers.Main) {
+                    app.toast(app.getString(R.string.sources_management_blocked))
+                }
+                return@dispatchAction state
+            }
 
             // Check for duplicate source
             val ready = state as? BundleState.Ready ?: return@dispatchAction state
@@ -1139,6 +1157,46 @@ class PatchBundleRepository(
             toast(R.string.sources_download_fail_named, bundle.displayTitle)
         }
     }
+
+    private fun isSourceBlocked(src: RemotePatchBundle): Boolean =
+        toBlocklistKey(src.endpoint)?.let { blocklistRepository.isBlocked(it) } == true
+
+    /**
+     * Logs any user sources that appear on the current blocklist. The in-app snackbar
+     * is state-driven from [blockedSources], so this only exists to surface the match in
+     * logcat for support/debugging.
+     */
+    suspend fun notifyBlockedSources() {
+        bundleState.first { it is BundleState.Ready }
+        val ready = bundleState.value as? BundleState.Ready ?: return
+        val blocked = blocklistRepository.entries.value
+
+        val matched = ready.sources.values.mapNotNull { src ->
+            val remote = src as? RemotePatchBundle ?: return@mapNotNull null
+            val key = toBlocklistKey(remote.endpoint) ?: return@mapNotNull null
+            val entry = blocked[key] ?: return@mapNotNull null
+            Triple(remote.endpoint, remote.name, entry)
+        }
+        Log.d(tag, "notifyBlockedSources: blocked=${blocked.size}, matched=${matched.size}")
+        matched.forEach { (endpoint, name, entry) ->
+            Log.i(tag, "Blocked source disabled: $name endpoint=$endpoint reason=${entry.reason}")
+        }
+    }
+
+    /** Returns the blocklist key for a normalized bundle URL, or null for non-GitHub/GitLab hosts. */
+    private fun toBlocklistKey(normalizedUrl: String): String? = try {
+        val parsed = Url(normalizedUrl)
+        val segments = parsed.encodedPath.trim('/').split('/').filter { it.isNotBlank() }
+        when {
+            segments.size < 2 -> null
+            parsed.host.equals("raw.githubusercontent.com", ignoreCase = true) ||
+                parsed.host.equals("github.com", ignoreCase = true) ->
+                "github=${segments[0]}/${segments[1]}".lowercase(Locale.US)
+            parsed.host.equals("gitlab.com", ignoreCase = true) ->
+                "gitlab=${segments[0]}/${segments[1]}".lowercase(Locale.US)
+            else -> null
+        }
+    } catch (_: Exception) { null }
 
     fun normalizeRemoteBundleUrl(input: String): String {
         val trimmed = input.trim()
@@ -1364,13 +1422,14 @@ class PatchBundleRepository(
             showToast = false,
             allowUnsafeNetwork = allowUnsafeNetwork,
             onPerBundleProgress = null,
-            predicate = { it.autoUpdate && it.enabled }
+            predicate = { it.autoUpdate && it.enabled && !isSourceBlocked(it) }
         )
     }
 
     /**
      * Updates all bundles that should be automatically updated AND are currently enabled.
      * Disabled bundles are skipped - they will be updated automatically when re-enabled.
+     * Blocked sources are skipped even if enabled.
      * Respects [PreferencesManager.allowMeteredUpdates]: if the network is metered and the
      * user has disabled metered updates, the update is skipped and
      * [BundleUpdateResult.SkippedMetered] is emitted so the UI can warn the user before patching.
@@ -1380,7 +1439,9 @@ class PatchBundleRepository(
      *   dialog action).
      */
     suspend fun updateCheck(allowUnsafeNetwork: Boolean = false) {
-        store.dispatch(Update(allowUnsafeNetwork = allowUnsafeNetwork) { it.autoUpdate && it.enabled })
+        store.dispatch(Update(allowUnsafeNetwork = allowUnsafeNetwork) {
+            it.autoUpdate && it.enabled && !isSourceBlocked(it)
+        })
         checkManualUpdates()
     }
 

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -1072,7 +1072,7 @@ class PatchBundleRepository(
                 return@dispatchAction state
             }
 
-            // Website gate is UX-only, so enforce the blocklist here for every code path.
+            // Website gate is UX-only, so enforce the blocklist here for every code path
             val blocklistKey = toBlocklistKey(normalizedUrl)
             if (blocklistKey != null && blocklistRepository.isBlocked(blocklistKey)) {
                 Log.i(tag, "Refused blocked source: $blocklistKey")
@@ -1162,11 +1162,11 @@ class PatchBundleRepository(
         toBlocklistKey(src.endpoint)?.let { blocklistRepository.isBlocked(it) } == true
 
     /**
-     * Logs any user sources that appear on the current blocklist. The in-app snackbar
-     * is state-driven from [blockedSources], so this only exists to surface the match in
-     * logcat for support/debugging.
+     * Logs any user sources that appear on the current blocklist. The in-app snackbar is
+     * state-driven from [blockedSources], so this only exists to surface the match in
+     * logcat for support/diagnostics.
      */
-    suspend fun notifyBlockedSources() {
+    suspend fun logBlockedSources() {
         bundleState.first { it is BundleState.Ready }
         val ready = bundleState.value as? BundleState.Ready ?: return
         val blocked = blocklistRepository.entries.value
@@ -1177,7 +1177,7 @@ class PatchBundleRepository(
             val entry = blocked[key] ?: return@mapNotNull null
             Triple(remote.endpoint, remote.name, entry)
         }
-        Log.d(tag, "notifyBlockedSources: blocked=${blocked.size}, matched=${matched.size}")
+        Log.d(tag, "logBlockedSources: blocked=${blocked.size}, matched=${matched.size}")
         matched.forEach { (endpoint, name, entry) ->
             Log.i(tag, "Blocked source disabled: $name endpoint=$endpoint reason=${entry.reason}")
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -205,17 +205,15 @@ fun HomeScreen(
         ) {
             SectionsLayout(
                 notifications = HomeNotificationsUi(
-                    hasManagerUpdate = hasManagerUpdate,
-                    showBundleUpdateSnackbar = homeViewModel.showBundleUpdateSnackbar,
-                    snackbarStatus = homeViewModel.snackbarStatus,
-                    bundleUpdateProgress = bundleUpdateProgress,
-                    onShowUpdateDetails = { showUpdateDetailsDialog.value = true },
-                    hasBlockedSources = hasBlockedSources,
-                    onShowBlockedSources = { homeViewModel.showBundleManagementSheet = true },
-                    hasMetadataErrors = hasMetadataErrors,
-                    onShowMetadataErrors = { homeViewModel.showBundleManagementSheet = true },
-                    updatesSkippedDueToMetered = homeViewModel.updatesSkippedDueToMetered,
-                    onShowMeteredDetails = { homeViewModel.showBundleManagementSheet = true }
+                    managerUpdate = AlertState(hasManagerUpdate) { showUpdateDetailsDialog.value = true },
+                    blockedSources = AlertState(hasBlockedSources) { homeViewModel.showBundleManagementSheet = true },
+                    metadataErrors = AlertState(hasMetadataErrors) { homeViewModel.showBundleManagementSheet = true },
+                    meteredSkipped = AlertState(homeViewModel.updatesSkippedDueToMetered) { homeViewModel.showBundleManagementSheet = true },
+                    bundleUpdate = BundleUpdateState(
+                        visible = homeViewModel.showBundleUpdateSnackbar,
+                        status = homeViewModel.snackbarStatus,
+                        progress = bundleUpdateProgress
+                    )
                 ),
                 apps = HomeAppListUi(
                     visible = homeAppItems,

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -149,6 +149,9 @@ fun HomeScreen(
     // Check for manager update
     val hasManagerUpdate = !homeViewModel.updatedManagerVersion.isNullOrEmpty()
 
+    val blockedSources by homeViewModel.patchBundleRepository.blockedSources.collectAsStateWithLifecycle(emptyMap())
+    val hasBlockedSources = blockedSources.isNotEmpty()
+
     // Manager update details dialog
     if (showUpdateDetailsDialog.value) {
         val updateViewModel: UpdateViewModel = koinViewModel(parameters = { parametersOf(false) })
@@ -203,7 +206,9 @@ fun HomeScreen(
                     showBundleUpdateSnackbar = homeViewModel.showBundleUpdateSnackbar,
                     snackbarStatus = homeViewModel.snackbarStatus,
                     bundleUpdateProgress = bundleUpdateProgress,
-                    onShowUpdateDetails = { showUpdateDetailsDialog.value = true }
+                    onShowUpdateDetails = { showUpdateDetailsDialog.value = true },
+                    hasBlockedSources = hasBlockedSources,
+                    onShowBlockedSources = { homeViewModel.showBundleManagementSheet = true }
                 ),
                 apps = HomeAppListUi(
                     visible = homeAppItems,

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -208,7 +208,7 @@ fun HomeScreen(
                     managerUpdate = AlertState(hasManagerUpdate) { showUpdateDetailsDialog.value = true },
                     blockedSources = AlertState(hasBlockedSources) { homeViewModel.showBundleManagementSheet = true },
                     metadataErrors = AlertState(hasMetadataErrors) { homeViewModel.showBundleManagementSheet = true },
-                    meteredSkipped = AlertState(homeViewModel.updatesSkippedDueToMetered) { homeViewModel.showBundleManagementSheet = true },
+                    meteredSkipped = AlertState(homeViewModel.updatesSkippedDueToMetered) { onSettingsClick() },
                     bundleUpdate = BundleUpdateState(
                         visible = homeViewModel.showBundleUpdateSnackbar,
                         status = homeViewModel.snackbarStatus,

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -152,6 +152,9 @@ fun HomeScreen(
     val blockedSources by homeViewModel.patchBundleRepository.blockedSources.collectAsStateWithLifecycle(emptyMap())
     val hasBlockedSources = blockedSources.isNotEmpty()
 
+    val metadataFetchErrors by homeViewModel.patchBundleRepository.metadataFetchErrors.collectAsStateWithLifecycle(emptyMap())
+    val hasMetadataErrors = metadataFetchErrors.isNotEmpty()
+
     // Manager update details dialog
     if (showUpdateDetailsDialog.value) {
         val updateViewModel: UpdateViewModel = koinViewModel(parameters = { parametersOf(false) })
@@ -208,7 +211,11 @@ fun HomeScreen(
                     bundleUpdateProgress = bundleUpdateProgress,
                     onShowUpdateDetails = { showUpdateDetailsDialog.value = true },
                     hasBlockedSources = hasBlockedSources,
-                    onShowBlockedSources = { homeViewModel.showBundleManagementSheet = true }
+                    onShowBlockedSources = { homeViewModel.showBundleManagementSheet = true },
+                    hasMetadataErrors = hasMetadataErrors,
+                    onShowMetadataErrors = { homeViewModel.showBundleManagementSheet = true },
+                    updatesSkippedDueToMetered = homeViewModel.updatesSkippedDueToMetered,
+                    onShowMeteredDetails = { homeViewModel.showBundleManagementSheet = true }
                 ),
                 apps = HomeAppListUi(
                     visible = homeAppItems,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -521,9 +521,6 @@ private fun alertColorsFor(level: AlertLevel): AlertColorPair = when (level) {
 /**
  * Dismissible card-style alert used for the home-screen notification strip. Swipe-dismiss clears
  * the alert for the current session; it reappears next launch while [visible] stays true.
- *
- * Set [swipeEnabled] to `false` to force the alert to remain on-screen until the underlying
- * condition changes; useful for critical warnings that the user should not silence in-session.
  */
 @Composable
 fun AlertSnackbar(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -94,7 +94,11 @@ data class HomeNotificationsUi(
     val bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
     val onShowUpdateDetails: () -> Unit,
     val hasBlockedSources: Boolean,
-    val onShowBlockedSources: () -> Unit
+    val onShowBlockedSources: () -> Unit,
+    val hasMetadataErrors: Boolean,
+    val onShowMetadataErrors: () -> Unit,
+    val updatesSkippedDueToMetered: Boolean,
+    val onShowMeteredDetails: () -> Unit
 )
 
 /** Visible and hidden app lists with their loading state. */
@@ -257,6 +261,10 @@ fun SectionsLayout(
             bundleUpdateProgress = notifications.bundleUpdateProgress,
             hasBlockedSources = notifications.hasBlockedSources,
             onShowBlockedSources = notifications.onShowBlockedSources,
+            hasMetadataErrors = notifications.hasMetadataErrors,
+            onShowMetadataErrors = notifications.onShowMetadataErrors,
+            updatesSkippedDueToMetered = notifications.updatesSkippedDueToMetered,
+            onShowMeteredDetails = notifications.onShowMeteredDetails,
             modifier = Modifier
                 .widthIn(max = maxCardWidth)
                 .align(Alignment.TopCenter)
@@ -433,6 +441,10 @@ fun NotificationsOverlay(
     bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
     hasBlockedSources: Boolean,
     onShowBlockedSources: () -> Unit,
+    hasMetadataErrors: Boolean,
+    onShowMetadataErrors: () -> Unit,
+    updatesSkippedDueToMetered: Boolean,
+    onShowMeteredDetails: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -443,7 +455,7 @@ fun NotificationsOverlay(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            // Blocked source alert takes priority over update notices
+            // Blocked source alert takes priority over other notices
             AlertSnackbar(
                 visible = hasBlockedSources,
                 level = AlertLevel.Error,
@@ -451,6 +463,26 @@ fun NotificationsOverlay(
                 title = stringResource(R.string.home_blocked_source_title),
                 subtitle = stringResource(R.string.home_blocked_source_subtitle),
                 onShowDetails = onShowBlockedSources,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            AlertSnackbar(
+                visible = updatesSkippedDueToMetered,
+                level = AlertLevel.Warning,
+                icon = Icons.Outlined.SignalCellularAlt,
+                title = stringResource(R.string.home_metered_skipped_title),
+                subtitle = stringResource(R.string.home_metered_skipped_subtitle),
+                onShowDetails = onShowMeteredDetails,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            AlertSnackbar(
+                visible = hasMetadataErrors,
+                level = AlertLevel.Warning,
+                icon = Icons.Outlined.CloudOff,
+                title = stringResource(R.string.home_metadata_errors_title),
+                subtitle = stringResource(R.string.home_metadata_errors_subtitle),
+                onShowDetails = onShowMetadataErrors,
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -85,20 +85,26 @@ private data class SwipeActionConfig(
     val contentColor: Color
 )
 
-/** Notifications strip state and its action. */
+/** Visibility flag paired with the tap callback for a single [AlertSnackbar] slot. */
+@Immutable
+data class AlertState(val visible: Boolean, val onShow: () -> Unit)
+
+/** Transient state driving the bundle-update progress snackbar. */
+@Immutable
+data class BundleUpdateState(
+    val visible: Boolean,
+    val status: BundleUpdateStatus,
+    val progress: PatchBundleRepository.BundleUpdateProgress?
+)
+
+/** Aggregate of all notification-strip inputs, grouped by alert. */
 @Immutable
 data class HomeNotificationsUi(
-    val hasManagerUpdate: Boolean,
-    val showBundleUpdateSnackbar: Boolean,
-    val snackbarStatus: BundleUpdateStatus,
-    val bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
-    val onShowUpdateDetails: () -> Unit,
-    val hasBlockedSources: Boolean,
-    val onShowBlockedSources: () -> Unit,
-    val hasMetadataErrors: Boolean,
-    val onShowMetadataErrors: () -> Unit,
-    val updatesSkippedDueToMetered: Boolean,
-    val onShowMeteredDetails: () -> Unit
+    val managerUpdate: AlertState,
+    val blockedSources: AlertState,
+    val metadataErrors: AlertState,
+    val meteredSkipped: AlertState,
+    val bundleUpdate: BundleUpdateState
 )
 
 /** Visible and hidden app lists with their loading state. */
@@ -254,17 +260,7 @@ fun SectionsLayout(
         // Section 1: Notifications overlay - matches maxCardWidth in AdaptiveContent
         val maxCardWidth = if (isLandscape()) 700.dp else 560.dp
         NotificationsOverlay(
-            hasManagerUpdate = notifications.hasManagerUpdate,
-            onShowUpdateDetails = notifications.onShowUpdateDetails,
-            showBundleUpdateSnackbar = notifications.showBundleUpdateSnackbar,
-            snackbarStatus = notifications.snackbarStatus,
-            bundleUpdateProgress = notifications.bundleUpdateProgress,
-            hasBlockedSources = notifications.hasBlockedSources,
-            onShowBlockedSources = notifications.onShowBlockedSources,
-            hasMetadataErrors = notifications.hasMetadataErrors,
-            onShowMetadataErrors = notifications.onShowMetadataErrors,
-            updatesSkippedDueToMetered = notifications.updatesSkippedDueToMetered,
-            onShowMeteredDetails = notifications.onShowMeteredDetails,
+            notifications = notifications,
             modifier = Modifier
                 .widthIn(max = maxCardWidth)
                 .align(Alignment.TopCenter)
@@ -434,17 +430,7 @@ private fun AdaptiveContent(
  */
 @Composable
 fun NotificationsOverlay(
-    hasManagerUpdate: Boolean,
-    onShowUpdateDetails: () -> Unit,
-    showBundleUpdateSnackbar: Boolean,
-    snackbarStatus: BundleUpdateStatus,
-    bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
-    hasBlockedSources: Boolean,
-    onShowBlockedSources: () -> Unit,
-    hasMetadataErrors: Boolean,
-    onShowMetadataErrors: () -> Unit,
-    updatesSkippedDueToMetered: Boolean,
-    onShowMeteredDetails: () -> Unit,
+    notifications: HomeNotificationsUi,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -457,49 +443,49 @@ fun NotificationsOverlay(
         ) {
             // Blocked source alert takes priority over other notices
             AlertSnackbar(
-                visible = hasBlockedSources,
+                visible = notifications.blockedSources.visible,
                 level = AlertLevel.Error,
                 icon = Icons.Outlined.Block,
                 title = stringResource(R.string.home_blocked_source_title),
                 subtitle = stringResource(R.string.home_blocked_source_subtitle),
-                onShowDetails = onShowBlockedSources,
+                onShowDetails = notifications.blockedSources.onShow,
                 modifier = Modifier.fillMaxWidth()
             )
 
             AlertSnackbar(
-                visible = updatesSkippedDueToMetered,
+                visible = notifications.meteredSkipped.visible,
                 level = AlertLevel.Warning,
                 icon = Icons.Outlined.SignalCellularAlt,
                 title = stringResource(R.string.home_metered_skipped_title),
                 subtitle = stringResource(R.string.home_metered_skipped_subtitle),
-                onShowDetails = onShowMeteredDetails,
+                onShowDetails = notifications.meteredSkipped.onShow,
                 modifier = Modifier.fillMaxWidth()
             )
 
             AlertSnackbar(
-                visible = hasMetadataErrors,
+                visible = notifications.metadataErrors.visible,
                 level = AlertLevel.Warning,
                 icon = Icons.Outlined.CloudOff,
                 title = stringResource(R.string.home_metadata_errors_title),
                 subtitle = stringResource(R.string.home_metadata_errors_subtitle),
-                onShowDetails = onShowMetadataErrors,
+                onShowDetails = notifications.metadataErrors.onShow,
                 modifier = Modifier.fillMaxWidth()
             )
 
             AlertSnackbar(
-                visible = hasManagerUpdate,
+                visible = notifications.managerUpdate.visible,
                 level = AlertLevel.Info,
                 icon = Icons.Outlined.Update,
                 title = stringResource(R.string.home_update_available),
                 subtitle = stringResource(R.string.home_update_available_subtitle),
-                onShowDetails = onShowUpdateDetails,
+                onShowDetails = notifications.managerUpdate.onShow,
                 modifier = Modifier.fillMaxWidth()
             )
 
             BundleUpdateSnackbar(
-                visible = showBundleUpdateSnackbar,
-                status = snackbarStatus,
-                progress = bundleUpdateProgress,
+                visible = notifications.bundleUpdate.visible,
+                status = notifications.bundleUpdate.status,
+                progress = notifications.bundleUpdate.progress,
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -443,21 +443,29 @@ fun NotificationsOverlay(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            // Blocked source snackbar (highest priority, security-relevant)
-            BlockedSourcesSnackbar(
+            // Blocked source alert takes priority over update notices
+            AlertSnackbar(
                 visible = hasBlockedSources,
+                icon = Icons.Outlined.Block,
+                title = stringResource(R.string.home_blocked_source_title),
+                subtitle = stringResource(R.string.home_blocked_source_subtitle),
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer,
                 onShowDetails = onShowBlockedSources,
                 modifier = Modifier.fillMaxWidth()
             )
 
-            // Manager update snackbar
-            ManagerUpdateSnackbar(
+            AlertSnackbar(
                 visible = hasManagerUpdate,
+                icon = Icons.Outlined.Update,
+                title = stringResource(R.string.home_update_available),
+                subtitle = stringResource(R.string.home_update_available_subtitle),
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
                 onShowDetails = onShowUpdateDetails,
                 modifier = Modifier.fillMaxWidth()
             )
 
-            // Bundle update snackbar
             BundleUpdateSnackbar(
                 visible = showBundleUpdateSnackbar,
                 status = snackbarStatus,
@@ -469,11 +477,17 @@ fun NotificationsOverlay(
 }
 
 /**
- * Manager update snackbar.
+ * Dismissible card-style alert used for both the manager-update and blocked-source snackbars.
+ * Swipe-dismiss clears the alert for the session; it reappears next launch while [visible] stays true.
  */
 @Composable
-fun ManagerUpdateSnackbar(
+fun AlertSnackbar(
     visible: Boolean,
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    containerColor: Color,
+    contentColor: Color,
     onShowDetails: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -506,9 +520,7 @@ fun ManagerUpdateSnackbar(
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 onClick = onShowDetails,
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
-                ),
+                colors = CardDefaults.cardColors(containerColor = containerColor),
                 elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
                 shape = RoundedCornerShape(16.dp)
             ) {
@@ -519,98 +531,19 @@ fun ManagerUpdateSnackbar(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    MorpheIcon(
-                        icon = Icons.Outlined.Update,
-                        tint = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
+                    MorpheIcon(icon = icon, tint = contentColor)
 
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
-                            text = stringResource(R.string.home_update_available),
+                            text = title,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer
+                            color = contentColor
                         )
                         Text(
-                            text = stringResource(R.string.home_update_available_subtitle),
+                            text = subtitle,
                             style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
- * Blocked-sources snackbar. Dismissible for the current session but reappears next launch
- * while any blocked source is still present.
- */
-@Composable
-fun BlockedSourcesSnackbar(
-    visible: Boolean,
-    onShowDetails: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val dismissed = remember { mutableStateOf(false) }
-    LaunchedEffect(visible) { if (visible) dismissed.value = false }
-
-    val swipeState = rememberSwipeToDismissBoxState(
-        positionalThreshold = { totalDistance -> totalDistance * 0.4f }
-    )
-    LaunchedEffect(swipeState.currentValue) {
-        if (swipeState.currentValue != SwipeToDismissBoxValue.Settled) {
-            dismissed.value = true
-        }
-    }
-
-    AnimatedVisibility(
-        visible = visible && !dismissed.value,
-        enter = MorpheAnimations.slideUpFadeEnter,
-        exit = MorpheAnimations.slideUpFadeExit,
-        modifier = modifier
-    ) {
-        SwipeToDismissBox(
-            state = swipeState,
-            backgroundContent = {},
-            enableDismissFromStartToEnd = true,
-            enableDismissFromEndToStart = true
-        ) {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                onClick = onShowDetails,
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
-                shape = RoundedCornerShape(16.dp)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    MorpheIcon(
-                        icon = Icons.Outlined.Block,
-                        tint = MaterialTheme.colorScheme.onErrorContainer
-                    )
-
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.home_blocked_source_title),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                        Text(
-                            text = stringResource(R.string.home_blocked_source_subtitle),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f)
+                            color = contentColor.copy(alpha = 0.8f)
                         )
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -446,22 +446,20 @@ fun NotificationsOverlay(
             // Blocked source alert takes priority over update notices
             AlertSnackbar(
                 visible = hasBlockedSources,
+                level = AlertLevel.Error,
                 icon = Icons.Outlined.Block,
                 title = stringResource(R.string.home_blocked_source_title),
                 subtitle = stringResource(R.string.home_blocked_source_subtitle),
-                containerColor = MaterialTheme.colorScheme.errorContainer,
-                contentColor = MaterialTheme.colorScheme.onErrorContainer,
                 onShowDetails = onShowBlockedSources,
                 modifier = Modifier.fillMaxWidth()
             )
 
             AlertSnackbar(
                 visible = hasManagerUpdate,
+                level = AlertLevel.Info,
                 icon = Icons.Outlined.Update,
                 title = stringResource(R.string.home_update_available),
                 subtitle = stringResource(R.string.home_update_available_subtitle),
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
                 onShowDetails = onShowUpdateDetails,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -476,21 +474,50 @@ fun NotificationsOverlay(
     }
 }
 
+/** Semantic level of an [AlertSnackbar], resolved into a Material color pair at call time. */
+enum class AlertLevel { Info, Warning, Error, Success }
+
+private data class AlertColorPair(val container: Color, val content: Color)
+
+@Composable
+private fun alertColorsFor(level: AlertLevel): AlertColorPair = when (level) {
+    AlertLevel.Info -> AlertColorPair(
+        MaterialTheme.colorScheme.tertiaryContainer,
+        MaterialTheme.colorScheme.onTertiaryContainer
+    )
+    AlertLevel.Warning -> AlertColorPair(
+        MaterialTheme.colorScheme.secondaryContainer,
+        MaterialTheme.colorScheme.onSecondaryContainer
+    )
+    AlertLevel.Error -> AlertColorPair(
+        MaterialTheme.colorScheme.errorContainer,
+        MaterialTheme.colorScheme.onErrorContainer
+    )
+    AlertLevel.Success -> AlertColorPair(
+        MaterialTheme.colorScheme.primaryContainer,
+        MaterialTheme.colorScheme.onPrimaryContainer
+    )
+}
+
 /**
- * Dismissible card-style alert used for both the manager-update and blocked-source snackbars.
- * Swipe-dismiss clears the alert for the session; it reappears next launch while [visible] stays true.
+ * Dismissible card-style alert used for the home-screen notification strip. Swipe-dismiss clears
+ * the alert for the current session; it reappears next launch while [visible] stays true.
+ *
+ * Set [swipeEnabled] to `false` to force the alert to remain on-screen until the underlying
+ * condition changes; useful for critical warnings that the user should not silence in-session.
  */
 @Composable
 fun AlertSnackbar(
     visible: Boolean,
+    level: AlertLevel,
     icon: ImageVector,
     title: String,
     subtitle: String,
-    containerColor: Color,
-    contentColor: Color,
     onShowDetails: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    swipeEnabled: Boolean = true
 ) {
+    val colors = alertColorsFor(level)
     val dismissed = remember { mutableStateOf(false) }
     LaunchedEffect(visible) { if (visible) dismissed.value = false }
 
@@ -498,7 +525,7 @@ fun AlertSnackbar(
         positionalThreshold = { totalDistance -> totalDistance * 0.4f }
     )
     LaunchedEffect(swipeState.currentValue) {
-        if (swipeState.currentValue != SwipeToDismissBoxValue.Settled) {
+        if (swipeEnabled && swipeState.currentValue != SwipeToDismissBoxValue.Settled) {
             dismissed.value = true
         }
     }
@@ -512,15 +539,15 @@ fun AlertSnackbar(
         SwipeToDismissBox(
             state = swipeState,
             backgroundContent = {},
-            enableDismissFromStartToEnd = true,
-            enableDismissFromEndToStart = true
+            enableDismissFromStartToEnd = swipeEnabled,
+            enableDismissFromEndToStart = swipeEnabled
         ) {
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 onClick = onShowDetails,
-                colors = CardDefaults.cardColors(containerColor = containerColor),
+                colors = CardDefaults.cardColors(containerColor = colors.container),
                 elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
                 shape = RoundedCornerShape(16.dp)
             ) {
@@ -531,19 +558,19 @@ fun AlertSnackbar(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    MorpheIcon(icon = icon, tint = contentColor)
+                    MorpheIcon(icon = icon, tint = colors.content)
 
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = title,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
-                            color = contentColor
+                            color = colors.content
                         )
                         Text(
                             text = subtitle,
                             style = MaterialTheme.typography.bodyMedium,
-                            color = contentColor.copy(alpha = 0.8f)
+                            color = colors.content.copy(alpha = 0.8f)
                         )
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -441,7 +441,7 @@ fun NotificationsOverlay(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            // Blocked source alert takes priority over other notices
+            // Blocked source alert takes priority and cannot be dismissed while the block persists
             AlertSnackbar(
                 visible = notifications.blockedSources.visible,
                 level = AlertLevel.Error,
@@ -449,6 +449,7 @@ fun NotificationsOverlay(
                 title = stringResource(R.string.home_blocked_source_title),
                 subtitle = stringResource(R.string.home_blocked_source_subtitle),
                 onShowDetails = notifications.blockedSources.onShow,
+                swipeEnabled = false,
                 modifier = Modifier.fillMaxWidth()
             )
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SectionsLayout.kt
@@ -92,7 +92,9 @@ data class HomeNotificationsUi(
     val showBundleUpdateSnackbar: Boolean,
     val snackbarStatus: BundleUpdateStatus,
     val bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
-    val onShowUpdateDetails: () -> Unit
+    val onShowUpdateDetails: () -> Unit,
+    val hasBlockedSources: Boolean,
+    val onShowBlockedSources: () -> Unit
 )
 
 /** Visible and hidden app lists with their loading state. */
@@ -253,6 +255,8 @@ fun SectionsLayout(
             showBundleUpdateSnackbar = notifications.showBundleUpdateSnackbar,
             snackbarStatus = notifications.snackbarStatus,
             bundleUpdateProgress = notifications.bundleUpdateProgress,
+            hasBlockedSources = notifications.hasBlockedSources,
+            onShowBlockedSources = notifications.onShowBlockedSources,
             modifier = Modifier
                 .widthIn(max = maxCardWidth)
                 .align(Alignment.TopCenter)
@@ -427,6 +431,8 @@ fun NotificationsOverlay(
     showBundleUpdateSnackbar: Boolean,
     snackbarStatus: BundleUpdateStatus,
     bundleUpdateProgress: PatchBundleRepository.BundleUpdateProgress?,
+    hasBlockedSources: Boolean,
+    onShowBlockedSources: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -437,6 +443,13 @@ fun NotificationsOverlay(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // Blocked source snackbar (highest priority, security-relevant)
+            BlockedSourcesSnackbar(
+                visible = hasBlockedSources,
+                onShowDetails = onShowBlockedSources,
+                modifier = Modifier.fillMaxWidth()
+            )
+
             // Manager update snackbar
             ManagerUpdateSnackbar(
                 visible = hasManagerUpdate,
@@ -522,6 +535,82 @@ fun ManagerUpdateSnackbar(
                             text = stringResource(R.string.home_update_available_subtitle),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Blocked-sources snackbar. Dismissible for the current session but reappears next launch
+ * while any blocked source is still present.
+ */
+@Composable
+fun BlockedSourcesSnackbar(
+    visible: Boolean,
+    onShowDetails: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val dismissed = remember { mutableStateOf(false) }
+    LaunchedEffect(visible) { if (visible) dismissed.value = false }
+
+    val swipeState = rememberSwipeToDismissBoxState(
+        positionalThreshold = { totalDistance -> totalDistance * 0.4f }
+    )
+    LaunchedEffect(swipeState.currentValue) {
+        if (swipeState.currentValue != SwipeToDismissBoxValue.Settled) {
+            dismissed.value = true
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible && !dismissed.value,
+        enter = MorpheAnimations.slideUpFadeEnter,
+        exit = MorpheAnimations.slideUpFadeExit,
+        modifier = modifier
+    ) {
+        SwipeToDismissBox(
+            state = swipeState,
+            backgroundContent = {},
+            enableDismissFromStartToEnd = true,
+            enableDismissFromEndToStart = true
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                onClick = onShowDetails,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    MorpheIcon(
+                        icon = Icons.Outlined.Block,
+                        tint = MaterialTheme.colorScheme.onErrorContainer
+                    )
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.home_blocked_source_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Text(
+                            text = stringResource(R.string.home_blocked_source_subtitle),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f)
                         )
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -64,6 +64,7 @@ import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.isDefault
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.manager.SourceBundleSortMode
+import app.morphe.manager.domain.repository.BlocklistRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.RemoteAvatar
@@ -103,6 +104,7 @@ fun BundleManagementSheet(
     val metadataFetchErrors by patchBundleRepository.metadataFetchErrors.collectAsStateWithLifecycle(emptyMap())
     val experimentalVersionsEnabled by prefs.bundleExperimentalVersionsEnabled.getAsState()
     val bundleInfo by patchBundleRepository.bundleInfoFlow.collectAsStateWithLifecycle(emptyMap())
+    val blockedSources by patchBundleRepository.blockedSources.collectAsStateWithLifecycle(emptyMap())
 
     val showSheetOnboarding = globalOnboardingState?.sheetOnboardingActive == true
 
@@ -282,6 +284,7 @@ fun BundleManagementSheet(
                                     updateInfo = manualUpdateInfo[bundle.uid],
                                     isUpdating = bundle.uid in activeUpdateUids,
                                     metadataFetchError = metadataFetchErrors[bundle.uid],
+                                    blockedInfo = blockedSources[bundle.uid],
                                     expanded = isSingleDefaultBundle || bundle.uid in expandedBundleUids ||
                                         (showSheetOnboarding && isFirstCard),
                                     onToggleExpanded = {
@@ -467,6 +470,7 @@ private fun BundleManagementCard(
     isDragging: Boolean = false,
     longPressModifier: Modifier = Modifier,
     metadataFetchError: Throwable? = null,
+    blockedInfo: BlocklistRepository.BlockedEntry? = null,
     expanded: Boolean,
     onToggleExpanded: () -> Unit,
     onDelete: () -> Unit,
@@ -498,7 +502,8 @@ private fun BundleManagementCard(
         action()
     }
 
-    val isEnabled = bundle.enabled
+    val isBlocked = blockedInfo != null
+    val isEnabled = bundle.enabled && !isBlocked
     val hasMetadataError = metadataFetchError != null
     val isMissing = bundle.state is PatchBundleSource.State.Missing
 
@@ -569,6 +574,7 @@ private fun BundleManagementCard(
                 showChevron = !forceExpanded,
                 enabled = isEnabled,
                 metadataFetchError = metadataFetchError,
+                blockedInfo = blockedInfo,
                 modifier = longPressModifier
                     .clickable(
                         indication = null,
@@ -597,6 +603,22 @@ private fun BundleManagementCard(
                         .fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
+                    // Blocked source banner (shown when the source appears on the remote blocklist)
+                    AnimatedVisibility(
+                        visible = blockedInfo != null,
+                        enter = MorpheAnimations.expandFadeEnter,
+                        exit = MorpheAnimations.shrinkFadeExit
+                    ) {
+                        val label = stringResource(R.string.sources_management_source_blocked_badge)
+                        val reason = blockedInfo?.reason?.trim()?.takeIf { it.isNotEmpty() }
+                            ?.replaceFirstChar { it.uppercase(Locale.getDefault()) }
+                        InfoBadge(
+                            text = if (reason != null) "$label: $reason" else label,
+                            icon = Icons.Outlined.Block,
+                            style = InfoBadgeStyle.Error
+                        )
+                    }
+
                     // Metadata unavailable hint (shown when patches-bundle.json / remote fetch failed)
                     AnimatedVisibility(
                         visible = metadataFetchError != null || bundle.state is PatchBundleSource.State.Missing,
@@ -812,12 +834,14 @@ private fun BundleManagementCard(
                                 targetState = disableIcon,
                                 label = "disable_icon"
                             ) { icon ->
-                                // Disable button
+                                // Disable button. Locked while the source is blocked because the
+                                // enabled state is forced to false regardless of the underlying toggle.
                                 ActionPillButton(
                                     onClick = withToast(disableToast, onDisable),
                                     icon = icon,
                                     contentDescription = disableEnableDesc,
-                                    tooltip = disableEnableVerb
+                                    tooltip = disableEnableVerb,
+                                    enabled = !isBlocked
                                 )
                             }
                         }
@@ -826,12 +850,13 @@ private fun BundleManagementCard(
                             val updateVerb = stringResource(R.string.update)
                             val updateDesc = updateVerb + " " + bundle.displayTitle
                             val updateToast = stringResource(R.string.sources_management_source_updating)
-                            // Update button
+                            // Update button. Blocked sources cannot be updated remotely.
                             ActionPillButton(
                                 onClick = withToast(updateToast, onUpdate),
                                 icon = Icons.Outlined.Refresh,
                                 contentDescription = updateDesc,
-                                tooltip = updateVerb
+                                tooltip = updateVerb,
+                                enabled = !isBlocked
                             )
                         }
 
@@ -875,7 +900,8 @@ private fun BundleCardHeader(
     showChevron: Boolean,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    metadataFetchError: Throwable? = null
+    metadataFetchError: Throwable? = null,
+    blockedInfo: BlocklistRepository.BlockedEntry? = null,
 ) {
     val rotation by animateFloatAsState(
         targetValue = if (expanded) 180f else 0f,
@@ -983,9 +1009,23 @@ private fun BundleCardHeader(
                     )
                 }
 
-                // Disabled badge
+                // Blocked badge in the header stays terse; the reason lives in the expanded banner
                 AnimatedVisibility(
-                    visible = !enabled,
+                    visible = blockedInfo != null,
+                    enter = MorpheAnimations.expandHorizFadeIn,
+                    exit = MorpheAnimations.shrinkHorizFadeOut
+                ) {
+                    InfoBadge(
+                        text = stringResource(R.string.sources_management_source_blocked_badge),
+                        style = InfoBadgeStyle.Error,
+                        icon = null,
+                        isCompact = true
+                    )
+                }
+
+                // Disabled badge (hidden when blocked to avoid a redundant second chip)
+                AnimatedVisibility(
+                    visible = !enabled && blockedInfo == null,
                     enter = MorpheAnimations.expandHorizFadeIn,
                     exit = MorpheAnimations.shrinkHorizFadeOut
                 ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -611,7 +611,7 @@ private fun BundleManagementCard(
                     ) {
                         val label = stringResource(R.string.sources_management_source_blocked_badge)
                         val reason = blockedInfo?.reason?.trim()?.takeIf { it.isNotEmpty() }
-                            ?.replaceFirstChar { it.uppercase(Locale.getDefault()) }
+                            ?.replaceFirstChar { it.uppercaseChar() }
                         InfoBadge(
                             text = if (reason != null) "$label: $reason" else label,
                             icon = Icons.Outlined.Block,
@@ -834,8 +834,7 @@ private fun BundleManagementCard(
                                 targetState = disableIcon,
                                 label = "disable_icon"
                             ) { icon ->
-                                // Disable button. Locked while the source is blocked because the
-                                // enabled state is forced to false regardless of the underlying toggle.
+                                // Disable button
                                 ActionPillButton(
                                     onClick = withToast(disableToast, onDisable),
                                     icon = icon,
@@ -850,7 +849,7 @@ private fun BundleManagementCard(
                             val updateVerb = stringResource(R.string.update)
                             val updateDesc = updateVerb + " " + bundle.displayTitle
                             val updateToast = stringResource(R.string.sources_management_source_updating)
-                            // Update button. Blocked sources cannot be updated remotely.
+                            // Update button
                             ActionPillButton(
                                 onClick = withToast(updateToast, onUpdate),
                                 icon = Icons.Outlined.Refresh,
@@ -1009,7 +1008,7 @@ private fun BundleCardHeader(
                     )
                 }
 
-                // Blocked badge in the header stays terse; the reason lives in the expanded banner
+                // Blocked badge
                 AnimatedVisibility(
                     visible = blockedInfo != null,
                     enter = MorpheAnimations.expandHorizFadeIn,
@@ -1023,7 +1022,7 @@ private fun BundleCardHeader(
                     )
                 }
 
-                // Disabled badge (hidden when blocked to avoid a redundant second chip)
+                // Disabled badge
                 AnimatedVisibility(
                     visible = !enabled && blockedInfo == null,
                     enter = MorpheAnimations.expandHorizFadeIn,

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheAnimations.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheAnimations.kt
@@ -59,8 +59,7 @@ object MorpheAnimations {
     val expandHorizFadeIn = expandHorizontally(defaultTween()) + fadeIn
     val shrinkHorizFadeOut = shrinkHorizontally(defaultTween()) + fadeOut
 
-    // Slide + fade + size collapse; the shrink/expand keeps the sibling layout in sync while the
-    // card is animating out so no empty gap lingers between neighbours
+    // Slide + fade + size collapse
     val slideUpFadeEnter = slideInVertically(defaultTween()) { -it } +
         fadeIn(defaultTween()) +
         expandVertically(defaultTween())

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheAnimations.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/MorpheAnimations.kt
@@ -59,9 +59,14 @@ object MorpheAnimations {
     val expandHorizFadeIn = expandHorizontally(defaultTween()) + fadeIn
     val shrinkHorizFadeOut = shrinkHorizontally(defaultTween()) + fadeOut
 
-    // Slide transitions
-    val slideUpFadeEnter = slideInVertically(defaultTween()) { -it } + fadeIn
-    val slideUpFadeExit = slideOutVertically(defaultTween()) { -it } + fadeOut
+    // Slide + fade + size collapse; the shrink/expand keeps the sibling layout in sync while the
+    // card is animating out so no empty gap lingers between neighbours
+    val slideUpFadeEnter = slideInVertically(defaultTween()) { -it } +
+        fadeIn(defaultTween()) +
+        expandVertically(defaultTween())
+    val slideUpFadeExit = slideOutVertically(defaultTween()) { -it } +
+        fadeOut(defaultTween()) +
+        shrinkVertically(defaultTween())
 
     // Push transitions (Settings screen slides up over home, returns by sliding down)
     val pushEnter = slideInVertically(

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -308,6 +308,11 @@ class HomeViewModel(
     var showBundleUpdateSnackbar by mutableStateOf(false)
     var snackbarStatus by mutableStateOf(BundleUpdateStatus.Updating)
 
+    // Latches when an update cycle was skipped due to metered network; cleared on the next
+    // successful/no-change update. Independent of the transient BundleUpdateSnackbar so the
+    // user still sees a persistent alert after the transient snackbar fades
+    var updatesSkippedDueToMetered by mutableStateOf(false)
+
     // Simple mode bundle selection dialog: shown when 2+ bundles have patches for the same app
     var showSimpleBundleSelectDialog by mutableStateOf(false)
     var simpleBundleSelectApp by mutableStateOf<SelectedApp?>(null)
@@ -746,6 +751,12 @@ class HomeViewModel(
                     PatchBundleRepository.BundleUpdateResult.Error -> BundleUpdateStatus.Error
                     PatchBundleRepository.BundleUpdateResult.None -> BundleUpdateStatus.Updating
                     PatchBundleRepository.BundleUpdateResult.SkippedMetered -> BundleUpdateStatus.Warning
+                }
+                updatesSkippedDueToMetered = when (progress.result) {
+                    PatchBundleRepository.BundleUpdateResult.SkippedMetered -> true
+                    PatchBundleRepository.BundleUpdateResult.Success,
+                    PatchBundleRepository.BundleUpdateResult.NoUpdates -> false
+                    else -> updatesSkippedDueToMetered
                 }
             }
         }

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -16,6 +16,7 @@ const val MANAGER_REPO_URL = "https://github.com/MorpheApp/morphe-manager"
 const val SOURCE_REPO_URL = "https://github.com/MorpheApp/morphe-patches"
 const val MORPHE_API_URL = "https://api.morphe.software"
 const val MORPHE_WEBSITE_URL = "https://morphe.software"
+const val BLOCKED_SOURCES_URL = "$MORPHE_API_URL/v2/blocked-sources"
 
 /**
  * Delay before showing a manager update notification to the user.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="sources_management_experimental_versions_toggle_description">Patches experimental app targets if available</string>
     <string name="sources_management_already_exists">This source has already been added</string>
     <string name="sources_management_invalid_url">Invalid source URL. Please check the address and try again</string>
+    <string name="sources_management_blocked">This patch source is blocked and cannot be added</string>
+    <string name="sources_management_source_blocked_badge">Blocked</string>
     <string name="sources_management_metadata_unavailable">Metadata N/A</string>
     <string name="sources_management_metadata_unavailable_hint">The remote metadata file is unavailable. Patching with the installed bundle still works, but auto-update is disabled for this source</string>
     <string name="sources_management_metadata_unavailable_hint_missing">The patch bundle could not be downloaded. The source URL may be incorrect or the file does not exist</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="home_metadata_errors_title">Some patch sources are unavailable</string>
     <string name="home_metadata_errors_subtitle">Tap to review sources</string>
     <string name="home_metered_skipped_title">Updates paused on mobile data</string>
-    <string name="home_metered_skipped_subtitle">Tap to review or reconnect on Wi-Fi</string>
+    <string name="home_metered_skipped_subtitle">Tap to allow updates on mobile data</string>
     <string name="home_update_error">Update failed</string>
     <string name="home_update_error_subtitle">Check your internet connection and try again</string>
     <string name="home_update_skipped_metered">Updates skipped</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="home_update_available_subtitle">New version ready to install</string>
     <string name="home_blocked_source_title">Blocked patch source detected</string>
     <string name="home_blocked_source_subtitle">Tap to review and remove</string>
+    <string name="home_metadata_errors_title">Some patch sources are unavailable</string>
+    <string name="home_metadata_errors_subtitle">Tap to review sources</string>
+    <string name="home_metered_skipped_title">Updates paused on mobile data</string>
+    <string name="home_metered_skipped_subtitle">Tap to review or reconnect on Wi-Fi</string>
     <string name="home_update_error">Update failed</string>
     <string name="home_update_error_subtitle">Check your internet connection and try again</string>
     <string name="home_update_skipped_metered">Updates skipped</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <!-- Home Screen - Update Notifications -->
     <string name="home_update_available">Morphe update available</string>
     <string name="home_update_available_subtitle">New version ready to install</string>
+    <string name="home_blocked_source_title">Blocked patch source detected</string>
+    <string name="home_blocked_source_subtitle">Tap to review and remove</string>
     <string name="home_update_error">Update failed</string>
     <string name="home_update_error_subtitle">Check your internet connection and try again</string>
     <string name="home_update_skipped_metered">Updates skipped</string>


### PR DESCRIPTION
 ## Summary

  - The `https://morphe.software/add-source` intent-filter no longer uses `autoVerify`, so on Android 12+ bare URL clicks default to the browser and the website acts as the gateway.
  - New `BlocklistRepository` fetches a remote list from `https://api.morphe.software/v2/blocked-sources` on startup, caches it in DataStore for offline enforcement, and refreshes on every launch.
  - `PatchBundleRepository.createRemote()` refuses any add attempt whose repo appears on the blocklist. This covers deep links, manual URL entry, and share sheet, every path funnels through this chokepoint.
  - Blocked sources that were added before they entered the blocklist are retroactively filtered out of `enabledBundlesInfoFlow` and update predicates, and the sources management sheet shows a red "Blocked" badge with the reason.
  - A new shared `AlertSnackbar` surfaces four state-driven alerts on Home:
    - Blocked source detected
    - Updates paused on mobile data
    - Some patch sources are unavailable
    - Morphe update available