### PR TITLE
feat: optionally delete patched APK after install

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -82,6 +82,7 @@ class PreferencesManager(
     val installerCustomComponents = stringSetPreference("installer_custom_components", emptySet())
     val installerHiddenComponents = stringSetPreference("installer_hidden_components", emptySet())
     val autoInstallWithShizuku = booleanPreference("auto_install_with_shizuku", false)
+    val deletePatchedApkAfterInstall = booleanPreference("delete_patched_apk_after_install", false)
 
     val useProcessRuntime = booleanPreference(
         "process_runtime", // Old key was 'use_process_runtime' and may have the wrong default for some devices.
@@ -180,6 +181,7 @@ class PreferencesManager(
         val installerPrimary: String? = null,
         val installerCustomComponents: Set<String>? = null,
         val installerHiddenComponents: Set<String>? = null,
+        val deletePatchedApkAfterInstall: Boolean? = null,
         val keystoreAlias: String? = null,
         val keystorePass: String? = null,
         val keystorePassword: String? = null,
@@ -233,6 +235,7 @@ class PreferencesManager(
         installerPrimary = installerPrimary.get(),
         installerCustomComponents = installerCustomComponents.get(),
         installerHiddenComponents = installerHiddenComponents.get(),
+        deletePatchedApkAfterInstall = deletePatchedApkAfterInstall.get(),
         keystoreAlias = keystoreAlias.get(),
         keystorePass = keystorePass.get(),
         keystorePassword = keystorePassword.get().takeIf { it.isNotEmpty() },
@@ -272,6 +275,7 @@ class PreferencesManager(
         snapshot.installerPrimary?.let { installerPrimary.value = it }
         snapshot.installerCustomComponents?.let { installerCustomComponents.value = it }
         snapshot.installerHiddenComponents?.let { installerHiddenComponents.value = it }
+        snapshot.deletePatchedApkAfterInstall?.let { deletePatchedApkAfterInstall.value = it }
         snapshot.keystoreAlias?.let { keystoreAlias.value = it }
         snapshot.keystorePass?.let { keystorePass.value = it }
         snapshot.keystorePassword?.let { keystorePassword.value = it }

--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -8,6 +8,7 @@ import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.data.room.apps.installed.SelectionPayload
 import app.morphe.manager.util.PatchSelection
+import app.morphe.manager.util.PM
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -19,7 +20,8 @@ private const val TAG = "Morphe InstalledAppRepository"
 class InstalledAppRepository(
     db: AppDatabase,
     private val patchBundleRepository: PatchBundleRepository,
-    private val filesystem: Filesystem
+    private val filesystem: Filesystem,
+    private val pm: PM
 ) {
     private val dao = db.installedAppDao()
     private val bundleDao = db.patchBundleDao()
@@ -111,27 +113,45 @@ class InstalledAppRepository(
             Log.i(TAG, "Reconciled version for ${app.currentPackageName}: ${app.version} → $newVersion")
         }
 
-    /**
-     * Delete installed app record and its saved patched APK file from storage.
-     * Looks up the file by both currentPackageName and originalPackageName to handle renamed packages.
-     */
-    suspend fun delete(installedApp: InstalledApp) = withContext(Dispatchers.IO) {
-        // Find the saved patched APK file
-        val savedFile = listOf(
+    private fun patchedApkFiles(installedApp: InstalledApp) =
+        listOf(
             filesystem.getPatchedAppFile(installedApp.currentPackageName, installedApp.version),
             filesystem.getPatchedAppFile(installedApp.originalPackageName, installedApp.version)
-        ).distinct().firstOrNull { it.exists() }
+        ).distinctBy { it.absolutePath }
 
-        if (savedFile != null) {
-            val deleted = runCatching { savedFile.delete() }.getOrElse { false }
-            if (deleted) {
+    private fun deletePatchedApkFiles(installedApp: InstalledApp) {
+        val existingFiles = patchedApkFiles(installedApp).filter { it.exists() }
+        if (existingFiles.isEmpty()) {
+            Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
+            return
+        }
+
+        existingFiles.forEach { savedFile ->
+            if (runCatching { savedFile.delete() }.getOrElse { false }) {
                 Log.d(TAG, "Deleted patched APK: ${savedFile.absolutePath}")
             } else {
                 Log.w(TAG, "Failed to delete patched APK: ${savedFile.absolutePath}")
             }
-        } else {
-            Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
         }
+    }
+
+    /**
+     * Delete only the saved patched APK. Keep the app record while the app is installed so it
+     * remains visible in Morphe; saved-only and uninstalled entries are removed to avoid ghosts.
+     */
+    suspend fun deletePatchedApk(installedApp: InstalledApp) = withContext(Dispatchers.IO) {
+        deletePatchedApkFiles(installedApp)
+        val isInstalled = pm.getPackageInfo(installedApp.currentPackageName) != null
+        if (installedApp.installType == InstallType.SAVED || !isInstalled) {
+            dao.delete(installedApp)
+        }
+    }
+
+    /**
+     * Delete installed app record and its saved patched APK file from storage.
+     */
+    suspend fun delete(installedApp: InstalledApp) = withContext(Dispatchers.IO) {
+        deletePatchedApkFiles(installedApp)
 
         dao.delete(installedApp)
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -283,14 +283,14 @@ private fun PatchedApksContent(
             onDeleteSelectedConfirm = { selectedItems ->
                 val appsToDelete = selectedItems.mapNotNull { appByKey[it.selectionKey] }
                 scope.launch {
-                    appsToDelete.forEach { repository.delete(it) }
+                    appsToDelete.forEach { repository.deletePatchedApk(it) }
                     context.toast(apksDeletedAllText)
                 }
             },
             onDeleteAllConfirm = {
                 val appsToDelete = apkItems.map { it.installedApp }
                 scope.launch {
-                    appsToDelete.forEach { repository.delete(it) }
+                    appsToDelete.forEach { repository.deletePatchedApk(it) }
                     context.toast(apksDeletedAllText)
                 }
             }
@@ -309,7 +309,7 @@ private fun PatchedApksContent(
             onDismiss = { itemToDelete.value = null },
             onConfirm = {
                 scope.launch {
-                    repository.delete(itemToDelete.value!!)
+                    repository.deletePatchedApk(itemToDelete.value!!)
                     context.toast(patchedApksDeletedText)
                     itemToDelete.value = null
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/FilesAndStorageSection.kt
@@ -41,6 +41,7 @@ fun FilesAndStorageSection(
     val isTV = remember { context.isAndroidTv() }
     val useExpertMode by settingsViewModel.prefs.useExpertMode.getAsState()
     val useCustomFilePicker by settingsViewModel.prefs.useCustomFilePicker.getAsState()
+    val deletePatchedApkAfterInstall by settingsViewModel.prefs.deletePatchedApkAfterInstall.getAsState()
     val enabledState = stringResource(R.string.enabled)
     val disabledState = stringResource(R.string.disabled)
 
@@ -71,6 +72,26 @@ fun FilesAndStorageSection(
                 title = stringResource(R.string.settings_system_storage_management_title),
                 subtitle = stringResource(R.string.settings_system_storage_management_description),
                 leadingContent = { MorpheIcon(icon = Icons.Outlined.Storage) }
+            )
+
+            MorpheSettingsDivider()
+
+            SettingsItem(
+                onClick = {
+                    settingsViewModel.setDeletePatchedApkAfterInstall(!deletePatchedApkAfterInstall)
+                },
+                title = stringResource(R.string.settings_system_delete_patched_apk_after_install),
+                subtitle = stringResource(R.string.settings_system_delete_patched_apk_after_install_description),
+                leadingContent = { MorpheIcon(icon = Icons.Outlined.DeleteSweep) },
+                trailingContent = {
+                    MorpheSwitch(
+                        checked = deletePatchedApkAfterInstall,
+                        onCheckedChange = null,
+                        modifier = Modifier.semantics {
+                            stateDescription = if (deletePatchedApkAfterInstall) enabledState else disabledState
+                        }
+                    )
+                }
             )
 
             // Patch Selections (Expert mode only)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/PatcherViewModel.kt
@@ -616,17 +616,24 @@ class PatcherViewModel(
             }
         }
 
-        // Save new version
+        // Explicit exports and root-mounted apps need a persistent patched APK. For regular
+        // installs, users can opt to keep only the original APK and patch configuration.
         val savedCopy = fs.getPatchedAppFile(finalPackageName, finalVersion)
-        try {
-            savedCopy.parentFile?.mkdirs()
-            outputFile.copyTo(savedCopy, overwrite = true)
-        } catch (error: IOException) {
-            if (installType == InstallType.SAVED) {
-                Log.e(TAG, "Failed to copy patched APK for later", error)
-                return@withContext false
-            } else {
-                Log.w(TAG, "Failed to update saved copy for $finalPackageName", error)
+        val retainPatchedApk = installType == InstallType.SAVED ||
+                installType == InstallType.MOUNT ||
+                !prefs.deletePatchedApkAfterInstall.get()
+
+        if (retainPatchedApk) {
+            try {
+                savedCopy.parentFile?.mkdirs()
+                outputFile.copyTo(savedCopy, overwrite = true)
+            } catch (error: IOException) {
+                if (installType == InstallType.SAVED) {
+                    Log.e(TAG, "Failed to copy patched APK for later", error)
+                    return@withContext false
+                } else {
+                    Log.w(TAG, "Failed to update saved copy for $finalPackageName", error)
+                }
             }
         }
 
@@ -661,7 +668,16 @@ class PatcherViewModel(
         appliedSelection = sanitizedSelection
         appliedOptions = sanitizedOptions
 
-        savedPatchedApp = savedPatchedApp || installType == InstallType.SAVED || savedCopy.exists()
+        // Delete only after all repatching metadata has been persisted successfully.
+        if (!retainPatchedApk && savedCopy.exists()) {
+            if (savedCopy.delete()) {
+                Log.d(TAG, "Deleted patched APK after successful install: ${savedCopy.name}")
+            } else {
+                Log.w(TAG, "Failed to delete patched APK after install: ${savedCopy.name}")
+            }
+        }
+
+        savedPatchedApp = savedCopy.exists()
         true
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -215,6 +215,10 @@ class SettingsViewModel(
         prefs.autoInstallWithShizuku.update(enabled)
     }
 
+    fun setDeletePatchedApkAfterInstall(enabled: Boolean) = viewModelScope.launch {
+        prefs.deletePatchedApkAfterInstall.update(enabled)
+    }
+
     fun setUseCustomFilePicker(enabled: Boolean) = viewModelScope.launch {
         prefs.useCustomFilePicker.update(enabled)
         prefs.customFilePickerUserConfigured.update(true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,6 +792,8 @@ The image dimensions must be as follows:
     <!-- Settings - System Tab - Storage Management screen -->
     <string name="settings_system_storage_management_title">Storage management</string>
     <string name="settings_system_storage_management_description">Review disk usage and clear cached files</string>
+    <string name="settings_system_delete_patched_apk_after_install">Delete patched APK after install</string>
+    <string name="settings_system_delete_patched_apk_after_install_description">Frees storage after successful installs. Original APKs and patch selections are kept for repatching</string>
     <string name="settings_system_storage_keystore_title">Signing keystore</string>
     <string name="settings_system_storage_app_data_title">App data</string>
     <string name="settings_system_storage_patch_bundles_title">Patch bundles</string>


### PR DESCRIPTION
## Summary

- add an opt-in **Delete patched APK after install** setting under Files & storage
- keep the original APK, patch selection, patch options, and installed-app metadata so the app can be repatched later
- keep installed apps visible in Morphe when their saved patched APK is deleted manually
- retain patched APKs for explicit saves and root-mounted installs, where the file is still required
- include the preference in Morphe settings import/export

## Why

Installed patched APKs do not need a second copy in Morphe when the original APK and patch configuration are already available. Skipping that copy can substantially reduce storage use for users with several patched apps.

Previously, deleting a patched APK through storage management also deleted its installed-app database record, making an app that was still installed disappear from Morphe's app list. Manual APK deletion now keeps that record whenever Android confirms the package is still installed.

Closes #722

## Validation

- `git diff --cached --check`
- parsed `app/src/main/res/values/strings.xml` as XML
- reviewed all successful install paths through the shared persistence callback
- verified home-list state is driven by the preserved `installed_app` record and live package-manager state
- full Gradle compile could not run locally because no Android SDK is installed; the pull-request build workflow will run `assembleDebug` with Java 17
