### PR TITLE
fix: Save the process runtime memory limit when the slider is tapped

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
@@ -44,6 +44,13 @@ fun ProcessRuntimeDialog(
     var sliderValue by remember { mutableFloatStateOf(currentLimit.toFloat()) }
     val selectedLimit = sliderValue.roundToInt()
 
+    // Persist every settled step change instead of relying on `onValueChangeFinished`,
+    // which the slider only delivers for drag gestures — tapping a position on the
+    // track moved the thumb but never saved
+    LaunchedEffect(selectedLimit) {
+        if (selectedLimit != currentLimit) onLimitChange(selectedLimit)
+    }
+
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.settings_system_process_runtime),
@@ -100,7 +107,6 @@ fun ProcessRuntimeDialog(
                     Slider(
                         value = sliderValue,
                         onValueChange = { sliderValue = it },
-                        onValueChangeFinished = { onLimitChange(selectedLimit) },
                         valueRange = PROCESS_RUNTIME_MEMORY_MINIMUM.toFloat()..maxLimit.toFloat(),
                         steps = (((maxLimit.toDouble() - PROCESS_RUNTIME_MEMORY_MINIMUM)
                                 / PROCESS_RUNTIME_MEMORY_STEP - 1)).toInt(),
@@ -135,7 +141,7 @@ fun ProcessRuntimeDialog(
 
                 // Warning for low values — top padding inside so shrink includes spacing
                 AnimatedVisibility(
-                    visible = enabled && sliderValue < PROCESS_RUNTIME_MEMORY_LOW_WARNING,
+                    visible = enabled && selectedLimit < PROCESS_RUNTIME_MEMORY_LOW_WARNING,
                     enter = MorpheAnimations.expandFadeEnter,
                     exit = MorpheAnimations.shrinkFadeExit
                 ) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
@@ -44,13 +44,6 @@ fun ProcessRuntimeDialog(
     var sliderValue by remember { mutableFloatStateOf(currentLimit.toFloat()) }
     val selectedLimit = sliderValue.roundToInt()
 
-    // Persist every settled step change instead of relying on `onValueChangeFinished`,
-    // which the slider only delivers for drag gestures — tapping a position on the
-    // track moved the thumb but never saved
-    LaunchedEffect(selectedLimit) {
-        if (selectedLimit != currentLimit) onLimitChange(selectedLimit)
-    }
-
     MorpheDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.settings_system_process_runtime),
@@ -106,7 +99,12 @@ fun ProcessRuntimeDialog(
                 ) {
                     Slider(
                         value = sliderValue,
-                        onValueChange = { sliderValue = it },
+                        // Saved here rather than from `onValueChangeFinished`, which a track tap
+                        // fires in the same pointer event and would persist the pre-tap value
+                        onValueChange = {
+                            sliderValue = it
+                            onLimitChange(it.roundToInt())
+                        },
                         valueRange = PROCESS_RUNTIME_MEMORY_MINIMUM.toFloat()..maxLimit.toFloat(),
                         steps = (((maxLimit.toDouble() - PROCESS_RUNTIME_MEMORY_MINIMUM)
                                 / PROCESS_RUNTIME_MEMORY_STEP - 1)).toInt(),
@@ -139,7 +137,7 @@ fun ProcessRuntimeDialog(
                     isExpanded = true
                 )
 
-                // Warning for low values — top padding inside so shrink includes spacing
+                // Warning for low values
                 AnimatedVisibility(
                     visible = enabled && selectedLimit < PROCESS_RUNTIME_MEMORY_LOW_WARNING,
                     enter = MorpheAnimations.expandFadeEnter,


### PR DESCRIPTION
The memory limit was only persisted from the slider's `onValueChangeFinished`, which Material3 delivers for drag gestures but not for a tap on the track — tapping moved the thumb and updated the readout, then discarded the value on close.

Persist from the settled step instead, so taps, drags, keyboard arrows and TalkBack's setProgress all save alike. Keying the effect on the rounded Int means a write only happens when the thumb crosses to a new 128 MB step, not on every frame of a drag.

Also compare the low-memory warning against the rounded step. Scaling the thumb position back to a user value lands a hair low, so selecting exactly 640 MB evaluated as 639.9999 < 640 and wrongly showed the "memory limit too low" badge.