### PR TITLE
feat: Add launch update controls

### DIFF
--- a/app/src/main/java/app/morphe/manager/ManagerApplication.kt
+++ b/app/src/main/java/app/morphe/manager/ManagerApplication.kt
@@ -123,7 +123,9 @@ class ManagerApplication : Application() {
         scope.launch(Dispatchers.Default) {
             with(patchBundleRepository) {
                 reload()
-                updateCheck()
+                if (prefs.updatePatchSourcesOnLaunch.get()) {
+                    updateCheck()
+                }
             }
         }
 

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -57,6 +57,12 @@ class PreferencesManager(
     /**  How often the background update check should run. */
     val updateCheckInterval = enumPreference("update_check_interval", UpdateCheckInterval.DAILY)
 
+    /** Whether to check for Morphe app updates when the app opens. */
+    val checkManagerUpdatesOnLaunch = booleanPreference("check_manager_updates_on_launch", true)
+
+    /** Whether to update patch sources when the app opens. */
+    val updatePatchSourcesOnLaunch = booleanPreference("update_patch_sources_on_launch", true)
+
     /** Tracks whether the POST_NOTIFICATIONS runtime permission dialog has already been shown at least once on first launch (Android 13+). */
     val notificationPermissionRequested = booleanPreference("notification_permission_requested", false)
 
@@ -182,6 +188,8 @@ class PreferencesManager(
         val keystorePassword: String? = null,
         val firstLaunch: Boolean? = null,
         val showManagerUpdateDialogOnLaunch: Boolean? = null,
+        val checkManagerUpdatesOnLaunch: Boolean? = null,
+        val updatePatchSourcesOnLaunch: Boolean? = null,
         val useManagerPrereleases: Boolean? = null,
         val bundlePrereleasesEnabled: Set<String>? = null,
         val bundleExperimentalVersionsEnabled: Set<String>? = null,
@@ -243,6 +251,8 @@ class PreferencesManager(
         randomBackgroundInterval = randomBackgroundInterval.get(),
         useExpertMode = useExpertMode.get(),
         updateCheckInterval = updateCheckInterval.get(),
+        checkManagerUpdatesOnLaunch = checkManagerUpdatesOnLaunch.get(),
+        updatePatchSourcesOnLaunch = updatePatchSourcesOnLaunch.get(),
         bytecodeModePreference = bytecodeModePreference.get(),
         filePickerSortMode = filePickerSortMode.get(),
         filePickerShowHiddenFiles = filePickerShowHiddenFiles.get(),
@@ -273,6 +283,10 @@ class PreferencesManager(
         snapshot.keystorePass?.let { keystorePass.value = it }
         snapshot.keystorePassword?.let { keystorePassword.value = it }
         snapshot.firstLaunch?.let { firstLaunch.value = it }
+        (snapshot.checkManagerUpdatesOnLaunch ?: snapshot.showManagerUpdateDialogOnLaunch)?.let {
+            checkManagerUpdatesOnLaunch.value = it
+        }
+        snapshot.updatePatchSourcesOnLaunch?.let { updatePatchSourcesOnLaunch.value = it }
         snapshot.useManagerPrereleases?.let { useManagerPrereleases.value = it }
         snapshot.bundlePrereleasesEnabled?.let { bundlePrereleasesEnabled.value = it }
         snapshot.bundleExperimentalVersionsEnabled?.let { bundleExperimentalVersionsEnabled.value = it }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
@@ -43,6 +43,8 @@ fun UpdatesSettingsItem(
     val prefs = settingsViewModel.prefs
     val backgroundUpdateNotifications by prefs.backgroundUpdateNotifications.getAsState()
     val updateCheckInterval by prefs.updateCheckInterval.getAsState()
+    val checkManagerUpdatesOnLaunch by prefs.checkManagerUpdatesOnLaunch.getAsState()
+    val updatePatchSourcesOnLaunch by prefs.updatePatchSourcesOnLaunch.getAsState()
     val allowMeteredUpdates by prefs.allowMeteredUpdates.getAsState()
     val useManagerPrereleases by prefs.useManagerPrereleases.getAsState()
     val usePatchesPrereleases by prefs.bundlePrereleasesEnabled.getAsState()
@@ -104,6 +106,48 @@ fun UpdatesSettingsItem(
                     onCheckedChange = null,
                     modifier = Modifier.semantics {
                         stateDescription = if (useManagerPrereleases) enabledState else disabledState
+                    }
+                )
+            }
+        )
+
+        MorpheSettingsDivider()
+
+        // Manager update check on launch toggle
+        SettingsItem(
+            onClick = {
+                settingsViewModel.toggleManagerUpdatesOnLaunch(checkManagerUpdatesOnLaunch)
+            },
+            leadingContent = { MorpheIcon(icon = Icons.Outlined.Update) },
+            title = stringResource(R.string.settings_advanced_updates_manager_on_launch),
+            subtitle = stringResource(R.string.settings_advanced_updates_manager_on_launch_description),
+            trailingContent = {
+                MorpheSwitch(
+                    checked = checkManagerUpdatesOnLaunch,
+                    onCheckedChange = null,
+                    modifier = Modifier.semantics {
+                        stateDescription = if (checkManagerUpdatesOnLaunch) enabledState else disabledState
+                    }
+                )
+            }
+        )
+
+        MorpheSettingsDivider()
+
+        // Patch source update check on launch toggle
+        SettingsItem(
+            onClick = {
+                settingsViewModel.togglePatchSourcesOnLaunch(updatePatchSourcesOnLaunch)
+            },
+            leadingContent = { MorpheIcon(icon = Icons.Outlined.Source) },
+            title = stringResource(R.string.settings_advanced_updates_patches_on_launch),
+            subtitle = stringResource(R.string.settings_advanced_updates_patches_on_launch_description),
+            trailingContent = {
+                MorpheSwitch(
+                    checked = updatePatchSourcesOnLaunch,
+                    onCheckedChange = null,
+                    modifier = Modifier.semantics {
+                        stateDescription = if (updatePatchSourcesOnLaunch) enabledState else disabledState
                     }
                 )
             }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -649,7 +649,7 @@ class HomeViewModel(
     var onStartQuickPatch: ((QuickPatchParams) -> Unit)? = null
 
     init {
-        triggerUpdateCheck()
+        triggerLaunchUpdateCheck()
         observeLoadingState()
         observeInstalledAppUpdates()
         observeDeletedAppsStatus()
@@ -894,6 +894,14 @@ class HomeViewModel(
     fun triggerUpdateCheck() {
         viewModelScope.launch {
             checkForManagerUpdates()
+        }
+    }
+
+    private fun triggerLaunchUpdateCheck() {
+        viewModelScope.launch {
+            if (prefs.checkManagerUpdatesOnLaunch.get()) {
+                checkForManagerUpdates()
+            }
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -136,6 +136,16 @@ class SettingsViewModel(
         if (!hasGms) UpdateCheckWorker.schedule(appContext, interval)
     }
 
+    /** Persists whether Morphe checks for manager updates when the app opens. */
+    fun toggleManagerUpdatesOnLaunch(current: Boolean) = viewModelScope.launch {
+        prefs.checkManagerUpdatesOnLaunch.update(!current)
+    }
+
+    /** Persists whether Morphe updates patch sources when the app opens. */
+    fun togglePatchSourcesOnLaunch(current: Boolean) = viewModelScope.launch {
+        prefs.updatePatchSourcesOnLaunch.update(!current)
+    }
+
     /** Persists the allow-metered-updates preference. */
     fun toggleAllowMeteredUpdates(current: Boolean) = viewModelScope.launch {
         prefs.allowMeteredUpdates.update(!current)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -540,6 +540,10 @@ Uninstalling will permanently erase all app data"</string>
     <string name="settings_advanced_updates">Updates</string>
     <string name="settings_advanced_updates_use_prereleases">Pre-release updates</string>
     <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe app versions. Enable pre-release per source in patch sources</string>
+    <string name="settings_advanced_updates_manager_on_launch">Check for Morphe app updates on launch</string>
+    <string name="settings_advanced_updates_manager_on_launch_description">Looks for new Morphe app versions when the Morphe app opens</string>
+    <string name="settings_advanced_updates_patches_on_launch">Update patch sources on launch</string>
+    <string name="settings_advanced_updates_patches_on_launch_description">Refreshes patch sources when the Morphe app opens</string>
     <string name="settings_advanced_updates_allow_metered">Mobile data updates</string>
     <string name="settings_advanced_updates_allow_metered_description">Allows Morphe and patch updates to download over mobile data</string>
     <string name="settings_advanced_updates_background_notifications">Background update notifications</string>


### PR DESCRIPTION
Add Advanced > Updates toggles for checking Morphe app updates and refreshing patch sources when the Morphe app opens.

Keep both toggles enabled by default so existing launch behavior is preserved until the user opts out.

Leave manual update paths unchanged, including Home pull-to-refresh and per-source patch updates.