### PR TITLE
feat: Copy patch selection between bundles

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/CopySelectionLoader.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/CopySelectionLoader.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.manager
+
+import app.morphe.manager.domain.repository.PatchBundleRepository
+import app.morphe.manager.domain.repository.PatchSelectionRepository
+import app.morphe.manager.patcher.patch.PatchInfo
+import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
+import app.morphe.manager.util.AppDataResolver
+import kotlinx.coroutines.flow.first
+import java.util.Locale
+
+/**
+ * Assemble the candidate list for
+ * [app.morphe.manager.ui.screen.shared.CopySelectionFromBundleDialog], excluding the
+ * target itself and enriching each row with the intersection count against
+ * [targetPatchNames], same-source detection, and a resolved app display name.
+ *
+ * Sorted so the most useful match is first: same normalized endpoint, then same
+ * package, then largest intersection, then bundle name.
+ */
+suspend fun loadCopySelectionCandidates(
+    patchSelectionRepository: PatchSelectionRepository,
+    patchBundleRepository: PatchBundleRepository,
+    appDataResolver: AppDataResolver,
+    targetPackageName: String,
+    targetBundleUid: Int,
+    targetPatchNames: Set<String>
+): List<CopySelectionCandidate> {
+    val summary = patchSelectionRepository.getSelectionsSummaryFlow().first()
+    if (summary.isEmpty()) return emptyList()
+
+    val sources = patchBundleRepository.sources.first().associateBy { it.uid }
+    val targetEndpointKey = normalizedEndpointKey(patchBundleRepository, targetBundleUid)
+    val displayNameCache = mutableMapOf<String, String>()
+
+    val candidates = summary.flatMap { (packageName, bundleMap) ->
+        bundleMap.mapNotNull { (bundleUid, _) ->
+            if (bundleUid == targetBundleUid && packageName == targetPackageName) return@mapNotNull null
+
+            val source = sources[bundleUid] ?: return@mapNotNull null
+            val sourcePatches = patchSelectionRepository.exportForPackageAndBundle(packageName, bundleUid)
+            if (sourcePatches.isEmpty()) return@mapNotNull null
+
+            val applicable = sourcePatches.count { it in targetPatchNames }
+            val packageDisplayName = displayNameCache.getOrPut(packageName) {
+                appDataResolver.resolveAppData(packageName).displayName
+            }
+
+            CopySelectionCandidate(
+                bundleUid = bundleUid,
+                bundleName = source.displayTitle,
+                packageName = packageName,
+                packageDisplayName = packageDisplayName,
+                sourceCount = sourcePatches.size,
+                applicableCount = applicable,
+                isSameSource = targetEndpointKey != null &&
+                        normalizedEndpointKey(patchBundleRepository, bundleUid) == targetEndpointKey,
+                isSamePackage = packageName == targetPackageName
+            )
+        }
+    }
+
+    return candidates.sortedWith(
+        compareByDescending<CopySelectionCandidate> { it.isSameSource }
+            .thenByDescending { it.isSamePackage }
+            .thenByDescending { it.applicableCount }
+            .thenBy { it.bundleName.lowercase(Locale.getDefault()) }
+    )
+}
+
+/**
+ * Reduce a raw options export to the (patch, option) pairs that still exist in
+ * [targetPatches] - required before importing into a bundle whose schema may
+ * differ from the source's (renamed patches, dropped option keys).
+ */
+fun filterOptionsForTarget(
+    sourceOptions: Map<String, Map<String, String>>,
+    targetPatches: Map<String, PatchInfo>
+): Map<String, Map<String, String>> = sourceOptions.mapNotNull { (patchName, patchOptions) ->
+    val targetPatch = targetPatches[patchName] ?: return@mapNotNull null
+    val validKeys = targetPatch.options?.mapTo(mutableSetOf()) { it.key } ?: return@mapNotNull null
+    val kept = patchOptions.filterKeys { it in validKeys }
+    if (kept.isEmpty()) null else patchName to kept
+}.toMap()
+
+/**
+ * Normalised endpoint identity, used to detect the same remote source imported
+ * under multiple uids. Returns null for local bundles or when the URL cannot be parsed.
+ */
+private fun normalizedEndpointKey(
+    patchBundleRepository: PatchBundleRepository,
+    bundleUid: Int
+): String? {
+    val endpoint = patchBundleRepository.getEndpointForUid(bundleUid) ?: return null
+    return runCatching { patchBundleRepository.normalizeRemoteBundleUrl(endpoint) }
+        .getOrElse { endpoint.lowercase(Locale.US) }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -44,6 +44,7 @@ class ExpertPatchActions(
     val onDeselectAll: (bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) -> Unit,
     val onResetToDefault: (bundleUid: Int, allPatches: List<Pair<PatchInfo, Boolean>>) -> Unit,
     val onRestoreSaved: (bundleUid: Int) -> Unit,
+    val onCopyFromBundle: (bundleUid: Int) -> Unit,
     val onOptionChange: (bundleUid: Int, patchName: String, optionKey: String, value: Any?) -> Unit,
     val onResetOptions: (bundleUid: Int, patchName: String) -> Unit
 )
@@ -233,6 +234,7 @@ fun ExpertModeDialog(
                     onDeselectAll = { patchActions.onDeselectAll(bundle.uid, displayPatches) },
                     onResetToDefault = { patchActions.onResetToDefault(bundle.uid, allPatches) },
                     onRestoreSaved = { patchActions.onRestoreSaved(bundle.uid) },
+                    onCopyFromBundle = { patchActions.onCopyFromBundle(bundle.uid) },
                     hasSavedSelection = savedPatches[bundle.uid]?.isNotEmpty() == true
                 )
 
@@ -347,6 +349,7 @@ fun ExpertModeDialog(
                             onDeselectAll = { patchActions.onDeselectAll(currentBundle.uid, currentFiltered) },
                             onResetToDefault = { patchActions.onResetToDefault(currentBundle.uid, currentAllPatches) },
                             onRestoreSaved = { patchActions.onRestoreSaved(currentBundle.uid) },
+                            onCopyFromBundle = { patchActions.onCopyFromBundle(currentBundle.uid) },
                             hasSavedSelection = savedPatches[currentBundle.uid]?.isNotEmpty() == true,
                             modifier = Modifier.padding(vertical = MorpheDefaults.ContentPaddingSmall)
                         )

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -26,7 +26,7 @@ import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.toast
 
 /**
- * Bundle controls: three action buttons (Select All / Default / Deselect All).
+ * Bundle controls: pill row with per-bundle bulk actions.
  */
 @Composable
 internal fun BundlePatchControls(
@@ -36,6 +36,7 @@ internal fun BundlePatchControls(
     onDeselectAll: () -> Unit,
     onResetToDefault: () -> Unit,
     onRestoreSaved: () -> Unit,
+    onCopyFromBundle: () -> Unit,
     hasSavedSelection: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -50,6 +51,7 @@ internal fun BundlePatchControls(
     val selectAllLabel = stringResource(R.string.expert_mode_enable_all)
     val defaultLabel = stringResource(R.string.expert_mode_reset_to_default)
     val restoreLabel = stringResource(R.string.expert_mode_restore_saved)
+    val copyLabel = stringResource(R.string.expert_mode_copy_from_bundle)
     val deselectAllLabel = stringResource(R.string.expert_mode_disable_all)
 
     val enabledDone = stringResource(R.string.expert_mode_enable_all_done)
@@ -91,6 +93,18 @@ internal fun BundlePatchControls(
             enabled = hasSavedSelection,
             colors = IconButtonDefaults.filledTonalIconButtonColors(
                 containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.6f),
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+            )
+        )
+        ActionPillButton(
+            onClick = onCopyFromBundle,
+            icon = Icons.Outlined.ContentCopy,
+            contentDescription = copyLabel,
+            tooltip = copyLabel,
+            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f),
                 contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
                 disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -410,6 +410,9 @@ fun HomeDialogs(
                 onRestoreSaved = { bundleUid ->
                     homeViewModel.expertModeRestoreSaved(bundleUid)
                 },
+                onCopyFromBundle = { bundleUid ->
+                    homeViewModel.openExpertModeCopyDialog(bundleUid)
+                },
                 onOptionChange = { bundleUid, patchName, optionKey, value ->
                     homeViewModel.updateOptionInExpertMode(bundleUid, patchName, optionKey, value)
                 },
@@ -425,6 +428,24 @@ fun HomeDialogs(
                 homeViewModel.proceedExpertMode()
             }
         )
+
+        homeViewModel.expertModeCopyTargetBundleUid?.let { targetUid ->
+            val selectedApp = homeViewModel.expertModeSelectedApp ?: return@let
+            val targetBundle = homeViewModel.expertModeBundles.firstOrNull { it.uid == targetUid }
+                ?: return@let
+            val appDisplayName = targetBundle.displayName ?: selectedApp.packageName
+            CopySelectionFromBundleDialog(
+                target = CopySelectionTarget(
+                    packageName = selectedApp.packageName,
+                    bundleUid = targetUid,
+                    bundleName = targetBundle.name,
+                    appDisplayName = appDisplayName
+                ),
+                candidates = homeViewModel.expertModeCopyCandidates,
+                onConfirm = { homeViewModel.applyExpertModeCopy(it) },
+                onDismiss = { homeViewModel.closeExpertModeCopyDialog() }
+            )
+        }
     }
 
     // Bundle management sheet

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -74,6 +74,8 @@ fun PatchSelectionManagementDialog(
     val showResetSelectedConfirmation = remember { mutableStateOf(false) }
     val resetTarget = remember { mutableStateOf<ResetTarget?>(null) }
     val showPatchDetailsTarget = remember { mutableStateOf<PatchDetailsTarget?>(null) }
+    val copyTarget = remember { mutableStateOf<CopyTarget?>(null) }
+    val copyCandidates = remember { mutableStateOf<List<CopySelectionCandidate>?>(null) }
     var pendingImportUri by remember { mutableStateOf<Uri?>(null) }
 
     val selections by settingsViewModel.selectionsSummary.collectAsStateWithLifecycle()
@@ -118,11 +120,52 @@ fun PatchSelectionManagementDialog(
         onShowResetAllConfirmation = { showResetAllConfirmation.value = true },
         onSetResetTarget = { resetTarget.value = it },
         onShowPatchDetails = { showPatchDetailsTarget.value = it },
+        onOpenCopyFromBundle = { target ->
+            copyTarget.value = target
+            copyCandidates.value = null
+            scope.launch {
+                val loaded = settingsViewModel.loadCopySelectionCandidates(
+                    targetPackageName = target.packageName,
+                    targetBundleUid = target.bundleUid
+                )
+                // Discard the result if the picker was closed or retargeted while loading.
+                if (copyTarget.value == target) copyCandidates.value = loaded
+            }
+        },
         onImportUriPicked = { pendingImportUri = it },
         onExitSelection = exitSelection,
         onSelectAll = { selectedPackages.setAll(selections.keys) },
         onShowResetSelectedConfirmation = { showResetSelectedConfirmation.value = true }
     )
+
+    // Confirmed picks are written to the database immediately here, unlike the expert-mode
+    // path which stages changes until the user proceeds to patching.
+    copyTarget.value?.let { target ->
+        CopySelectionFromBundleDialog(
+            target = CopySelectionTarget(
+                packageName = target.packageName,
+                bundleUid = target.bundleUid,
+                bundleName = bundleNames[target.bundleUid]
+                    ?: stringResource(R.string.settings_system_patch_selection_source_format, target.bundleUid),
+                appDisplayName = target.appDisplayName
+            ),
+            candidates = copyCandidates.value,
+            onConfirm = { candidate ->
+                scope.launch {
+                    settingsViewModel.copySelectionFromBundle(
+                        target = target,
+                        candidate = candidate
+                    )
+                    copyTarget.value = null
+                    copyCandidates.value = null
+                }
+            },
+            onDismiss = {
+                copyTarget.value = null
+                copyCandidates.value = null
+            }
+        )
+    }
 
     if (showResetSelectedConfirmation.value) {
         val selectedKeys = selectedPackages.keys.toList()
@@ -246,6 +289,7 @@ private fun PatchSelectionManagementDialogContent(
     onShowResetAllConfirmation: () -> Unit,
     onSetResetTarget: (ResetTarget) -> Unit,
     onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    onOpenCopyFromBundle: (CopyTarget) -> Unit,
     onImportUriPicked: (Uri) -> Unit,
     onExitSelection: () -> Unit,
     onSelectAll: () -> Unit,
@@ -352,7 +396,9 @@ private fun PatchSelectionManagementDialogContent(
                 settingsViewModel = settingsViewModel,
                 importExportViewModel = importExportViewModel,
                 onSetResetTarget = onSetResetTarget,
-                onShowPatchDetails = onShowPatchDetails
+                onShowPatchDetails = onShowPatchDetails,
+                onOpenCopyFromBundle = onOpenCopyFromBundle,
+                onImport = openImportAllSelectionsPicker
             )
         }
     }
@@ -368,7 +414,9 @@ private fun SelectionList(
     settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel,
     onSetResetTarget: (ResetTarget) -> Unit,
-    onShowPatchDetails: (PatchDetailsTarget) -> Unit
+    onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    onOpenCopyFromBundle: (CopyTarget) -> Unit,
+    onImport: () -> Unit
 ) {
     val selections = data.selections
     val listState = rememberLazyListState()
@@ -420,6 +468,8 @@ private fun SelectionList(
                         onSetResetTarget(ResetTarget.PackageBundle(packageName, bundleUid))
                     },
                     onShowPatchDetails = onShowPatchDetails,
+                    onOpenCopyFromBundle = onOpenCopyFromBundle,
+                    onImport = onImport,
                     isSelected = multiSelect.selectedPackages.contains(packageName),
                     isSelectionMode = multiSelect.isSelectionMode,
                     onEnterSelection = { multiSelect.onEnterSelection(packageName) },
@@ -453,6 +503,8 @@ private fun PackageSelectionItem(
     onResetPackage: () -> Unit,
     onResetPackageBundle: (Int) -> Unit,
     onShowPatchDetails: (PatchDetailsTarget) -> Unit,
+    onOpenCopyFromBundle: (CopyTarget) -> Unit,
+    onImport: () -> Unit,
     isSelected: Boolean,
     isSelectionMode: Boolean,
     onEnterSelection: () -> Unit,
@@ -593,7 +645,11 @@ private fun PackageSelectionItem(
                                 onReset = { onResetPackageBundle(bundleUid) },
                                 onShowDetails = {
                                     onShowPatchDetails(PatchDetailsTarget(packageName, bundleUid, displayName))
-                                }
+                                },
+                                onCopyFromBundle = {
+                                    onOpenCopyFromBundle(CopyTarget(packageName, bundleUid, displayName))
+                                },
+                                onImport = onImport
                             )
                         }
 
@@ -628,7 +684,9 @@ private fun BundleSelectionItem(
     patchCount: Int,
     importExportViewModel: ImportExportViewModel,
     onReset: () -> Unit,
-    onShowDetails: () -> Unit
+    onShowDetails: () -> Unit,
+    onCopyFromBundle: () -> Unit,
+    onImport: () -> Unit
 ) {
 
     // Display bundle name or fallback to "Bundle #N"
@@ -700,26 +758,48 @@ private fun BundleSelectionItem(
             }
         }
 
-        CardActionRow(
-            actions = listOf(
-                CardAction(
-                    icon = Icons.Outlined.Upload,
-                    label = stringResource(R.string.export),
-                    onClick = {
-                        val fileName = importExportViewModel.getPackageBundleDataExportFileName(
-                            packageName, bundleUid, bundleName
-                        )
-                        exportLauncher.launch(fileName)
-                    }
-                ),
-                CardAction(
-                    icon = Icons.Outlined.Restore,
-                    label = stringResource(R.string.reset),
-                    onClick = onReset,
-                    destructive = true
+        ActionPillRow {
+            val copyLabel = stringResource(R.string.copy)
+            ActionPillButton(
+                onClick = onCopyFromBundle,
+                icon = Icons.Outlined.ContentCopy,
+                contentDescription = copyLabel,
+                tooltip = copyLabel
+            )
+
+            val importLabel = stringResource(R.string.import_)
+            ActionPillButton(
+                onClick = onImport,
+                icon = Icons.Outlined.Download,
+                contentDescription = importLabel,
+                tooltip = importLabel
+            )
+
+            val exportLabel = stringResource(R.string.export)
+            ActionPillButton(
+                onClick = {
+                    val fileName = importExportViewModel.getPackageBundleDataExportFileName(
+                        packageName, bundleUid, bundleName
+                    )
+                    exportLauncher.launch(fileName)
+                },
+                icon = Icons.Outlined.Upload,
+                contentDescription = exportLabel,
+                tooltip = exportLabel
+            )
+
+            val resetLabel = stringResource(R.string.reset)
+            ActionPillButton(
+                onClick = onReset,
+                icon = Icons.Outlined.Restore,
+                contentDescription = resetLabel,
+                tooltip = resetLabel,
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer
                 )
             )
-        )
+        }
     }
 }
 
@@ -1016,6 +1096,13 @@ private sealed interface ResetTarget {
 }
 
 private data class PatchDetailsTarget(
+    val packageName: String,
+    val bundleUid: Int,
+    val appDisplayName: String
+)
+
+/** Destination (package + bundle) for a copy-from-another-bundle operation. */
+data class CopyTarget(
     val packageName: String,
     val bundleUid: Int,
     val appDisplayName: String

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/CopySelectionFromBundleDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/CopySelectionFromBundleDialog.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+
+/**
+ * Package + bundle the user is copying INTO.
+ * Also used to filter the target itself out of the candidate list.
+ */
+@Immutable
+data class CopySelectionTarget(
+    val packageName: String,
+    val bundleUid: Int,
+    val bundleName: String,
+    val appDisplayName: String
+)
+
+/**
+ * A (bundle + package) pair the user can copy from.
+ * [applicableCount] is the count of source patches that survive intersection
+ * with the target bundle's patch names.
+ */
+@Immutable
+data class CopySelectionCandidate(
+    val bundleUid: Int,
+    val bundleName: String,
+    val packageName: String,
+    val packageDisplayName: String,
+    val sourceCount: Int,
+    val applicableCount: Int,
+    val isSameSource: Boolean,
+    val isSamePackage: Boolean
+)
+
+/**
+ * Picker for the "copy selection from another bundle" flow. Renders a radio list
+ * of candidates and previews the intersection count so the user can see how many
+ * patches will actually apply.
+ *
+ * Pass `candidates = null` while the list is loading to render a branded loader.
+ */
+@Composable
+fun CopySelectionFromBundleDialog(
+    target: CopySelectionTarget,
+    candidates: List<CopySelectionCandidate>?,
+    onConfirm: (CopySelectionCandidate) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selectedIndex by remember { mutableIntStateOf(-1) }
+    val visibleCandidates = candidates.orEmpty()
+
+    val selectedCandidate = visibleCandidates.getOrNull(selectedIndex)
+    val canConfirm = selectedCandidate != null && selectedCandidate.applicableCount > 0
+    val confirmLabel = if (selectedCandidate != null && selectedCandidate.applicableCount > 0) {
+        stringResource(R.string.copy_selection_confirm_with_count, selectedCandidate.applicableCount)
+    } else {
+        stringResource(R.string.copy)
+    }
+
+    MorpheDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.copy_selection_title),
+        footer = {
+            MorpheDialogButtonRow(
+                primaryText = confirmLabel,
+                onPrimaryClick = { selectedCandidate?.let(onConfirm) },
+                primaryEnabled = canConfirm,
+                primaryIcon = Icons.Outlined.ContentCopy,
+                secondaryText = stringResource(android.R.string.cancel),
+                onSecondaryClick = onDismiss
+            )
+        },
+        padding = DialogPadding.Compact,
+        scrollable = false,
+        contentArrangement = Arrangement.Top
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPaddingSmall)
+        ) {
+            HeroInfoCard(
+                icon = Icons.Outlined.Extension,
+                title = target.appDisplayName,
+                subtitle = {
+                    Text(
+                        text = target.bundleName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = LocalDialogSecondaryTextColor.current,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            )
+
+            when {
+                candidates == null -> Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    PulsingLogoWithCaption(caption = stringResource(R.string.loading))
+                }
+                visibleCandidates.isEmpty() -> EmptyState(
+                    message = stringResource(R.string.copy_selection_empty),
+                    icon = Icons.Outlined.FolderOff
+                )
+                else -> CandidateList(
+                    candidates = visibleCandidates,
+                    selectedIndex = selectedIndex,
+                    onSelect = { selectedIndex = it }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.CandidateList(
+    candidates: List<CopySelectionCandidate>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit
+) {
+    val listState = rememberLazyListState()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f, fill = false)
+    ) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPaddingSmall)
+        ) {
+            items(
+                items = candidates.withIndex().toList(),
+                key = { (_, c) -> "${c.bundleUid}:${c.packageName}" }
+            ) { (index, candidate) ->
+                CandidateRow(
+                    candidate = candidate,
+                    selected = index == selectedIndex,
+                    onSelect = { onSelect(index) }
+                )
+            }
+        }
+        ScrollToTopButton(listState = listState)
+    }
+}
+
+@Composable
+private fun CandidateRow(
+    candidate: CopySelectionCandidate,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    val enabled = candidate.applicableCount > 0
+    val availableText = stringResource(
+        R.string.copy_selection_available_format,
+        candidate.applicableCount,
+        candidate.sourceCount
+    )
+
+    RadioSelectionCard(
+        selected = selected,
+        onSelect = onSelect,
+        enabled = enabled,
+        contentDescription = "${candidate.packageDisplayName}, ${candidate.bundleName}, $availableText"
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(MorpheDefaults.ContentPaddingSmall)
+            ) {
+                Text(
+                    text = candidate.bundleName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (candidate.isSameSource) {
+                    InfoBadge(
+                        text = stringResource(R.string.copy_selection_same_source),
+                        style = InfoBadgeStyle.Primary,
+                        isCompact = true
+                    )
+                }
+            }
+            Text(
+                text = candidate.packageDisplayName,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            InfoBadge(
+                text = availableText,
+                style = if (enabled) InfoBadgeStyle.Primary else InfoBadgeStyle.Default,
+                icon = Icons.Outlined.CheckCircle,
+                isCompact = true
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -43,8 +43,11 @@ import app.morphe.manager.patcher.patch.PatchBundleInfo.Extensions.toPatchSelect
 import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.patcher.split.SplitApkInspector
 import app.morphe.manager.patcher.split.SplitApkPreparer
+import app.morphe.manager.domain.manager.filterOptionsForTarget
+import app.morphe.manager.domain.manager.loadCopySelectionCandidates
 import app.morphe.manager.ui.model.HomeAppItem
 import app.morphe.manager.ui.model.SelectedApp
+import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
 import app.morphe.manager.util.*
 import app.morphe.manager.util.PatchSelectionUtils.filterGmsCore
 import app.morphe.manager.util.PatchSelectionUtils.resetOptionsForPatch
@@ -303,6 +306,13 @@ class HomeViewModel(
     var expertModeOptions by mutableStateOf<Options>(emptyMap())
     // Patches that are new in the current bundle version relative to the last saved selection
     var expertModeNewPatches by mutableStateOf<Map<Int, Set<String>>>(emptyMap())
+
+    /** Target bundle uid for the in-flight copy-from-another-bundle picker; null while the picker is closed. */
+    var expertModeCopyTargetBundleUid by mutableStateOf<Int?>(null)
+        private set
+    /** Loaded candidates for the picker; null while the initial load is in progress. */
+    var expertModeCopyCandidates by mutableStateOf<List<CopySelectionCandidate>?>(null)
+        private set
 
     // Bundle file selection
     var selectedBundleUri by mutableStateOf<Uri?>(null)
@@ -2830,7 +2840,112 @@ class HomeViewModel(
         expertModeInitialPatches = emptyMap()
         expertModeOptions = emptyMap()
         expertModeNewPatches = emptyMap()
+        closeExpertModeCopyDialog()
     }
+
+    /**
+     * Open the copy-from-another-bundle picker for [targetBundleUid] inside the current
+     * expert-mode session. Candidates are loaded off the main thread and published to
+     * [expertModeCopyCandidates] once ready.
+     */
+    fun openExpertModeCopyDialog(targetBundleUid: Int) {
+        val selectedApp = expertModeSelectedApp ?: return
+        expertModeCopyTargetBundleUid = targetBundleUid
+        expertModeCopyCandidates = null
+        viewModelScope.launch(Dispatchers.IO) {
+            val candidates = loadCopySelectionCandidates(
+                patchSelectionRepository = patchSelectionRepository,
+                patchBundleRepository = patchBundleRepository,
+                appDataResolver = appDataResolver,
+                targetPackageName = selectedApp.packageName,
+                targetBundleUid = targetBundleUid,
+                targetPatchNames = targetBundlePatchNames(targetBundleUid)
+            )
+            withContext(Dispatchers.Main) {
+                // Discard the result if the user closed or retargeted the dialog while loading.
+                if (expertModeCopyTargetBundleUid == targetBundleUid) {
+                    expertModeCopyCandidates = candidates
+                }
+            }
+        }
+    }
+
+    fun closeExpertModeCopyDialog() {
+        expertModeCopyTargetBundleUid = null
+        expertModeCopyCandidates = null
+    }
+
+    /**
+     * Apply a picked [candidate] to the in-memory expert-mode selection.
+     * Patches and options are filtered against the target bundle's schema so the
+     * copy silently drops entries that no longer exist under the new bundle uid.
+     * Changes are persisted to the database only when the user proceeds to patching.
+     */
+    fun applyExpertModeCopy(candidate: CopySelectionCandidate) {
+        expertModeSelectedApp ?: return
+        val targetBundleUid = expertModeCopyTargetBundleUid ?: return
+
+        viewModelScope.launch {
+            val (patches, options) = withContext(Dispatchers.IO) {
+                val targetPatches = targetBundlePatchInfos(targetBundleUid)
+                val sourcePatchNames = patchSelectionRepository.exportForPackageAndBundle(
+                    candidate.packageName,
+                    candidate.bundleUid
+                )
+                val filteredPatches = sourcePatchNames
+                    .filter { it in targetPatches }
+                    .toSet()
+
+                val sourceOptions = optionsRepository.exportOptionsForBundle(
+                    packageName = candidate.packageName,
+                    bundleUid = candidate.bundleUid
+                )
+                val filteredOptions = filterOptionsForTarget(sourceOptions, targetPatches)
+                filteredPatches to filteredOptions
+            }
+
+            if (patches.isEmpty() && options.isEmpty()) {
+                app.toast(app.getString(R.string.expert_mode_copy_from_bundle_no_patches))
+                closeExpertModeCopyDialog()
+                return@launch
+            }
+
+            val updatedSelection = expertModePatches.toMutableMap()
+            if (patches.isEmpty()) updatedSelection.remove(targetBundleUid)
+            else updatedSelection[targetBundleUid] = patches
+            expertModePatches = updatedSelection
+
+            val currentOptions = expertModeOptions.toMutableMap()
+            val bundleOptions = currentOptions[targetBundleUid]?.toMutableMap() ?: mutableMapOf()
+            options.forEach { (patchName, patchOptions) ->
+                bundleOptions[patchName] = patchOptions
+            }
+            if (bundleOptions.isEmpty()) currentOptions.remove(targetBundleUid)
+            else currentOptions[targetBundleUid] = bundleOptions
+            expertModeOptions = currentOptions
+
+            app.toast(
+                app.resources.getQuantityString(
+                    R.plurals.expert_mode_copy_from_bundle_done,
+                    patches.size,
+                    patches.size
+                )
+            )
+            closeExpertModeCopyDialog()
+        }
+    }
+
+    private fun targetBundlePatchNames(bundleUid: Int): Set<String> =
+        expertModeBundles.firstOrNull { it.uid == bundleUid }
+            ?.patches
+            ?.mapTo(mutableSetOf()) { it.name }
+            ?: emptySet()
+
+    private fun targetBundlePatchInfos(bundleUid: Int): Map<String, PatchInfo> =
+        expertModeBundles.firstOrNull { it.uid == bundleUid }
+            ?.patches
+            ?.associateBy { it.name }
+            ?: emptyMap()
 
     private suspend fun saveSeenPatchesForBundles(packageName: String) {
         expertModeBundles.forEach { bundle ->

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/SettingsViewModel.kt
@@ -14,10 +14,15 @@ import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.SessionInstaller
 import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.domain.manager.filterOptionsForTarget
+import app.morphe.manager.domain.manager.loadCopySelectionCandidates as loadCopySelectionCandidatesShared
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository.Companion.DEFAULT_SOURCE_UID
 import app.morphe.manager.domain.repository.PatchOptionsRepository
 import app.morphe.manager.domain.repository.PatchSelectionRepository
+import app.morphe.manager.patcher.patch.PatchInfo
+import app.morphe.manager.ui.screen.settings.system.CopyTarget
+import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
 import app.morphe.manager.util.AppDataResolver
 import app.morphe.manager.util.AppDataSource
 import app.morphe.manager.util.syncFcmTopics
@@ -38,7 +43,7 @@ class SettingsViewModel(
     private val rootInstaller: RootInstaller,
     private val selectionRepository: PatchSelectionRepository,
     private val optionsRepository: PatchOptionsRepository,
-    patchBundleRepository: PatchBundleRepository,
+    private val patchBundleRepository: PatchBundleRepository,
     private val appDataResolver: AppDataResolver,
     private val appContext: Context,
 ) : ViewModel() {
@@ -336,6 +341,68 @@ class SettingsViewModel(
             }
             PatchDetails(patchList, optionsMap)
         }
+
+    /** Assemble picker candidates intersected against the target bundle's patch list. */
+    suspend fun loadCopySelectionCandidates(
+        targetPackageName: String,
+        targetBundleUid: Int
+    ): List<CopySelectionCandidate> = withContext(Dispatchers.IO) {
+        val targetPatchNames = targetBundlePatchNames(targetBundleUid)
+        loadCopySelectionCandidatesShared(
+            patchSelectionRepository = selectionRepository,
+            patchBundleRepository = patchBundleRepository,
+            appDataResolver = appDataResolver,
+            targetPackageName = targetPackageName,
+            targetBundleUid = targetBundleUid,
+            targetPatchNames = targetPatchNames
+        )
+    }
+
+    /**
+     * Replace the target's saved selection (and matching options) with a filtered copy of
+     * [candidate]'s data. Entries the target bundle no longer defines are silently dropped.
+     */
+    fun copySelectionFromBundle(
+        target: CopyTarget,
+        candidate: CopySelectionCandidate
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        val targetPatches = targetBundlePatchInfos(target.bundleUid)
+        val sourcePatchNames = selectionRepository.exportForPackageAndBundle(
+            candidate.packageName,
+            candidate.bundleUid
+        )
+        val filteredPatches = sourcePatchNames.filter { it in targetPatches }
+        if (filteredPatches.isEmpty()) return@launch
+
+        selectionRepository.importForPackageAndBundle(
+            packageName = target.packageName,
+            bundleUid = target.bundleUid,
+            patches = filteredPatches
+        )
+
+        val sourceOptions = optionsRepository.exportOptionsForBundle(
+            packageName = candidate.packageName,
+            bundleUid = candidate.bundleUid
+        )
+        val filteredOptions = filterOptionsForTarget(sourceOptions, targetPatches)
+        if (filteredOptions.isNotEmpty()) {
+            optionsRepository.importOptionsForBundle(
+                packageName = target.packageName,
+                bundleUid = target.bundleUid,
+                options = filteredOptions
+            )
+        }
+    }
+
+    private suspend fun targetBundlePatchNames(bundleUid: Int): Set<String> {
+        val info = patchBundleRepository.allBundlesInfoFlow.first()[bundleUid] ?: return emptySet()
+        return info.patches.mapTo(mutableSetOf()) { it.name }
+    }
+
+    private suspend fun targetBundlePatchInfos(bundleUid: Int): Map<String, PatchInfo> {
+        val info = patchBundleRepository.allBundlesInfoFlow.first()[bundleUid] ?: return emptyMap()
+        return info.patches.associateBy { it.name }
+    }
 
     companion object {
         fun parseJsonValue(jsonString: String): Any? = try {

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -64,4 +64,8 @@
         <item quantity="one">%s app</item>
         <item quantity="other">%s apps</item>
     </plurals>
+    <plurals name="expert_mode_copy_from_bundle_done">
+        <item quantity="one">Copied %s patch from selected bundle</item>
+        <item quantity="other">Copied %s patches from selected bundle</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,8 @@
     <string name="expert_mode_reset_to_default_done">Recommended patches applied</string>
     <string name="expert_mode_restore_saved">Restore saved selection</string>
     <string name="expert_mode_restore_saved_done">Saved selection restored</string>
+    <string name="expert_mode_copy_from_bundle">Copy selection from another bundle</string>
+    <string name="expert_mode_copy_from_bundle_no_patches">No matching patches in this bundle</string>
     <string name="expert_mode_no_results">No patches found</string>
     <string name="expert_mode_universal_patches">Universal patches</string>
     <string name="expert_mode_new_patches">New</string>
@@ -931,6 +933,13 @@ Details: %2$s"</string>
     <string name="settings_system_patch_options_section">Patch options</string>
     <string name="settings_system_no_patches_or_options">No patches or options saved</string>
 
+    <!-- Copy selection from another bundle -->
+    <string name="copy_selection_title">Copy selection from…</string>
+    <string name="copy_selection_confirm_with_count">Copy %s</string>
+    <string name="copy_selection_empty">No other saved selections to copy from</string>
+    <string name="copy_selection_available_format">%1$s of %2$s available</string>
+    <string name="copy_selection_same_source">Same source</string>
+
     <!-- Settings - System Tab - Custom file picker -->
     <string name="settings_system_custom_file_picker">Custom file picker</string>
     <string name="settings_system_custom_file_picker_description">Browse storage with Morphe\'s built-in file picker instead of the system default</string>
@@ -1021,6 +1030,7 @@ Details: %2$s"</string>
     <string name="rename">Rename</string>
     <string name="import_">Import</string>
     <string name="export">Export</string>
+    <string name="copy">Copy</string>
     <string name="download">Download</string>
     <string name="less">Less</string>
     <string name="expand">Expand</string>


### PR DESCRIPTION
Adds a Copy action that lets reuse a saved patch selection from another bundle in one tap.

Available both in the `Expert Mode` dialog and in `Settings` → `System` → `Patch selections`. The picker previews how many of the source's patches actually apply to the target bundle so user know upfront whether the copy is worthwhile.
___
![Screenshot_2026-07-24-16-39-27-212_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/60a4cd19-5fc9-44c3-8b8f-3b45a800deba)

