### PR TITLE
feat: Add universal patch default setting

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -65,6 +65,8 @@ class PreferencesManager(
 
     val useExpertMode = booleanPreference("use_expert_mode", false)
 
+    val includeUniversalPatchesByDefault = booleanPreference("include_universal_patches_by_default", true)
+
     val stripUnusedNativeLibs = booleanPreference("strip_unused_native_libs", false)
 
     /**
@@ -202,6 +204,7 @@ class PreferencesManager(
         val backgroundType: BackgroundType? = null,
         val randomBackgroundInterval: RandomInterval? = null,
         val useExpertMode: Boolean? = null,
+        val includeUniversalPatchesByDefault: Boolean? = null,
         val updateCheckInterval: UpdateCheckInterval? = null,
         val customBundles: List<BundleSnapshot>? = null,
         val bytecodeModePreference: BytecodeMode? = null,
@@ -242,6 +245,7 @@ class PreferencesManager(
         backgroundType = backgroundType.get(),
         randomBackgroundInterval = randomBackgroundInterval.get(),
         useExpertMode = useExpertMode.get(),
+        includeUniversalPatchesByDefault = includeUniversalPatchesByDefault.get(),
         updateCheckInterval = updateCheckInterval.get(),
         bytecodeModePreference = bytecodeModePreference.get(),
         filePickerSortMode = filePickerSortMode.get(),
@@ -281,6 +285,7 @@ class PreferencesManager(
         snapshot.backgroundType?.let { backgroundType.value = it }
         snapshot.randomBackgroundInterval?.let { randomBackgroundInterval.value = it }
         snapshot.useExpertMode?.let { useExpertMode.value = it }
+        snapshot.includeUniversalPatchesByDefault?.let { includeUniversalPatchesByDefault.value = it }
         snapshot.updateCheckInterval?.let { updateCheckInterval.value = it }
         snapshot.bytecodeModePreference?.let { bytecodeModePreference.value = it }
         snapshot.filePickerSortMode?.let { filePickerSortMode.value = it }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/AdvancedTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/AdvancedTabContent.kt
@@ -49,6 +49,7 @@ fun AdvancedTabContent(
 ) {
     val prefs = settingsViewModel.prefs
     val useExpertMode by prefs.useExpertMode.getAsState()
+    val includeUniversalPatchesByDefault by prefs.includeUniversalPatchesByDefault.getAsState()
     val stripUnusedNativeLibs by prefs.stripUnusedNativeLibs.getAsState()
 
     // Notify VM on expert mode changes so it can derive showExpertModeNotice
@@ -126,6 +127,29 @@ fun AdvancedTabContent(
                         onCheckedChange = null,
                         modifier = Modifier.semantics {
                             stateDescription = if (useExpertMode) enabledState else disabledState
+                        }
+                    )
+                }
+            )
+
+            MorpheSettingsDivider()
+
+            SettingsItem(
+                onClick = {
+                    settingsViewModel.setIncludeUniversalPatchesByDefault(!includeUniversalPatchesByDefault)
+                },
+                leadingContent = {
+                    MorpheIcon(icon = Icons.Outlined.Extension)
+                },
+                title = stringResource(R.string.settings_advanced_universal_patches_default),
+                subtitle = stringResource(R.string.settings_advanced_universal_patches_default_description),
+                trailingContent = {
+                    MorpheSwitch(
+                        checked = includeUniversalPatchesByDefault,
+                        onCheckedChange = null,
+                        modifier = Modifier.semantics {
+                            stateDescription =
+                                if (includeUniversalPatchesByDefault) enabledState else disabledState
                         }
                     )
                 }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -422,6 +422,12 @@ class HomeViewModel(
     /** Convenience accessor - reads expert mode preference without blocking. */
     private suspend fun isExpertMode() = prefs.useExpertMode.get()
 
+    private val PatchInfo.isUniversalPatch: Boolean
+        get() = compatiblePackages == null || compatiblePackages.any { it.packageName == null }
+
+    private fun PatchInfo.shouldEnableByDefault(includeUniversalPatches: Boolean): Boolean =
+        include && (includeUniversalPatches || !isUniversalPatch)
+
     /**
      * Per-bundle recommended version for each package.
      * Returns Map<PackageName, Map<BundleUid, AppTarget>> so the APK availability dialog
@@ -2218,6 +2224,8 @@ class HomeViewModel(
         fun PatchSelection.applyGmsCoreFilter(): PatchSelection =
             if (usingMountInstall) this.filterGmsCore() else this
 
+        val includeUniversalPatchesByDefault = prefs.includeUniversalPatchesByDefault.get()
+
         if (isExpertMode()) {
             // Expert Mode: Load saved selections and options only for current bundles
             val currentBundleUids = allBundles.map { it.uid }.toSet()
@@ -2277,7 +2285,10 @@ class HomeViewModel(
 
                         // Among the genuinely new patches, auto-select those with include=true
                         val newDefaultEnabled = bundle.patches
-                            .filter { it.name in newPatchNames && it.include }
+                            .filter {
+                                it.name in newPatchNames &&
+                                        it.shouldEnableByDefault(includeUniversalPatchesByDefault)
+                            }
                             .mapTo(mutableSetOf()) { it.name }
 
                         if (newDefaultEnabled.isNotEmpty()) {
@@ -2290,7 +2301,9 @@ class HomeViewModel(
                 mergedPatches
             } else {
                 // No saved selections - use default for all current bundles
-                allBundles.toPatchSelection(allowIncompatible) { _, patch -> patch.include }
+                allBundles.toPatchSelection(allowIncompatible) { _, patch ->
+                    patch.shouldEnableByDefault(includeUniversalPatchesByDefault)
+                }
             }.applyGmsCoreFilter()
 
             // Compute new patches map for the dialog to highlight.
@@ -2339,12 +2352,13 @@ class HomeViewModel(
             // or ask the user to pick one if multiple bundles have applicable patches.
             // A patch is applicable if:
             //   - compatiblePackages == null (universal), OR
+            //   - compatiblePackages contains a null packageName (universal), OR
             //   - compatiblePackages contains this packageName
             val bundleWithPatches = allBundles
                 .filter { it.enabled }
                 .map { bundle ->
                     val patchNames = bundle.patchSequence(allowIncompatible)
-                        .filter { it.include }
+                        .filter { it.shouldEnableByDefault(includeUniversalPatchesByDefault) }
                         .mapTo(mutableSetOf()) { it.name }
                     bundle to patchNames
                 }
@@ -2384,7 +2398,7 @@ class HomeViewModel(
                 val bundle = allBundles.find { it.uid == preSelectedUid }
                 if (bundle != null) {
                     val patchNames = bundle.patchSequence(allowIncompatible = true)
-                        .filter { it.include }
+                        .filter { it.shouldEnableByDefault(includeUniversalPatchesByDefault) }
                         .mapTo(mutableSetOf()) { it.name }
                     if (patchNames.isNotEmpty()) {
                         val patches = mapOf(bundle.uid to patchNames).applyGmsCoreFilter()
@@ -2521,8 +2535,9 @@ class HomeViewModel(
      * are computed from the complete set, not just search results.
      */
     fun expertModeResetToDefault(bundleUid: Int, allPatches: List<Pair<PatchInfo, Boolean>>) {
+        val includeUniversalPatchesByDefault = prefs.includeUniversalPatchesByDefault.getBlocking()
         val defaults = allPatches
-            .filter { (patch, _) -> patch.include }
+            .filter { (patch, _) -> patch.shouldEnableByDefault(includeUniversalPatchesByDefault) }
             .mapTo(mutableSetOf()) { (patch, _) -> patch.name }
         val current = expertModePatches.toMutableMap()
         if (defaults.isEmpty()) current.remove(bundleUid) else current[bundleUid] = defaults

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -185,6 +185,10 @@ class SettingsViewModel(
         }
     }
 
+    fun setIncludeUniversalPatchesByDefault(enabled: Boolean) = viewModelScope.launch {
+        prefs.includeUniversalPatchesByDefault.update(enabled)
+    }
+
     fun setProcessRuntime(enabled: Boolean) = viewModelScope.launch {
         prefs.useProcessRuntime.update(enabled)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,6 +573,8 @@ Uninstalling will permanently erase all app data"</string>
     <string name="settings_advanced_expert_mode_description">Enables complex Morphe patching settings and customization options</string>
     <string name="settings_advanced_expert_mode_dialog_title">Enable Expert mode?</string>
     <string name="settings_advanced_expert_mode_dialog_message">Expert mode gives more control over how patches are applied, but misconfiguring settings in expert mode can result in a non-functional app</string>
+    <string name="settings_advanced_universal_patches_default">Include universal patches by default</string>
+    <string name="settings_advanced_universal_patches_default_description">Automatically selects universal patches in recommended selections. Required dependencies still apply when this is off</string>
     <string name="settings_advanced_strip_unused_libs">Optimize for device architecture</string>
     <string name="settings_advanced_strip_unused_libs_description">Removes unused CPU architecture libs and split APK modules</string>
 


### PR DESCRIPTION
Add an Advanced setting for controlling whether universal patches are automatically included in recommended/default patch selections.

When disabled, universal patches are skipped for simple-mode defaults, new default patch auto-selection, and Expert mode reset-to-default. Explicit saved selections and patcher-required dependencies are still respected.

https://github.com/MorpheApp/morphe-manager/issues/716