### PR TITLE
fix: Validate saved APKs and tracked installs

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Cache Gradle
         uses: burrunan/gradle-cache-action@v3
 
+      - name: Run unit tests
+        env:
+          _JAVA_OPTIONS: "-Djava.awt.headless=true"
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :app:testDebugUnitTest --stacktrace
+
       - name: Build APK
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,7 +121,8 @@ dependencies {
     // Semantic versioning parser
     implementation(libs.semver.parser)
 
-    testImplementation(kotlin("test-junit"))
+    // Unit tests
+    testImplementation(libs.kotlin.test.junit)
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,8 @@ dependencies {
 
     // Semantic versioning parser
     implementation(libs.semver.parser)
+
+    testImplementation(kotlin("test-junit"))
 }
 
 android {

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -103,6 +103,22 @@ internal fun resolveTrackedPatchState(
 }
 
 /**
+ * Whether the tracked record can still be removed from the app detail view.
+ *
+ * The record outlives the build it describes, so cleanup has to stay reachable whenever the
+ * patched build is no longer accounted for. Only a confirmed patched install with nothing
+ * retained has nothing to clean up, since the record then describes the app on the device.
+ */
+internal fun canRemoveTrackedRecord(
+    installType: InstallType,
+    patchState: InstalledPatchState?,
+    hasSavedApk: Boolean
+): Boolean =
+    hasSavedApk ||
+            installType == InstallType.SAVED ||
+            patchState != InstalledPatchState.Patched
+
+/**
  * The APKs already on the device that an app could be patched from: the original Morphe kept
  * from a previous run, and the app as the system has it installed.
  */

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -13,13 +13,19 @@ import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.repository.InstalledAppRepository
 import app.morphe.manager.domain.repository.OriginalApkRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository
+import app.morphe.manager.util.AOSP_INSTALLER_PACKAGE
+import app.morphe.manager.util.AOSP_INSTALLER_PACKAGE_LEGACY
 import app.morphe.manager.util.AppDataResolver
 import app.morphe.manager.util.AppDataSource
+import app.morphe.manager.util.PLAY_STORE_INSTALLER_PACKAGE
 import app.morphe.manager.util.PM
 import app.morphe.manager.util.tag
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+
+// The record is written once the install finished, so only clock skew separates the two stamps
+private const val INSTALL_TIME_TOLERANCE_MS = 60_000L
 
 /** Saved APK information for display in APK selection dialog. */
 data class SavedApkInfo(
@@ -47,17 +53,31 @@ enum class InstalledPatchState {
     Unknown
 }
 
+/**
+ * Everything a UI action needs to know about a tracked app, resolved in one pass.
+ *
+ * [patchState] is null exactly when nothing is installed under the tracked package name, and
+ * [savedPatchedApkInfo] is the archive parse behind [savedPatchedApk] so callers can read the
+ * label or version without opening the file again.
+ */
 data class TrackedAppSnapshot(
     val installedPackageInfo: PackageInfo?,
     val savedPatchedApk: File?,
+    val savedPatchedApkInfo: PackageInfo?,
     val patchState: InstalledPatchState?
 )
 
+/**
+ * Weighs the evidence that the installed package still is the build Morphe patched.
+ * Kept free of Android APIs so the ordering between the signals can be tested directly.
+ */
 internal fun resolveTrackedPatchState(
     installedHashes: Set<String>,
     savedPatchedHashes: Set<String>,
     originalHashes: Set<String>,
-    installedByPatchManager: Boolean
+    installedByPatchManager: Boolean,
+    installerAttributionMatches: Boolean,
+    installedAfterPatching: Boolean
 ): InstalledPatchState {
     // A mismatch only proves that the installed package is not the reference artifact; it does
     // not identify what replaced it. Only positive matches and trusted installer evidence can
@@ -71,6 +91,14 @@ internal fun resolveTrackedPatchState(
     }
 
     if (installedByPatchManager) return InstalledPatchState.Patched
+
+    // The record knows which installer Morphe would have attributed its own install to. A
+    // different installer on a package that only appeared after the patch is somebody else's
+    // installation, which is the one case certificates cannot describe when nothing was retained.
+    if (!installerAttributionMatches && installedAfterPatching) {
+        return InstalledPatchState.NotPatched
+    }
+
     return InstalledPatchState.Unknown
 }
 
@@ -163,15 +191,19 @@ class LocalApkSources(
     suspend fun trackedPatchState(app: InstalledApp): InstalledPatchState? =
         trackedAppSnapshot(app).patchState
 
-    /** Resolves the saved APK and installed identity together for UI action gating. */
+    /**
+     * Resolves the saved APK and installed identity together for UI action gating.
+     *
+     * Certificate reads go through [PM]'s archive cache, so repeated calls for an unchanged app
+     * cost a package manager query rather than a full archive verification.
+     */
     suspend fun trackedAppSnapshot(app: InstalledApp): TrackedAppSnapshot = withContext(Dispatchers.IO) {
-        val savedPatchedApk = validatedPatchedApk(app)
-        if (app.installType == InstallType.SAVED) {
-            return@withContext TrackedAppSnapshot(null, savedPatchedApk, null)
-        }
+        val savedPatched = validatedPatchedApk(app)
+        val savedPatchedApk: File? = savedPatched?.first
+        val savedPatchedInfo: PackageInfo? = savedPatched?.second
 
         val installedPackageInfo = pm.getPackageInfo(app.currentPackageName)
-            ?: return@withContext TrackedAppSnapshot(null, savedPatchedApk, null)
+            ?: return@withContext TrackedAppSnapshot(null, savedPatchedApk, savedPatchedInfo, null)
 
         // A mounted install keeps the stock certificate in PackageManager while sourceDir points
         // at the patched APK, so this signal must win over all certificate comparisons below.
@@ -179,47 +211,87 @@ class LocalApkSources(
             return@withContext TrackedAppSnapshot(
                 installedPackageInfo,
                 savedPatchedApk,
+                savedPatchedInfo,
                 InstalledPatchState.Patched
             )
         }
 
-        val installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName)
-        val savedPatchedHashes = savedPatchedApk?.let(pm::getApkFileSignatureHashes).orEmpty()
+        val installer = pm.getInstallerPackageName(app.currentPackageName)
 
-        val savedOriginalHashes = originalApkRepository.get(app.originalPackageName)
-            ?.let { File(it.filePath) }
-            ?.takeIf { it.exists() }
-            ?.let(pm::getApkFileSignatureHashes)
-            .orEmpty()
-        val originalHashes = savedOriginalHashes.ifEmpty {
-            patchBundleRepository.appMetadata.value[app.originalPackageName]?.signatures.orEmpty()
-        }
-
-        // Play Store-attributed and custom install modes make installer identity inconclusive.
-        // An unverified same-name package must not enable actions that could uninstall stock.
         TrackedAppSnapshot(
             installedPackageInfo = installedPackageInfo,
             savedPatchedApk = savedPatchedApk,
+            savedPatchedApkInfo = savedPatchedInfo,
             patchState = resolveTrackedPatchState(
-                installedHashes = installedHashes,
-                savedPatchedHashes = savedPatchedHashes,
-                originalHashes = originalHashes,
-                installedByPatchManager = pm.isInstalledByPatchManager(app.currentPackageName)
+                installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName),
+                savedPatchedHashes = savedPatchedInfo?.let(pm::signatureHashes).orEmpty(),
+                originalHashes = referenceSignatureHashes(app.originalPackageName),
+                installedByPatchManager = pm.isPatchManagerInstaller(installer),
+                installerAttributionMatches = installerMatchesRecord(app.installType, installer),
+                installedAfterPatching = installedAfterPatching(app, installedPackageInfo)
             )
         )
+    }
+
+    /**
+     * Whether the current installer is the one Morphe itself would have set for this record.
+     *
+     * Play Store-attributed and custom install modes make installer identity inconclusive, so
+     * only the modes that leave a predictable attribution can rule an installation out.
+     */
+    private fun installerMatchesRecord(installType: InstallType, installer: String?): Boolean =
+        when (installType) {
+            InstallType.PLAY_STORE,
+            InstallType.ROOT_PLAY_STORE,
+            InstallType.SHIZUKU_PLAY_STORE -> installer == PLAY_STORE_INSTALLER_PACKAGE
+
+            // A mounted stock app and a user-picked installer can carry any attribution
+            InstallType.MOUNT, InstallType.CUSTOM -> true
+
+            // Handing the APK to the system installer can leave either Morphe or the installer
+            // itself as the attribution, and the Morphe case was already accepted as proof above
+            InstallType.DEFAULT -> installer == null ||
+                    installer == AOSP_INSTALLER_PACKAGE ||
+                    installer == AOSP_INSTALLER_PACKAGE_LEGACY
+
+            // Shizuku installs leave no attribution behind, so anything else replaced the package
+            InstallType.SHIZUKU, InstallType.SAVED -> installer == null
+        }
+
+    /**
+     * Whether the installation on the device is newer than the patch record tracking it.
+     * Morphe's own reinstalls keep the original record, so this is only trusted next to an
+     * installer that Morphe would not have set.
+     */
+    private fun installedAfterPatching(app: InstalledApp, installedPackageInfo: PackageInfo): Boolean {
+        val patchedAt = app.patchedAt ?: return false
+        return installedPackageInfo.firstInstallTime > patchedAt + INSTALL_TIME_TOLERANCE_MS
     }
 
     /**
      * Searches both current and legacy storage paths, but only accepts the package Morphe tracks.
      * A renamed app must never fall back to an APK whose embedded id is the original package.
      */
-    private fun validatedPatchedApk(app: InstalledApp): File? =
+    private fun validatedPatchedApk(app: InstalledApp): Pair<File, PackageInfo>? =
         listOf(
             filesystem.getPatchedAppFile(app.currentPackageName, app.version),
             filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }.firstOrNull {
-            pm.isUsableApk(it, app.version, app.currentPackageName)
+        ).distinctBy { it.absolutePath }.firstNotNullOfOrNull { file ->
+            pm.readSavedApkInfo(file, app.currentPackageName)?.let { file to it }
         }
+
+    /** Certificates that identify the stock build: the retained original first, then the bundle. */
+    private suspend fun referenceSignatureHashes(packageName: String): Set<String> {
+        val savedHashes = originalApkRepository.get(packageName)
+            ?.let { File(it.filePath) }
+            ?.takeIf { it.exists() }
+            ?.let(pm::getApkFileSignatureHashes)
+            .orEmpty()
+
+        return savedHashes.ifEmpty {
+            patchBundleRepository.appMetadata.value[packageName]?.signatures.orEmpty()
+        }
+    }
 
     /**
      * Decided in priority order, most reliable first: a mounted install, the saved original's
@@ -231,14 +303,7 @@ class LocalApkSources(
         // that "Use installed APK" would copy is the patched one
         if (pm.hasSourceApkSignatureMismatch(packageName)) return InstalledPatchState.Patched
 
-        val savedHashes = originalApkRepository.get(packageName)
-            ?.let { File(it.filePath) }
-            ?.takeIf { it.exists() }
-            ?.let { pm.getApkFileSignatureHashes(it) }
-            .orEmpty()
-        val referenceHashes = savedHashes.ifEmpty {
-            patchBundleRepository.appMetadata.value[packageName]?.signatures.orEmpty()
-        }
+        val referenceHashes = referenceSignatureHashes(packageName)
 
         if (referenceHashes.isNotEmpty()) {
             val installedHashes = pm.getInstalledSignatureHashes(packageName)

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -51,20 +51,15 @@ internal fun resolveTrackedPatchState(
     originalHashes: Set<String>,
     installedByPatchManager: Boolean
 ): InstalledPatchState {
-    if (savedPatchedHashes.isNotEmpty() && installedHashes.isNotEmpty()) {
-        return if (installedHashes.any { it in savedPatchedHashes }) {
-            InstalledPatchState.Patched
-        } else {
-            InstalledPatchState.NotPatched
-        }
+    // A mismatch only proves that the installed package is not the reference artifact; it does
+    // not identify what replaced it. Only positive matches and trusted installer evidence can
+    // confirm either state.
+    if (installedHashes.any { it in savedPatchedHashes }) {
+        return InstalledPatchState.Patched
     }
 
-    if (originalHashes.isNotEmpty() && installedHashes.isNotEmpty()) {
-        return if (installedHashes.any { it in originalHashes }) {
-            InstalledPatchState.NotPatched
-        } else {
-            InstalledPatchState.Patched
-        }
+    if (installedHashes.any { it in originalHashes }) {
+        return InstalledPatchState.NotPatched
     }
 
     if (installedByPatchManager) return InstalledPatchState.Patched

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -5,8 +5,10 @@
 
 package app.morphe.manager.domain.apk
 
+import android.content.pm.PackageInfo
 import android.util.Log
 import app.morphe.manager.data.platform.Filesystem
+import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.repository.InstalledAppRepository
 import app.morphe.manager.domain.repository.OriginalApkRepository
@@ -44,6 +46,12 @@ enum class InstalledPatchState {
     NotPatched,
     Unknown
 }
+
+data class TrackedAppSnapshot(
+    val installedPackageInfo: PackageInfo?,
+    val savedPatchedApk: File?,
+    val patchState: InstalledPatchState?
+)
 
 internal fun resolveTrackedPatchState(
     installedHashes: Set<String>,
@@ -152,22 +160,31 @@ class LocalApkSources(
      * certificates, or the installer rather than being accepted merely because the row exists.
      * Null means the package is no longer installed.
      */
-    suspend fun trackedPatchState(app: InstalledApp): InstalledPatchState? = withContext(Dispatchers.IO) {
-        if (pm.getPackageInfo(app.currentPackageName) == null) return@withContext null
+    suspend fun trackedPatchState(app: InstalledApp): InstalledPatchState? =
+        trackedAppSnapshot(app).patchState
+
+    /** Resolves the saved APK and installed identity together for UI action gating. */
+    suspend fun trackedAppSnapshot(app: InstalledApp): TrackedAppSnapshot = withContext(Dispatchers.IO) {
+        val savedPatchedApk = validatedPatchedApk(app)
+        if (app.installType == InstallType.SAVED) {
+            return@withContext TrackedAppSnapshot(null, savedPatchedApk, null)
+        }
+
+        val installedPackageInfo = pm.getPackageInfo(app.currentPackageName)
+            ?: return@withContext TrackedAppSnapshot(null, savedPatchedApk, null)
 
         // A mounted install keeps the stock certificate in PackageManager while sourceDir points
         // at the patched APK, so this signal must win over all certificate comparisons below.
         if (pm.hasSourceApkSignatureMismatch(app.currentPackageName)) {
-            return@withContext InstalledPatchState.Patched
+            return@withContext TrackedAppSnapshot(
+                installedPackageInfo,
+                savedPatchedApk,
+                InstalledPatchState.Patched
+            )
         }
 
         val installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName)
-        val savedPatchedHashes = listOf(
-            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
-            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }.firstOrNull {
-            pm.isUsableApk(it, app.version, app.currentPackageName, app.originalPackageName)
-        }?.let(pm::getApkFileSignatureHashes).orEmpty()
+        val savedPatchedHashes = savedPatchedApk?.let(pm::getApkFileSignatureHashes).orEmpty()
 
         val savedOriginalHashes = originalApkRepository.get(app.originalPackageName)
             ?.let { File(it.filePath) }
@@ -180,13 +197,29 @@ class LocalApkSources(
 
         // Play Store-attributed and custom install modes make installer identity inconclusive.
         // An unverified same-name package must not enable actions that could uninstall stock.
-        resolveTrackedPatchState(
-            installedHashes = installedHashes,
-            savedPatchedHashes = savedPatchedHashes,
-            originalHashes = originalHashes,
-            installedByPatchManager = pm.isInstalledByPatchManager(app.currentPackageName)
+        TrackedAppSnapshot(
+            installedPackageInfo = installedPackageInfo,
+            savedPatchedApk = savedPatchedApk,
+            patchState = resolveTrackedPatchState(
+                installedHashes = installedHashes,
+                savedPatchedHashes = savedPatchedHashes,
+                originalHashes = originalHashes,
+                installedByPatchManager = pm.isInstalledByPatchManager(app.currentPackageName)
+            )
         )
     }
+
+    /**
+     * Searches both current and legacy storage paths, but only accepts the package Morphe tracks.
+     * A renamed app must never fall back to an APK whose embedded id is the original package.
+     */
+    private fun validatedPatchedApk(app: InstalledApp): File? =
+        listOf(
+            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
+            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
+        ).distinctBy { it.absolutePath }.firstOrNull {
+            pm.isUsableApk(it, app.version, app.currentPackageName)
+        }
 
     /**
      * Decided in priority order, most reliable first: a mounted install, the saved original's

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -6,6 +6,8 @@
 package app.morphe.manager.domain.apk
 
 import android.util.Log
+import app.morphe.manager.data.platform.Filesystem
+import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.repository.InstalledAppRepository
 import app.morphe.manager.domain.repository.OriginalApkRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository
@@ -13,6 +15,8 @@ import app.morphe.manager.util.AppDataResolver
 import app.morphe.manager.util.AppDataSource
 import app.morphe.manager.util.PM
 import app.morphe.manager.util.tag
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /** Saved APK information for display in APK selection dialog. */
@@ -41,6 +45,32 @@ enum class InstalledPatchState {
     Unknown
 }
 
+internal fun resolveTrackedPatchState(
+    installedHashes: Set<String>,
+    savedPatchedHashes: Set<String>,
+    originalHashes: Set<String>,
+    installedByPatchManager: Boolean
+): InstalledPatchState {
+    if (savedPatchedHashes.isNotEmpty() && installedHashes.isNotEmpty()) {
+        return if (installedHashes.any { it in savedPatchedHashes }) {
+            InstalledPatchState.Patched
+        } else {
+            InstalledPatchState.NotPatched
+        }
+    }
+
+    if (originalHashes.isNotEmpty() && installedHashes.isNotEmpty()) {
+        return if (installedHashes.any { it in originalHashes }) {
+            InstalledPatchState.NotPatched
+        } else {
+            InstalledPatchState.Patched
+        }
+    }
+
+    if (installedByPatchManager) return InstalledPatchState.Patched
+    return InstalledPatchState.Unknown
+}
+
 /**
  * The APKs already on the device that an app could be patched from: the original Morphe kept
  * from a previous run, and the app as the system has it installed.
@@ -50,6 +80,7 @@ class LocalApkSources(
     private val installedAppRepository: InstalledAppRepository,
     private val patchBundleRepository: PatchBundleRepository,
     private val appDataResolver: AppDataResolver,
+    private val filesystem: Filesystem,
     private val pm: PM
 ) {
     /** The original APK kept after a previous patch, or null when there is none on disk. */
@@ -114,6 +145,52 @@ class LocalApkSources(
     } catch (e: Exception) {
         Log.e(tag, "Failed to load installed app info", e)
         false to null
+    }
+
+    /**
+     * Identifies whether the package currently occupying a tracked app's package name is still
+     * the patched build Morphe recorded.
+     *
+     * The installed-app row is deliberately not evidence here: it survives an uninstall so the
+     * user can retain patch settings. A stock reinstall with the same package and version must
+     * therefore be checked against the saved patched APK, the original certificate, bundle
+     * certificates, or the installer rather than being accepted merely because the row exists.
+     * Null means the package is no longer installed.
+     */
+    suspend fun trackedPatchState(app: InstalledApp): InstalledPatchState? = withContext(Dispatchers.IO) {
+        if (pm.getPackageInfo(app.currentPackageName) == null) return@withContext null
+
+        // A mounted install keeps the stock certificate in PackageManager while sourceDir points
+        // at the patched APK, so this signal must win over all certificate comparisons below.
+        if (pm.hasSourceApkSignatureMismatch(app.currentPackageName)) {
+            return@withContext InstalledPatchState.Patched
+        }
+
+        val installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName)
+        val savedPatchedHashes = listOf(
+            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
+            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
+        ).distinctBy { it.absolutePath }.firstOrNull {
+            pm.isUsableApk(it, app.version, app.currentPackageName, app.originalPackageName)
+        }?.let(pm::getApkFileSignatureHashes).orEmpty()
+
+        val savedOriginalHashes = originalApkRepository.get(app.originalPackageName)
+            ?.let { File(it.filePath) }
+            ?.takeIf { it.exists() }
+            ?.let(pm::getApkFileSignatureHashes)
+            .orEmpty()
+        val originalHashes = savedOriginalHashes.ifEmpty {
+            patchBundleRepository.appMetadata.value[app.originalPackageName]?.signatures.orEmpty()
+        }
+
+        // Play Store-attributed and custom install modes make installer identity inconclusive.
+        // An unverified same-name package must not enable actions that could uninstall stock.
+        resolveTrackedPatchState(
+            installedHashes = installedHashes,
+            savedPatchedHashes = savedPatchedHashes,
+            originalHashes = originalHashes,
+            installedByPatchManager = pm.isInstalledByPatchManager(app.currentPackageName)
+        )
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -269,15 +269,16 @@ class LocalApkSources(
     }
 
     /**
-     * Searches both current and legacy storage paths, but only accepts the package Morphe tracks.
-     * A renamed app must never fall back to an APK whose embedded id is the original package.
+     * Searches both current and legacy storage paths, but only accepts the artifact the record
+     * describes. A renamed app must never fall back to an APK whose embedded id is the original
+     * package, and the expected file name is not on its own proof of what the file contains.
      */
     private fun validatedPatchedApk(app: InstalledApp): Pair<File, PackageInfo>? =
         listOf(
             filesystem.getPatchedAppFile(app.currentPackageName, app.version),
             filesystem.getPatchedAppFile(app.originalPackageName, app.version)
         ).distinctBy { it.absolutePath }.firstNotNullOfOrNull { file ->
-            pm.readSavedApkInfo(file, app.currentPackageName)?.let { file to it }
+            pm.readSavedApkInfo(file, app.version, app.currentPackageName)?.let { file to it }
         }
 
     /** Certificates that identify the stock build: the retained original first, then the bundle. */

--- a/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
@@ -19,6 +19,7 @@ data class HomeAppItem(
     val isPinnedByDefault: Boolean,
     val isInstalledOnDevice: Boolean,
     val isDeleted: Boolean,
+    val isInstallStateUnknown: Boolean,
     val hasSavedCopy: Boolean,
     val hasUpdate: Boolean,
     val patchCount: Int
@@ -27,5 +28,5 @@ data class HomeAppItem(
      * Whether the pending update is worth surfacing in the UI.
      * Uninstalled apps keep their update flag but show the uninstalled state instead.
      */
-    val showsUpdateBadge: Boolean get() = hasUpdate && !isDeleted
+    val showsUpdateBadge: Boolean get() = hasUpdate && !isDeleted && !isInstallStateUnknown
 }

--- a/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
@@ -4,6 +4,7 @@ import android.content.pm.PackageInfo
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import app.morphe.manager.data.room.apps.installed.InstalledApp
+import java.io.File
 
 /**
  * Represents a single app button on the home screen.
@@ -20,10 +21,12 @@ data class HomeAppItem(
     val isInstalledOnDevice: Boolean,
     val isDeleted: Boolean,
     val isInstallStateUnknown: Boolean,
-    val hasSavedCopy: Boolean,
+    val savedApkFile: File?,
     val hasUpdate: Boolean,
     val patchCount: Int
 ) {
+    val hasSavedCopy: Boolean get() = savedApkFile != null
+
     /**
      * Whether the pending update is worth surfacing in the UI.
      * Uninstalled apps keep their update flag but show the uninstalled state instead.

--- a/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/HomeScreen.kt
@@ -154,7 +154,7 @@ fun HomeScreen(
     val startBatchReinstall: (List<HomeAppItem>) -> Unit = { items ->
         val requests = items.mapNotNull { item ->
             val installed = item.installedApp ?: return@mapNotNull null
-            val savedFile = homeViewModel.savedPatchedApkFile(installed) ?: return@mapNotNull null
+            val savedFile = item.savedApkFile ?: return@mapNotNull null
             InstallQueueRequest(
                 file = savedFile,
                 originalPackageName = installed.originalPackageName,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material3.MaterialTheme
@@ -192,29 +193,48 @@ fun InstalledAppCard(
     modifier: Modifier = Modifier,
     hasUpdate: Boolean = false,
     isAppDeleted: Boolean = false,
+    isInstallStateUnknown: Boolean = false,
     onLongClick: (() -> Unit)? = null
 ) {
     val cardStyle = homeAppCardStyle(subtitleAlpha = 0.85f)
-    val showsUpdateBadge = hasUpdate && !isAppDeleted
+    val showsUpdateBadge = hasUpdate && !isAppDeleted && !isInstallStateUnknown
 
     val versionLabel = stringResource(R.string.version)
     val installedLabel = stringResource(R.string.installed)
     val updateAvailableLabel = stringResource(R.string.update_available)
     val deletedLabel = stringResource(R.string.uninstalled)
+    val unverifiedLabel = stringResource(R.string.home_unverified)
 
     val version = remember(packageInfo, installedApp, isAppDeleted) {
         val raw = packageInfo?.versionName ?: installedApp.version
         if (raw.startsWith("v")) raw else "v$raw"
     }
 
-    val contentDesc = remember(displayName, version, versionLabel, installedLabel, showsUpdateBadge, updateAvailableLabel, isAppDeleted, deletedLabel) {
+    val contentDesc = remember(
+        displayName,
+        version,
+        versionLabel,
+        installedLabel,
+        showsUpdateBadge,
+        updateAvailableLabel,
+        isAppDeleted,
+        deletedLabel,
+        isInstallStateUnknown,
+        unverifiedLabel
+    ) {
         buildString {
             append(displayName)
             if (version.isNotEmpty()) {
                 append(", $versionLabel $version")
             }
             append(", ")
-            append(if (isAppDeleted) deletedLabel else installedLabel)
+            append(
+                when {
+                    isAppDeleted -> deletedLabel
+                    isInstallStateUnknown -> unverifiedLabel
+                    else -> installedLabel
+                }
+            )
             if (showsUpdateBadge) append(", $updateAvailableLabel")
         }
     }
@@ -274,6 +294,15 @@ fun InstalledAppCard(
                     StatusBadge(
                         text = stringResource(R.string.uninstalled),
                         icon = Icons.Outlined.DeleteOutline,
+                        containerColor = cardStyle.chipContainerColor,
+                        contentColor = cardStyle.chipContentColor
+                    )
+                }
+
+                if (isInstallStateUnknown) {
+                    StatusBadge(
+                        text = unverifiedLabel,
+                        icon = Icons.AutoMirrored.Outlined.HelpOutline,
                         containerColor = cardStyle.chipContainerColor,
                         contentColor = cardStyle.chipContentColor
                     )

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
@@ -365,6 +365,7 @@ internal fun DynamicAppCard(
                                 onClick = onAppClick,
                                 hasUpdate = hasUpdate,
                                 isAppDeleted = item.isDeleted,
+                                isInstallStateUnknown = item.isInstallStateUnknown,
                                 onLongClick = {
                                     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                                     onLongPress()
@@ -493,7 +494,8 @@ internal fun HiddenSearchAppCard(
                     gradientColors = item.gradientColors,
                     onClick = onAppClick,
                     hasUpdate = item.hasUpdate,
-                    isAppDeleted = item.isDeleted
+                    isAppDeleted = item.isDeleted,
+                    isInstallStateUnknown = item.isInstallStateUnknown
                 )
             } else {
                 AppButton(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -93,6 +93,9 @@ fun InstalledAppInfoDialog(
     // Get update status from the shared HomeViewModel instance
     val appUpdates by homeViewModel.appUpdatesAvailable.collectAsStateWithLifecycle()
     val hasUpdate = appUpdates[packageName] == true
+    val showsUpdateBanner = hasUpdate &&
+            !viewModel.isAppDeleted &&
+            !viewModel.isInstallStateUnknown
 
     // Accent color resolution order: bundle metadata (appIconColor) -> KnownApps.brandColor -> default.
     // originalPackageName needed because metadata is keyed by original pkg, not patched.
@@ -380,7 +383,7 @@ fun InstalledAppInfoDialog(
                                         availablePatches = availablePatches,
                                         isInstalling = isInstalling,
                                         mountOperation = mountOperation,
-                                        hasUpdate = hasUpdate,
+                                        showsUpdateBanner = showsUpdateBanner,
                                         accentColor = infoAccentColor,
                                         onPatchClick = { handlePatchClick() },
                                         onUninstall = { showUninstallConfirm.value = true },
@@ -474,9 +477,7 @@ fun InstalledAppInfoDialog(
                                     }
                                 }
                                 AnimatedVisibility(
-                                    visible = hasUpdate &&
-                                            !viewModel.isAppDeleted &&
-                                            !viewModel.isInstallStateUnknown,
+                                    visible = showsUpdateBanner,
                                     enter = Animations.expandFadeEnter,
                                     exit = Animations.shrinkFadeExit
                                 ) {
@@ -561,7 +562,24 @@ fun InstalledAppInfoDialog(
                                     }
                                 }
                                 androidx.compose.animation.AnimatedVisibility(
-                                    visible = hasUpdate && !viewModel.isAppDeleted,
+                                    visible = viewModel.isInstallStateUnknown,
+                                    enter = Animations.expandFadeEnter,
+                                    exit = Animations.shrinkFadeExit
+                                ) {
+                                    Column {
+                                        Spacer(Modifier.height(Defaults.ItemSpacing))
+                                        StaggeredItem(entered = entered.value, index = 1) {
+                                            Notice(
+                                                text = stringResource(R.string.home_apk_use_installed_unverified),
+                                                tone = SemanticTone.Warning,
+                                                icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                                                modifier = Modifier.padding(horizontal = Defaults.ContentPadding)
+                                            )
+                                        }
+                                    }
+                                }
+                                androidx.compose.animation.AnimatedVisibility(
+                                    visible = showsUpdateBanner,
                                     enter = Animations.expandFadeEnter,
                                     exit = Animations.shrinkFadeExit
                                 ) {
@@ -615,7 +633,7 @@ fun InstalledAppInfoDialog(
                                     availablePatches = availablePatches,
                                     isInstalling = isInstalling,
                                     mountOperation = mountOperation,
-                                    hasUpdate = hasUpdate,
+                                    showsUpdateBanner = showsUpdateBanner,
                                     accentColor = infoAccentColor,
                                     onPatchClick = { handlePatchClick() },
                                     onUninstall = { showUninstallConfirm.value = true },
@@ -1173,7 +1191,7 @@ private fun ActionsSection(
     availablePatches: Int,
     isInstalling: Boolean,
     mountOperation: InstallViewModel.MountOperation?,
-    hasUpdate: Boolean,
+    showsUpdateBanner: Boolean,
     accentColor: Color,
     onPatchClick: () -> Unit,
     onUninstall: () -> Unit,
@@ -1190,7 +1208,7 @@ private fun ActionsSection(
 
     // Primary actions - Single Patch button that triggers APK selection dialog
     // The dialog will show "Use saved APK" option if original APK exists
-    if (!hasUpdate && !viewModel.isAppDeleted) { // Hide the Patch button if there is a banner with its own button
+    if (!showsUpdateBanner && !viewModel.isAppDeleted) {
         primaryActions.add(
             ActionItem(
                 text = stringResource(R.string.patch),
@@ -1352,7 +1370,7 @@ private fun ActionsSection(
         )
     }
 
-    if (viewModel.hasSavedCopy || viewModel.isAppDeleted) {
+    if (viewModel.hasSavedCopy || viewModel.isAppDeleted || installedApp.installType == InstallType.SAVED) {
         destructiveActions.add(
             ActionItem(
                 text = stringResource(R.string.delete),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.automirrored.outlined.Launch
 import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.*
@@ -460,7 +461,22 @@ fun InstalledAppInfoDialog(
                                     }
                                 }
                                 AnimatedVisibility(
-                                    visible = hasUpdate && !viewModel.isAppDeleted,
+                                    visible = viewModel.isInstallStateUnknown,
+                                    enter = Animations.expandFadeEnter,
+                                    exit = Animations.shrinkFadeExit
+                                ) {
+                                    StaggeredItem(entered = entered.value, index = 2) {
+                                        Notice(
+                                            text = stringResource(R.string.home_apk_use_installed_unverified),
+                                            tone = SemanticTone.Warning,
+                                            icon = Icons.AutoMirrored.Outlined.HelpOutline
+                                        )
+                                    }
+                                }
+                                AnimatedVisibility(
+                                    visible = hasUpdate &&
+                                            !viewModel.isAppDeleted &&
+                                            !viewModel.isInstallStateUnknown,
                                     enter = Animations.expandFadeEnter,
                                     exit = Animations.shrinkFadeExit
                                 ) {
@@ -1336,7 +1352,7 @@ private fun ActionsSection(
         )
     }
 
-    if (viewModel.hasSavedCopy) {
+    if (viewModel.hasSavedCopy || viewModel.isAppDeleted) {
         destructiveActions.add(
             ActionItem(
                 text = stringResource(R.string.delete),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -306,7 +306,10 @@ fun InstalledAppInfoDialog(
         show = showDeleteDialog.value,
         isSavedOnly = installedApp?.installType == InstallType.SAVED,
         appInfo = viewModel.appInfo,
-        appLabel = viewModel.appInfo?.applicationInfo?.loadLabel(context.packageManager)?.toString(),
+        packageName = packageName,
+        appLabel = appLabel,
+        hasSavedApk = viewModel.hasSavedCopy,
+        hasOriginalApk = viewModel.hasOriginalApk,
         onConfirm = {
             viewModel.removeAppCompletely()
             showDeleteDialog.value = false
@@ -1370,7 +1373,7 @@ private fun ActionsSection(
         )
     }
 
-    if (viewModel.hasSavedCopy || viewModel.isAppDeleted || installedApp.installType == InstallType.SAVED) {
+    if (viewModel.canRemoveRecord) {
         destructiveActions.add(
             ActionItem(
                 text = stringResource(R.string.delete),
@@ -1589,7 +1592,10 @@ private fun DeleteConfirmDialog(
     show: Boolean,
     isSavedOnly: Boolean,
     appInfo: PackageInfo?,
-    appLabel: String?,
+    packageName: String,
+    appLabel: String,
+    hasSavedApk: Boolean,
+    hasOriginalApk: Boolean,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -1615,18 +1621,17 @@ private fun DeleteConfirmDialog(
         ) {
             AppIcon(
                 packageInfo = appInfo,
+                packageName = packageName,
                 contentDescription = null,
                 modifier = Modifier.size(64.dp)
             )
-            if (appLabel != null) {
-                Text(
-                    text = appLabel,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = LocalDialogTextColor.current,
-                    textAlign = TextAlign.Center
-                )
-            }
+            Text(
+                text = appLabel,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = LocalDialogTextColor.current,
+                textAlign = TextAlign.Center
+            )
             LabeledSection(
                 title = stringResource(R.string.home_app_info_remove_app_warning)
             ) {
@@ -1636,18 +1641,23 @@ private fun DeleteConfirmDialog(
                         text = stringResource(R.string.home_app_info_delete_item_patched_apk)
                     )
                 } else {
+                    // A record can outlive both archives, so only list the files that are there
                     DeleteListItem(
                         icon = Icons.Outlined.Storage,
                         text = stringResource(R.string.home_app_info_delete_item_database)
                     )
-                    DeleteListItem(
-                        icon = Icons.Outlined.Android,
-                        text = stringResource(R.string.home_app_info_delete_item_patched_apk)
-                    )
-                    DeleteListItem(
-                        icon = Icons.Outlined.FilePresent,
-                        text = stringResource(R.string.home_app_info_delete_item_original_apk)
-                    )
+                    if (hasSavedApk) {
+                        DeleteListItem(
+                            icon = Icons.Outlined.Android,
+                            text = stringResource(R.string.home_app_info_delete_item_patched_apk)
+                        )
+                    }
+                    if (hasOriginalApk) {
+                        DeleteListItem(
+                            icon = Icons.Outlined.FilePresent,
+                            text = stringResource(R.string.home_app_info_delete_item_original_apk)
+                        )
+                    }
                 }
             }
             if (!isSavedOnly) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -470,7 +470,7 @@ fun InstalledAppInfoDialog(
                                 ) {
                                     StaggeredItem(entered = entered.value, index = 2) {
                                         Notice(
-                                            text = stringResource(R.string.home_apk_use_installed_unverified),
+                                            text = stringResource(R.string.home_app_info_install_unverified),
                                             tone = SemanticTone.Warning,
                                             icon = Icons.AutoMirrored.Outlined.HelpOutline
                                         )
@@ -570,7 +570,7 @@ fun InstalledAppInfoDialog(
                                         Spacer(Modifier.height(Defaults.ItemSpacing))
                                         StaggeredItem(entered = entered.value, index = 1) {
                                             Notice(
-                                                text = stringResource(R.string.home_apk_use_installed_unverified),
+                                                text = stringResource(R.string.home_app_info_install_unverified),
                                                 tone = SemanticTone.Warning,
                                                 icon = Icons.AutoMirrored.Outlined.HelpOutline,
                                                 modifier = Modifier.padding(horizontal = Defaults.ContentPadding)

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -221,8 +221,9 @@ private fun PatchedApksContent(
                             app.currentPackageName,
                             preferredSource = AppDataSource.PATCHED_APK
                         )
-                        val savedDisplayName = savedFile
-                            ?.let(pm::getPackageInfo)
+                        // Taken from the archive the row actually points at, which can differ from
+                        // the resolver's answer once the installed app is no longer the patched one
+                        val savedDisplayName = snapshot.savedPatchedApkInfo
                             ?.let { packageInfo -> runCatching { with(pm) { packageInfo.label() } }.getOrNull() }
                             ?.takeUnless(String::isBlank)
 
@@ -302,18 +303,23 @@ private fun PatchedApksContent(
 
     val uninstallTimeoutText = stringResource(R.string.uninstall_timeout)
     val uninstallFailTemplate = stringResource(R.string.uninstall_app_fail)
+    val uninstallUnverifiedText = stringResource(R.string.uninstall_app_unverified)
 
     fun uninstallItems(items: List<ApkItemData>) {
         if (items.isEmpty()) return
         scope.launch {
             var completed = 0
             var skipped = 0
+            var unverified = 0
             for (item in items) {
                 val installedApp = appByKey[item.selectionKey]
                 val result = runCatching {
-                    if (installedApp == null ||
-                        localApkSources.trackedPatchState(installedApp) != InstalledPatchState.Patched
+                    // Unmounting is safe without verification, every other mode removes a package
+                    if (item.installType != InstallType.MOUNT &&
+                        (installedApp == null ||
+                                localApkSources.trackedPatchState(installedApp) != InstalledPatchState.Patched)
                     ) {
+                        unverified++
                         return@runCatching false
                     }
                     val removed = withTimeoutOrNull(BATCH_UNINSTALL_TIMEOUT) {
@@ -338,6 +344,7 @@ private fun PatchedApksContent(
                     }
                 }
             }
+            if (unverified > 0) context.toast(uninstallUnverifiedText)
             context.batchActionSummary(R.plurals.batch_uninstall_summary, completed, skipped)
                 ?.let { context.toast(it) }
         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -43,6 +43,8 @@ import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.data.room.apps.installed.supportsMount
 import app.morphe.manager.data.room.apps.original.OriginalApk
+import app.morphe.manager.domain.apk.InstalledPatchState
+import app.morphe.manager.domain.apk.LocalApkSources
 import app.morphe.manager.domain.installer.InstallerFileProvider
 import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.UninstallCancelledException
@@ -196,6 +198,7 @@ private fun PatchedApksContent(
     val appDataResolver: AppDataResolver = koinInject()
     val prefs: PreferencesManager = koinInject()
     val pm: PM = koinInject()
+    val localApkSources: LocalApkSources = koinInject()
     val installerManager: InstallerManager = koinInject()
     val savePatchedApks by prefs.savePatchedApks.getAsState()
 
@@ -206,28 +209,33 @@ private fun PatchedApksContent(
             state = ApkLoadState.Loaded(
                 withContext(Dispatchers.IO) {
                     apps.mapNotNull { app ->
-                        // Check if saved APK file exists
-                        val savedFile = listOf(
+                        val storedFile = listOf(
                             filesystem.getPatchedAppFile(app.currentPackageName, app.version),
                             filesystem.getPatchedAppFile(app.originalPackageName, app.version)
                         ).distinct().firstOrNull { it.exists() } ?: return@mapNotNull null
+                        val snapshot = localApkSources.trackedAppSnapshot(app)
+                        val savedFile = snapshot.savedPatchedApk
 
                         // Use AppDataResolver to get data
                         val resolvedData = appDataResolver.resolveAppData(
                             app.currentPackageName,
                             preferredSource = AppDataSource.PATCHED_APK
                         )
+                        val savedDisplayName = savedFile
+                            ?.let(pm::getPackageInfo)
+                            ?.let { packageInfo -> runCatching { with(pm) { packageInfo.label() } }.getOrNull() }
+                            ?.takeUnless(String::isBlank)
 
                         ApkItemDataWithApp(
                             packageName = app.currentPackageName,
-                            displayName = resolvedData.displayName,
+                            displayName = savedDisplayName ?: resolvedData.displayName,
                             version = app.version,
-                            fileSize = savedFile.length(),
+                            fileSize = (savedFile ?: storedFile).length(),
                             installedApp = app,
                             file = savedFile,
                             installType = app.installType,
-                            isInstalledOnDevice = pm.getPackageInfo(app.currentPackageName) != null,
-                            abis = NativeLibStripper.extractAbisFromApk(savedFile)
+                            isInstalledOnDevice = snapshot.patchState == InstalledPatchState.Patched,
+                            abis = savedFile?.let(NativeLibStripper::extractAbisFromApk).orEmpty()
                         )
                     }
                 }
@@ -303,6 +311,11 @@ private fun PatchedApksContent(
             for (item in items) {
                 val installedApp = appByKey[item.selectionKey]
                 val result = runCatching {
+                    if (installedApp == null ||
+                        localApkSources.trackedPatchState(installedApp) != InstalledPatchState.Patched
+                    ) {
+                        return@runCatching false
+                    }
                     val removed = withTimeoutOrNull(BATCH_UNINSTALL_TIMEOUT) {
                         uninstallStorageItem(
                             item = item,
@@ -313,9 +326,10 @@ private fun PatchedApksContent(
                         true
                     } == true
                     if (!removed) error(uninstallTimeoutText)
+                    true
                 }
-                result.onSuccess {
-                    completed++
+                result.onSuccess { removed ->
+                    if (removed) completed++ else skipped++
                     updateInstalledState(item.packageName, false)
                 }.onFailure { error ->
                     skipped++

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -7,10 +7,12 @@ package app.morphe.manager.ui.viewmodel
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.net.Uri
@@ -20,6 +22,7 @@ import android.provider.OpenableColumns
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.*
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.morphe.manager.R
@@ -75,6 +78,8 @@ import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.InstallerType
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
@@ -443,6 +448,14 @@ class HomeViewModel(
 
     // Ticker to force homeAppState recomputation after install/uninstall without changing DB state
     private val _appStateTicker = MutableStateFlow(0L)
+    private val trackedAppInspectionSemaphore = Semaphore(4)
+
+    private val packageChangeReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            val packageName = intent?.data?.schemeSpecificPart ?: return
+            notifyAppStateChanged(packageName)
+        }
+    }
 
     // Track when at least one third-party source is enabled
     val hasThirdPartySource: StateFlow<Boolean> =
@@ -618,6 +631,19 @@ class HomeViewModel(
     var onStartQuickPatch: ((QuickPatchParams) -> Unit)? = null
 
     init {
+        ContextCompat.registerReceiver(
+            app,
+            packageChangeReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_PACKAGE_ADDED)
+                addAction(Intent.ACTION_PACKAGE_REMOVED)
+                addAction(Intent.ACTION_PACKAGE_REPLACED)
+                addDataScheme("package")
+            },
+            // Package lifecycle broadcasts originate outside this app. The receiver only
+            // invalidates cached UI state, so accepting them does not expose a privileged action.
+            ContextCompat.RECEIVER_EXPORTED
+        )
         observeManagerUpdate()
         triggerUpdateCheck()
         observeLoadingState()
@@ -1206,11 +1232,14 @@ class HomeViewModel(
             val displayName = resolvedData.displayName.takeIf {
                 resolvedData.source == AppDataSource.INSTALLED || resolvedData.source == AppDataSource.PATCHED_APK
             } ?: bundleMeta?.displayName ?: KnownApps.getAppName(packageName)
-            val savedPatchedApk = installedApp?.let(::savedPatchedApkFile)
-            val hasSavedCopy = savedPatchedApk != null
-            val trackedPatchState = installedApp
-                ?.takeUnless { it.installType == InstallType.SAVED }
-                ?.let { localApkSources.trackedPatchState(it) }
+            val trackedSnapshot = installedApp?.let {
+                trackedAppInspectionSemaphore.withPermit {
+                    localApkSources.trackedAppSnapshot(it)
+                }
+            }
+            val savedPatchedApk = trackedSnapshot?.savedPatchedApk
+            val savedPackageInfo = savedPatchedApk?.let(pm::getPackageInfo)
+            val trackedPatchState = trackedSnapshot?.patchState
             val isInstalledOnDevice = trackedPatchState == InstalledPatchState.Patched
             val isDeleted = installedApp != null &&
                     installedApp.installType != InstallType.SAVED &&
@@ -1224,14 +1253,14 @@ class HomeViewModel(
                 displayName = displayName,
                 gradientColors = gradientColors,
                 installedApp = installedApp,
-                packageInfo = resolvedData.packageInfo.takeIf {
+                packageInfo = savedPackageInfo ?: resolvedData.packageInfo.takeIf {
                     installedApp == null || isInstalledOnDevice
-                } ?: savedPatchedApk?.let(pm::getPackageInfo),
+                },
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
                 isInstalledOnDevice = isInstalledOnDevice,
                 isDeleted = isDeleted,
                 isInstallStateUnknown = isInstallStateUnknown,
-                hasSavedCopy = hasSavedCopy,
+                savedApkFile = savedPatchedApk,
                 hasUpdate = hasUpdate,
                 patchCount = 0
             )
@@ -1569,14 +1598,6 @@ class HomeViewModel(
             (state?.visible?.size ?: 0) > 4 || thirdParty
         }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
-    fun savedPatchedApkFile(app: InstalledApp): File? =
-        listOf(
-            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
-            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }.firstOrNull {
-            pm.isUsableApk(it, app.version, app.currentPackageName, app.originalPackageName)
-        }
-
     suspend fun persistReinstalledApp(
         app: InstalledApp,
         packageName: String,
@@ -1598,9 +1619,7 @@ class HomeViewModel(
     }
 
     fun uninstallApps(items: Collection<HomeAppItem>) {
-        val apps = items.mapNotNull { it.installedApp }.filter { installed ->
-            installed.installType == InstallType.MOUNT || pm.getPackageInfo(installed.currentPackageName) != null
-        }
+        val apps = items.mapNotNull { it.installedApp }.distinctBy { it.currentPackageName }
         if (apps.isEmpty()) return
 
         viewModelScope.launch {
@@ -1608,6 +1627,9 @@ class HomeViewModel(
             var skipped = 0
             for (installed in apps) {
                 runCatching {
+                    if (localApkSources.trackedPatchState(installed) != InstalledPatchState.Patched) {
+                        return@runCatching false
+                    }
                     when (installed.installType) {
                         InstallType.MOUNT -> {
                             installerManager.uninstallPackage(installed.currentPackageName, installed.installType)
@@ -1621,8 +1643,9 @@ class HomeViewModel(
                             if (!removed) error(app.getString(R.string.uninstall_timeout))
                         }
                     }
-                }.onSuccess {
-                    completed++
+                    true
+                }.onSuccess { removed ->
+                    if (removed) completed++ else skipped++
                     notifyAppStateChanged(installed.currentPackageName)
                 }.onFailure { error ->
                     skipped++
@@ -1647,13 +1670,17 @@ class HomeViewModel(
     fun uninstallOrphanedInstall(orphan: InstalledApp) {
         viewModelScope.launch {
             runCatching {
+                if (localApkSources.trackedPatchState(orphan) != InstalledPatchState.Patched) {
+                    return@runCatching false
+                }
                 val removed = withTimeoutOrNull(BATCH_UNINSTALL_TIMEOUT) {
                     installerManager.uninstallPackage(orphan.currentPackageName, orphan.installType)
                     true
                 } == true
                 if (!removed) error(app.getString(R.string.uninstall_timeout))
-            }.onSuccess {
-                notifyAppStateChanged(orphan.currentPackageName)
+                true
+            }.onSuccess { removed ->
+                if (removed) notifyAppStateChanged(orphan.currentPackageName)
             }.onFailure { error ->
                 if (error !is UninstallCancelledException) {
                     app.toast(app.getString(R.string.uninstall_app_fail, error.simpleMessage()))
@@ -3032,6 +3059,7 @@ class HomeViewModel(
      * the ViewModel while a temporary APK file is still held in pendingSelectedApp.
      */
     override fun onCleared() {
+        runCatching { app.unregisterReceiver(packageChangeReceiver) }
         val pending = pendingSelectedApp
         if (pending is SelectedApp.Local && pending.temporary) {
             pending.file.delete()

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -28,6 +28,7 @@ import app.morphe.manager.data.platform.NetworkInfo
 import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.apk.InstalledApkInfo
+import app.morphe.manager.domain.apk.InstalledPatchState
 import app.morphe.manager.domain.apk.LocalApkSources
 import app.morphe.manager.domain.apk.SavedApkInfo
 import app.morphe.manager.domain.batch.BatchPatchCoordinator
@@ -1163,7 +1164,10 @@ class HomeViewModel(
                 }
                 // Reconcile DB version with the actually-installed version.
                 // Skipped for MOUNT (PM reports the stock APK) and SAVED (no live install)
-                if (app.installType != InstallType.MOUNT && app.installType != InstallType.SAVED) {
+                if (app.installType != InstallType.MOUNT &&
+                    app.installType != InstallType.SAVED &&
+                    localApkSources.trackedPatchState(app) == InstalledPatchState.Patched
+                ) {
                     val liveVersion = pm.getPackageInfo(app.currentPackageName)?.versionName
                     if (!liveVersion.isNullOrBlank() && liveVersion != app.version) {
                         installedAppRepository.updateInstalledVersion(app, liveVersion)
@@ -1202,14 +1206,16 @@ class HomeViewModel(
             val displayName = resolvedData.displayName.takeIf {
                 resolvedData.source == AppDataSource.INSTALLED || resolvedData.source == AppDataSource.PATCHED_APK
             } ?: bundleMeta?.displayName ?: KnownApps.getAppName(packageName)
-            val hasSavedCopy = installedApp?.let { savedPatchedApkFile(it) != null } == true
-            val isInstalledOnDevice = installedApp?.let { pm.getPackageInfo(it.currentPackageName) != null } == true
-            val isDeleted = installedApp?.let { installed ->
-                pm.isAppDeleted(
-                    packageName = installed.currentPackageName,
-                    wasInstalledOnDevice = installed.installType != InstallType.SAVED
-                )
-            } == true
+            val savedPatchedApk = installedApp?.let(::savedPatchedApkFile)
+            val hasSavedCopy = savedPatchedApk != null
+            val trackedPatchState = installedApp
+                ?.takeUnless { it.installType == InstallType.SAVED }
+                ?.let { localApkSources.trackedPatchState(it) }
+            val isInstalledOnDevice = trackedPatchState == InstalledPatchState.Patched
+            val isDeleted = installedApp != null &&
+                    installedApp.installType != InstallType.SAVED &&
+                    (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
+            val isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
             } == true
@@ -1218,10 +1224,13 @@ class HomeViewModel(
                 displayName = displayName,
                 gradientColors = gradientColors,
                 installedApp = installedApp,
-                packageInfo = resolvedData.packageInfo,
+                packageInfo = resolvedData.packageInfo.takeIf {
+                    installedApp == null || isInstalledOnDevice
+                } ?: savedPatchedApk?.let(pm::getPackageInfo),
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
                 isInstalledOnDevice = isInstalledOnDevice,
                 isDeleted = isDeleted,
+                isInstallStateUnknown = isInstallStateUnknown,
                 hasSavedCopy = hasSavedCopy,
                 hasUpdate = hasUpdate,
                 patchCount = 0
@@ -1564,7 +1573,9 @@ class HomeViewModel(
         listOf(
             filesystem.getPatchedAppFile(app.currentPackageName, app.version),
             filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }.firstOrNull { it.exists() && it.length() > 0 }
+        ).distinctBy { it.absolutePath }.firstOrNull {
+            pm.isUsableApk(it, app.version, app.currentPackageName, app.originalPackageName)
+        }
 
     suspend fun persistReinstalledApp(
         app: InstalledApp,

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -450,11 +450,33 @@ class HomeViewModel(
     private val _appStateTicker = MutableStateFlow(0L)
     private val trackedAppInspectionSemaphore = Semaphore(4)
 
+    // Package names worth reacting to, refreshed from the same flow that feeds the home cards
+    @Volatile
+    private var trackedPackageNames: Set<String> = emptySet()
+    private val pendingPackageChanges = MutableStateFlow<Set<String>>(emptySet())
+
     private val packageChangeReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
             val packageName = intent?.data?.schemeSpecificPart ?: return
-            notifyAppStateChanged(packageName)
+            if (packageName !in trackedPackageNames) return
+            pendingPackageChanges.update { it + packageName }
         }
+    }
+
+    /**
+     * Coalesces package broadcasts before rebuilding the home state.
+     * A store updating apps in the background emits add, remove and replace in bursts, and every
+     * one of them would otherwise re-inspect every tracked app.
+     */
+    private fun observePackageChanges() = viewModelScope.launch {
+        pendingPackageChanges
+            .filter { it.isNotEmpty() }
+            .collectLatest { pending ->
+                delay(PACKAGE_CHANGE_DEBOUNCE_MS)
+                pending.forEach { appDataResolver.invalidate(it) }
+                _appStateTicker.value = System.currentTimeMillis()
+                pendingPackageChanges.value = emptySet()
+            }
     }
 
     // Track when at least one third-party source is enabled
@@ -640,10 +662,11 @@ class HomeViewModel(
                 addAction(Intent.ACTION_PACKAGE_REPLACED)
                 addDataScheme("package")
             },
-            // Package lifecycle broadcasts originate outside this app. The receiver only
-            // invalidates cached UI state, so accepting them does not expose a privileged action.
-            ContextCompat.RECEIVER_EXPORTED
+            // Only the system can send these protected broadcasts, so the receiver never has to
+            // be reachable by other apps.
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
+        observePackageChanges()
         observeManagerUpdate()
         triggerUpdateCheck()
         observeLoadingState()
@@ -1183,21 +1206,13 @@ class HomeViewModel(
         patchBundleRepository.bundleState,
         _homePrefsFlow,
         installedAppRepository.getAll().onEach { apps ->
+            trackedPackageNames = apps.flatMapTo(mutableSetOf()) {
+                listOf(it.currentPackageName, it.originalPackageName)
+            }
             apps.forEach { app ->
                 appDataResolver.invalidate(app.currentPackageName)
                 if (app.originalPackageName != app.currentPackageName) {
                     appDataResolver.invalidate(app.originalPackageName)
-                }
-                // Reconcile DB version with the actually-installed version.
-                // Skipped for MOUNT (PM reports the stock APK) and SAVED (no live install)
-                if (app.installType != InstallType.MOUNT &&
-                    app.installType != InstallType.SAVED &&
-                    localApkSources.trackedPatchState(app) == InstalledPatchState.Patched
-                ) {
-                    val liveVersion = pm.getPackageInfo(app.currentPackageName)?.versionName
-                    if (!liveVersion.isNullOrBlank() && liveVersion != app.version) {
-                        installedAppRepository.updateInstalledVersion(app, liveVersion)
-                    }
                 }
             }
         },
@@ -1238,7 +1253,7 @@ class HomeViewModel(
                 }
             }
             val savedPatchedApk = trackedSnapshot?.savedPatchedApk
-            val savedPackageInfo = savedPatchedApk?.let(pm::getPackageInfo)
+            val savedPackageInfo = trackedSnapshot?.savedPatchedApkInfo
             val trackedPatchState = trackedSnapshot?.patchState
             val isInstalledOnDevice = trackedPatchState == InstalledPatchState.Patched
             val isDeleted = installedApp != null &&
@@ -1248,13 +1263,22 @@ class HomeViewModel(
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
             } == true
+
+            if (installedApp != null && trackedSnapshot != null && isInstalledOnDevice) {
+                reconcileInstalledVersion(installedApp, trackedSnapshot.installedPackageInfo)
+            }
+
             return HomeAppItem(
                 packageName = packageName,
                 displayName = displayName,
                 gradientColors = gradientColors,
                 installedApp = installedApp,
-                packageInfo = savedPackageInfo ?: resolvedData.packageInfo.takeIf {
-                    installedApp == null || isInstalledOnDevice
+                // A tracked app that cannot be confirmed shows what Morphe kept on disk rather
+                // than describing whatever package took over its name
+                packageInfo = when {
+                    installedApp == null -> resolvedData.packageInfo
+                    isInstalledOnDevice -> resolvedData.packageInfo ?: savedPackageInfo
+                    else -> savedPackageInfo
                 },
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
                 isInstalledOnDevice = isInstalledOnDevice,
@@ -1312,6 +1336,22 @@ class HomeViewModel(
     }
         .flowOn(Dispatchers.IO)
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    /**
+     * Aligns the recorded version with the running one after an in-place update.
+     *
+     * Only a confirmed tracked install may do this: reconciling against a package that merely
+     * shares the name would rewrite the record to describe a build Morphe never produced.
+     * Skipped for MOUNT (the package manager reports the stock APK) and SAVED (no live install).
+     */
+    private suspend fun reconcileInstalledVersion(app: InstalledApp, installedPackageInfo: PackageInfo?) {
+        if (app.installType == InstallType.MOUNT || app.installType == InstallType.SAVED) return
+
+        val liveVersion = installedPackageInfo?.versionName
+        if (liveVersion.isNullOrBlank() || liveVersion == app.version) return
+
+        installedAppRepository.updateInstalledVersion(app, liveVersion)
+    }
 
     private fun buildHomeAppSourceGroups(
         enabledInfo: Map<Int, PatchBundleInfo.Global>,
@@ -1625,17 +1665,21 @@ class HomeViewModel(
         viewModelScope.launch {
             var completed = 0
             var skipped = 0
+            var unverified = 0
             for (installed in apps) {
                 runCatching {
-                    if (localApkSources.trackedPatchState(installed) != InstalledPatchState.Patched) {
-                        return@runCatching false
-                    }
                     when (installed.installType) {
+                        // Unmounting only removes the bind mount and the module files, so it is
+                        // safe even when the underlying package can no longer be identified
                         InstallType.MOUNT -> {
                             installerManager.uninstallPackage(installed.currentPackageName, installed.installType)
                             installedAppRepository.delete(installed)
                         }
                         else -> {
+                            if (localApkSources.trackedPatchState(installed) != InstalledPatchState.Patched) {
+                                unverified++
+                                return@runCatching false
+                            }
                             val removed = withTimeoutOrNull(BATCH_UNINSTALL_TIMEOUT) {
                                 installerManager.uninstallPackage(installed.currentPackageName, installed.installType)
                                 true
@@ -1655,6 +1699,7 @@ class HomeViewModel(
                 }
             }
 
+            if (unverified > 0) app.toast(app.getString(R.string.uninstall_app_unverified))
             app.batchActionSummary(R.plurals.batch_uninstall_summary, completed, skipped)
                 ?.let { app.toast(it) }
         }
@@ -1666,11 +1711,13 @@ class HomeViewModel(
     /**
      * Uninstalls a copy that patching left behind under its previous package name.
      * The prompt is cleared either way: a refused or failed uninstall must not keep reappearing.
+     * A copy that cannot be identified is left on the device, so the user is told about it.
      */
     fun uninstallOrphanedInstall(orphan: InstalledApp) {
         viewModelScope.launch {
             runCatching {
                 if (localApkSources.trackedPatchState(orphan) != InstalledPatchState.Patched) {
+                    app.toast(app.getString(R.string.uninstall_app_unverified))
                     return@runCatching false
                 }
                 val removed = withTimeoutOrNull(BATCH_UNINSTALL_TIMEOUT) {

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -209,7 +209,7 @@ class InstalledAppInfoViewModel(
 
         // Delete patched APK file
         withContext(Dispatchers.IO) {
-            savedApkFile(app)?.delete()
+            savedApkCandidates(app).forEach { it.delete() }
         }
         hasSavedCopy = false
     }
@@ -234,14 +234,16 @@ class InstalledAppInfoViewModel(
 
     fun savedApkFile(app: InstalledApp? = this.installedApp): File? {
         val target = app ?: return null
-        val candidates = listOf(
-            filesystem.getPatchedAppFile(target.currentPackageName, target.version),
-            filesystem.getPatchedAppFile(target.originalPackageName, target.version)
-        ).distinct()
-        return candidates.firstOrNull {
+        return savedApkCandidates(target).firstOrNull {
             pm.isUsableApk(it, target.version, target.currentPackageName, target.originalPackageName)
         }
     }
+
+    private fun savedApkCandidates(app: InstalledApp): List<File> =
+        listOf(
+            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
+            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
+        ).distinctBy { it.absolutePath }
 
     private suspend fun refreshAppState(app: InstalledApp) {
         val installedInfo = withContext(Dispatchers.IO) {

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -13,6 +13,7 @@ import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.apk.InstalledPatchState
 import app.morphe.manager.domain.apk.LocalApkSources
+import app.morphe.manager.domain.apk.canRemoveTrackedRecord
 import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
@@ -67,6 +68,8 @@ class InstalledAppInfoViewModel(
     var isAppDeleted by mutableStateOf(false)
         private set
     var isInstallStateUnknown by mutableStateOf(false)
+        private set
+    var canRemoveRecord by mutableStateOf(false)
         private set
     var isLoading by mutableStateOf(true)
         private set
@@ -292,6 +295,8 @@ class InstalledAppInfoViewModel(
             isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
             appInfo = snapshot.savedPatchedApkInfo
         }
+
+        canRemoveRecord = canRemoveTrackedRecord(app.installType, trackedPatchState, hasSavedCopy)
 
         // Update mounted state
         isMounted = rootInstaller.isDeviceRooted() && rootInstaller.isAppMounted(app.currentPackageName)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -11,6 +11,8 @@ import app.morphe.manager.R
 import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
+import app.morphe.manager.domain.apk.InstalledPatchState
+import app.morphe.manager.domain.apk.LocalApkSources
 import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
@@ -39,6 +41,7 @@ class InstalledAppInfoViewModel(
     private val originalApkRepository: OriginalApkRepository by inject()
     private val filesystem: Filesystem by inject()
     private val applicationScope: AppCoroutineScope by inject()
+    private val localApkSources: LocalApkSources by inject()
 
     lateinit var onBackClick: () -> Unit
     var onAppStateChanged: ((packageName: String) -> Unit)? = null
@@ -61,6 +64,8 @@ class InstalledAppInfoViewModel(
     var hasOriginalApk by mutableStateOf(false)
         private set
     var isAppDeleted by mutableStateOf(false)
+        private set
+    var isInstallStateUnknown by mutableStateOf(false)
         private set
     var isLoading by mutableStateOf(true)
         private set
@@ -233,28 +238,38 @@ class InstalledAppInfoViewModel(
             filesystem.getPatchedAppFile(target.currentPackageName, target.version),
             filesystem.getPatchedAppFile(target.originalPackageName, target.version)
         ).distinct()
-        return candidates.firstOrNull { it.exists() && it.length() > 0 }
+        return candidates.firstOrNull {
+            pm.isUsableApk(it, target.version, target.currentPackageName, target.originalPackageName)
+        }
     }
 
     private suspend fun refreshAppState(app: InstalledApp) {
         val installedInfo = withContext(Dispatchers.IO) {
             pm.getPackageInfo(app.currentPackageName)
         }
-        hasSavedCopy = withContext(Dispatchers.IO) { savedApkFile(app) != null }
+        val savedFile = withContext(Dispatchers.IO) { savedApkFile(app) }
+        hasSavedCopy = savedFile != null
 
-        if (installedInfo != null) {
+        val trackedPatchState = if (app.installType == InstallType.SAVED) {
+            null
+        } else {
+            withContext(Dispatchers.IO) { localApkSources.trackedPatchState(app) }
+        }
+
+        if (installedInfo != null && trackedPatchState == InstalledPatchState.Patched) {
             isInstalledOnDevice = true
             isAppDeleted = false
+            isInstallStateUnknown = false
             appInfo = installedInfo
         } else {
             isInstalledOnDevice = false
-            // App is deleted if it was installed on device but now missing
-            isAppDeleted = pm.isAppDeleted(
-                packageName = app.currentPackageName,
-                wasInstalledOnDevice = app.installType != InstallType.SAVED
-            )
+            // A missing or stock package means the tracked patched build is gone. Unknown is kept
+            // separate so the UI stays honest while still withholding destructive app actions.
+            isAppDeleted = app.installType != InstallType.SAVED &&
+                    (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
+            isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
             appInfo = withContext(Dispatchers.IO) {
-                savedApkFile(app)?.let(pm::getPackageInfo)
+                savedFile?.let(pm::getPackageInfo)
             }
         }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -134,7 +134,8 @@ class InstalledAppInfoViewModel(
                 if (localApkSources.trackedPatchState(app) == InstalledPatchState.Patched) {
                     pm.launch(app.currentPackageName)
                 } else {
-                    // The dialog was opened before the package changed underneath it
+                    // Covers both a package replaced under an open dialog and one whose identity
+                    // cannot be established, so the message must not claim which of the two it is
                     context.toast(context.getString(R.string.launch_app_unverified))
                     refreshAppState(app)
                     onAppStateChanged?.invoke(app.currentPackageName)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -134,6 +134,8 @@ class InstalledAppInfoViewModel(
                 if (localApkSources.trackedPatchState(app) == InstalledPatchState.Patched) {
                     pm.launch(app.currentPackageName)
                 } else {
+                    // The dialog was opened before the package changed underneath it
+                    context.toast(context.getString(R.string.launch_app_unverified))
                     refreshAppState(app)
                     onAppStateChanged?.invoke(app.currentPackageName)
                 }
@@ -154,6 +156,7 @@ class InstalledAppInfoViewModel(
                 viewModelScope.launch {
                     try {
                         if (localApkSources.trackedPatchState(app) != InstalledPatchState.Patched) {
+                            context.toast(context.getString(R.string.uninstall_app_unverified))
                             refreshAppState(app)
                             onAppStateChanged?.invoke(app.currentPackageName)
                             return@launch
@@ -169,14 +172,9 @@ class InstalledAppInfoViewModel(
                 }
             }
 
+            // No verification gate: unmounting only removes the bind mount and the module files,
+            // so it never touches whichever package currently owns the name
             InstallType.MOUNT -> applicationScope.launch {
-                if (localApkSources.trackedPatchState(app) != InstalledPatchState.Patched) {
-                    withContext(Dispatchers.Main) {
-                        refreshAppState(app)
-                        onAppStateChanged?.invoke(app.currentPackageName)
-                    }
-                    return@launch
-                }
                 // Detached from viewModelScope: dialog dismissal must not abort the cleanup
                 rootInstaller.uninstall(app.currentPackageName)
                 // Delete record and APK but preserve selection and options
@@ -235,6 +233,23 @@ class InstalledAppInfoViewModel(
         hasSavedCopy = false
     }
 
+    /**
+     * Both storage paths this app can occupy, minus any that another record owns.
+     * A rename leaves a copy under the original package name, but that same path is where a
+     * separate, unrenamed record would keep its own APK.
+     */
+    private suspend fun savedApkCandidates(app: InstalledApp): List<File> {
+        val paths = mutableListOf(filesystem.getPatchedAppFile(app.currentPackageName, app.version))
+
+        if (app.originalPackageName != app.currentPackageName &&
+            installedAppRepository.get(app.originalPackageName) == null
+        ) {
+            paths.add(filesystem.getPatchedAppFile(app.originalPackageName, app.version))
+        }
+
+        return paths.distinctBy { it.absolutePath }
+    }
+
     suspend fun updateInstallType(packageName: String, newInstallType: InstallType) {
         val app = installedApp ?: return
         // Update in database
@@ -255,12 +270,6 @@ class InstalledAppInfoViewModel(
 
     fun savedApkFile(): File? = usableSavedApk
 
-    private fun savedApkCandidates(app: InstalledApp): List<File> =
-        listOf(
-            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
-            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }
-
     private suspend fun refreshAppState(app: InstalledApp) {
         val snapshot = localApkSources.trackedAppSnapshot(app)
         val installedInfo = snapshot.installedPackageInfo
@@ -280,9 +289,7 @@ class InstalledAppInfoViewModel(
             isAppDeleted = app.installType != InstallType.SAVED &&
                     (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
             isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
-            appInfo = withContext(Dispatchers.IO) {
-                usableSavedApk?.let(pm::getPackageInfo)
-            }
+            appInfo = snapshot.savedPatchedApkInfo
         }
 
         // Update mounted state

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -50,6 +50,7 @@ class InstalledAppInfoViewModel(
         private set
     var appInfo: PackageInfo? by mutableStateOf(null)
         private set
+    private var usableSavedApk: File? = null
 
     private val _appliedPatches = MutableStateFlow<PatchSelection?>(null)
     var appliedPatches: PatchSelection?
@@ -129,7 +130,14 @@ class InstalledAppInfoViewModel(
         if (app.installType == InstallType.SAVED) {
             context.toast(context.getString(R.string.saved_app_launch_unavailable))
         } else {
-            pm.launch(app.currentPackageName)
+            viewModelScope.launch {
+                if (localApkSources.trackedPatchState(app) == InstalledPatchState.Patched) {
+                    pm.launch(app.currentPackageName)
+                } else {
+                    refreshAppState(app)
+                    onAppStateChanged?.invoke(app.currentPackageName)
+                }
+            }
         }
     }
 
@@ -145,6 +153,11 @@ class InstalledAppInfoViewModel(
             InstallType.SAVED -> {
                 viewModelScope.launch {
                     try {
+                        if (localApkSources.trackedPatchState(app) != InstalledPatchState.Patched) {
+                            refreshAppState(app)
+                            onAppStateChanged?.invoke(app.currentPackageName)
+                            return@launch
+                        }
                         installerManager.uninstallPackage(app.currentPackageName, app.installType)
                         refreshCurrentAppState()
                         onAppStateChanged?.invoke(app.currentPackageName)
@@ -157,6 +170,13 @@ class InstalledAppInfoViewModel(
             }
 
             InstallType.MOUNT -> applicationScope.launch {
+                if (localApkSources.trackedPatchState(app) != InstalledPatchState.Patched) {
+                    withContext(Dispatchers.Main) {
+                        refreshAppState(app)
+                        onAppStateChanged?.invoke(app.currentPackageName)
+                    }
+                    return@launch
+                }
                 // Detached from viewModelScope: dialog dismissal must not abort the cleanup
                 rootInstaller.uninstall(app.currentPackageName)
                 // Delete record and APK but preserve selection and options
@@ -211,6 +231,7 @@ class InstalledAppInfoViewModel(
         withContext(Dispatchers.IO) {
             savedApkCandidates(app).forEach { it.delete() }
         }
+        usableSavedApk = null
         hasSavedCopy = false
     }
 
@@ -232,12 +253,7 @@ class InstalledAppInfoViewModel(
         refreshAppState(app.copy(installType = newInstallType, currentPackageName = packageName))
     }
 
-    fun savedApkFile(app: InstalledApp? = this.installedApp): File? {
-        val target = app ?: return null
-        return savedApkCandidates(target).firstOrNull {
-            pm.isUsableApk(it, target.version, target.currentPackageName, target.originalPackageName)
-        }
-    }
+    fun savedApkFile(): File? = usableSavedApk
 
     private fun savedApkCandidates(app: InstalledApp): List<File> =
         listOf(
@@ -246,17 +262,11 @@ class InstalledAppInfoViewModel(
         ).distinctBy { it.absolutePath }
 
     private suspend fun refreshAppState(app: InstalledApp) {
-        val installedInfo = withContext(Dispatchers.IO) {
-            pm.getPackageInfo(app.currentPackageName)
-        }
-        val savedFile = withContext(Dispatchers.IO) { savedApkFile(app) }
-        hasSavedCopy = savedFile != null
-
-        val trackedPatchState = if (app.installType == InstallType.SAVED) {
-            null
-        } else {
-            withContext(Dispatchers.IO) { localApkSources.trackedPatchState(app) }
-        }
+        val snapshot = localApkSources.trackedAppSnapshot(app)
+        val installedInfo = snapshot.installedPackageInfo
+        usableSavedApk = snapshot.savedPatchedApk
+        hasSavedCopy = usableSavedApk != null
+        val trackedPatchState = snapshot.patchState
 
         if (installedInfo != null && trackedPatchState == InstalledPatchState.Patched) {
             isInstalledOnDevice = true
@@ -271,7 +281,7 @@ class InstalledAppInfoViewModel(
                     (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
             isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
             appInfo = withContext(Dispatchers.IO) {
-                savedFile?.let(pm::getPackageInfo)
+                usableSavedApk?.let(pm::getPackageInfo)
             }
         }
 

--- a/app/src/main/java/app/morphe/manager/util/Constants.kt
+++ b/app/src/main/java/app/morphe/manager/util/Constants.kt
@@ -126,6 +126,12 @@ object KnownApps {
  */
 val BATCH_UNINSTALL_TIMEOUT: Duration = 2.minutes
 
+/**
+ * Window used to collect package add, remove and replace broadcasts into a single home refresh.
+ * A store updating several apps emits them in bursts, and each refresh re-inspects tracked apps.
+ */
+const val PACKAGE_CHANGE_DEBOUNCE_MS = 400L
+
 const val APK_MIMETYPE  = "application/vnd.android.package-archive"
 
 const val PLAY_STORE_INSTALLER_PACKAGE = "com.android.vending"

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -245,6 +245,26 @@ class PM(
         }
     }
 
+    /**
+     * Whether [file] is a signed APK for [version] and one of [packageNames].
+     *
+     * A path alone is not a usable saved copy: an interrupted write, corrupt archive or stale
+     * file for another package/version must not enable install, export or mount actions.
+     */
+    fun isUsableApk(file: File, version: String, vararg packageNames: String): Boolean {
+        if (!file.isFile) return false
+        return try {
+            val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
+                ?: return false
+            info.packageName in packageNames &&
+                    info.versionName == version &&
+                    !info.extractSignatures().isNullOrEmpty()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to validate APK file: ${file.absolutePath}", e)
+            false
+        }
+    }
+
     @Suppress("DEPRECATION")
     private fun signingFlags() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
         PackageManager.GET_SIGNING_CERTIFICATES
@@ -268,14 +288,6 @@ class PM(
             digest.reset()
             digest.digest(sig.toByteArray()).joinToString("") { b -> "%02x".format(b) }
         }
-    }
-
-    /**
-     * Whether a tracked app that was installed on the device is now gone.
-     */
-    fun isAppDeleted(packageName: String, wasInstalledOnDevice: Boolean): Boolean {
-        val currentlyInstalled = getPackageInfo(packageName) != null
-        return !currentlyInstalled && wasInstalledOnDevice
     }
 
     private fun cleanLabel(raw: String, packageName: String): String {

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -40,6 +40,10 @@ class PM(
     private companion object {
         const val TAG = "Morphe PM"
 
+        // Certificate extraction verifies the whole archive, so repeating it for every home
+        // refresh is the single most expensive thing this class can do.
+        const val SIGNATURE_CACHE_ENTRIES = 64
+
         // Other managers whose installs are always patched.
         // Morphe's own id comes from the application at runtime so debug builds are covered too.
         val PATCH_MANAGER_PACKAGES = setOf(
@@ -50,6 +54,13 @@ class PM(
             "app.universal.revanced.manager"
         )
     }
+
+    // Keyed by size and timestamp as well as path, so a rewritten APK never returns a stale answer
+    private val archiveSignatureCache =
+        object : LinkedHashMap<String, Set<String>>(0, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Set<String>>) =
+                size > SIGNATURE_CACHE_ENTRIES
+        }
 
     val application: Application get() = app
 
@@ -193,7 +204,7 @@ class PM(
     /** Certificate fingerprints the package manager holds for [packageName], without disk access. */
     private fun recordedSignatureHashes(packageName: String): Set<String> =
         try {
-            getPackageInfo(packageName, signingFlags())?.extractSignatures()?.toSha256Hashes().orEmpty()
+            getPackageInfo(packageName, signingFlags())?.let(::signatureHashes).orEmpty()
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read installed signatures for $packageName", e)
             emptySet()
@@ -220,8 +231,12 @@ class PM(
      * Reinstalling from another source (Play, a store, adb) replaces the installer, so this does
      * not linger after the user goes back to the original app.
      */
-    fun isInstalledByPatchManager(packageName: String): Boolean {
-        val installer = getInstallerPackageName(packageName) ?: return false
+    fun isInstalledByPatchManager(packageName: String): Boolean =
+        isPatchManagerInstaller(getInstallerPackageName(packageName))
+
+    /** [isInstalledByPatchManager] for callers that already resolved the installer. */
+    fun isPatchManagerInstaller(installer: String?): Boolean {
+        if (installer == null) return false
         return installer == app.packageName || installer in PATCH_MANAGER_PACKAGES
     }
 
@@ -231,6 +246,9 @@ class PM(
      * Uses full signing history to handle apps with certificate rotation.
      */
     fun getApkFileSignatureHashes(file: File): Set<String> {
+        val key = signatureCacheKey(file) ?: return emptySet()
+        cachedSignatureHashes(key)?.let { return it }
+
         return try {
             val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
                 ?: return emptySet()
@@ -238,7 +256,7 @@ class PM(
                 sourceDir = file.absolutePath
                 publicSourceDir = file.absolutePath
             }
-            info.extractSignatures()?.toSha256Hashes() ?: emptySet()
+            signatureHashes(info).also { cacheSignatureHashes(key, it) }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read APK file signatures", e)
             emptySet()
@@ -246,23 +264,53 @@ class PM(
     }
 
     /**
-     * Whether [file] is a signed APK for [version] and one of [packageNames].
+     * Parsed [file] when it is a signed APK belonging to one of [packageNames], or null otherwise.
      *
-     * A path alone is not a usable saved copy: an interrupted write, corrupt archive or stale
-     * file for another package/version must not enable install, export or mount actions.
+     * A path alone is not a usable saved copy: an interrupted write, corrupt archive or a file
+     * left behind by another package must not enable install, export or mount actions. The
+     * version is deliberately not compared, because patches are free to rewrite `versionName`
+     * while the file keeps the name it was saved under.
+     *
+     * The parse is shared with [getApkFileSignatureHashes] so callers that need both the identity
+     * and the certificates pay for the archive only once.
      */
-    fun isUsableApk(file: File, version: String, vararg packageNames: String): Boolean {
-        if (!file.isFile) return false
+    fun readSavedApkInfo(file: File, vararg packageNames: String): PackageInfo? {
+        if (!file.isFile) return null
         return try {
             val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
-                ?: return false
-            info.packageName in packageNames &&
-                    info.versionName == version &&
-                    !info.extractSignatures().isNullOrEmpty()
+                ?: return null
+            if (info.packageName !in packageNames) return null
+
+            val hashes = signatureHashes(info)
+            if (hashes.isEmpty()) return null
+
+            signatureCacheKey(file)?.let { cacheSignatureHashes(it, hashes) }
+            // Needed by callers that read the label or icon straight off the archive
+            info.applicationInfo?.apply {
+                sourceDir = file.absolutePath
+                publicSourceDir = file.absolutePath
+            }
+            info
         } catch (e: Exception) {
             Log.e(TAG, "Failed to validate APK file: ${file.absolutePath}", e)
-            false
+            null
         }
+    }
+
+    /** SHA-256 certificate fingerprints of an already parsed [packageInfo]. */
+    fun signatureHashes(packageInfo: PackageInfo): Set<String> =
+        packageInfo.extractSignatures()?.toSha256Hashes().orEmpty()
+
+    private fun signatureCacheKey(file: File): String? {
+        if (!file.isFile) return null
+        return "${file.absolutePath}:${file.length()}:${file.lastModified()}"
+    }
+
+    private fun cachedSignatureHashes(key: String): Set<String>? =
+        synchronized(archiveSignatureCache) { archiveSignatureCache[key] }
+
+    private fun cacheSignatureHashes(key: String, hashes: Set<String>) {
+        synchronized(archiveSignatureCache) { archiveSignatureCache[key] = hashes }
     }
 
     @Suppress("DEPRECATION")

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -264,25 +264,30 @@ class PM(
     }
 
     /**
-     * Parsed [file] when it is a signed APK belonging to one of [packageNames], or null otherwise.
+     * Parsed [file] when it is the signed APK the record describes, or null otherwise.
      *
      * A path alone is not a usable saved copy: an interrupted write, corrupt archive or a file
-     * left behind by another package must not enable install, export or mount actions. The
-     * version is deliberately not compared, because patches are free to rewrite `versionName`
-     * while the file keeps the name it was saved under.
+     * left behind by another package or version must not enable install, export or mount actions,
+     * and must never stand in as the certificate that proves an install is the patched build.
      *
      * The parse is shared with [getApkFileSignatureHashes] so callers that need both the identity
      * and the certificates pay for the archive only once.
      */
-    fun readSavedApkInfo(file: File, vararg packageNames: String): PackageInfo? {
+    fun readSavedApkInfo(file: File, version: String, vararg packageNames: String): PackageInfo? {
         if (!file.isFile) return null
         return try {
             val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
                 ?: return null
-            if (info.packageName !in packageNames) return null
 
             val hashes = signatureHashes(info)
-            if (hashes.isEmpty()) return null
+            val matches = matchesSavedApkRecord(
+                archivePackageName = info.packageName,
+                archiveVersionName = info.versionName,
+                isSigned = hashes.isNotEmpty(),
+                trackedPackageNames = packageNames.asList(),
+                trackedVersion = version
+            )
+            if (!matches) return null
 
             signatureCacheKey(file)?.let { cacheSignatureHashes(it, hashes) }
             // Needed by callers that read the label or icon straight off the archive
@@ -350,6 +355,25 @@ class PM(
         return candidate.ifBlank { trimmed }
     }
 }
+
+/**
+ * Whether a parsed archive is the artifact a saved-APK record describes.
+ *
+ * The version is compared rather than inferred from the file name: the patcher persists the
+ * version it produced both as the record's version and in the retained file name, so an archive
+ * that reports a different one is not the build the record was written for. Accepting it would
+ * hand its certificate to the tracked-install check as proof that an install is patched.
+ */
+internal fun matchesSavedApkRecord(
+    archivePackageName: String?,
+    archiveVersionName: String?,
+    isSigned: Boolean,
+    trackedPackageNames: Collection<String>,
+    trackedVersion: String
+): Boolean =
+    isSigned &&
+            archivePackageName in trackedPackageNames &&
+            archiveVersionName == trackedVersion
 
 fun File.sha256OrNull(): String? = runCatching {
     if (!isFile) return@runCatching null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -535,8 +535,8 @@ Uninstalling will permanently erase all app data"</string>
     <string name="install_app_success">Installed successfully</string>
     <string name="install_app_fail">Failed to install app: %s</string>
     <string name="uninstall_app_fail">Failed to uninstall app: %s</string>
-    <string name="uninstall_app_unverified">Left in place: the installed app is no longer the patched build Morphe tracked</string>
-    <string name="launch_app_unverified">The installed app is no longer the patched build Morphe tracked</string>
+    <string name="uninstall_app_unverified">Left in place: Morphe could not verify that the installed app is the build it patched</string>
+    <string name="launch_app_unverified">Morphe could not verify that the installed app is the build it patched</string>
     <string name="uninstall_timeout">Uninstall timed out</string>
     <string name="save_apk_success">APK Saved</string>
     <string name="saved_app_export_failed">Failed to export patched app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="home_apk_use_saved">Use saved APK</string>
     <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_apk_use_installed_unverified">Could not verify the signature of the installed app, so it may already be patched</string>
+    <string name="home_unverified">Unverified</string>
     <string name="home_app_info_no_saved_apk">No saved APK. Patching will require selecting the APK file again</string>
     <string name="home_version_requires_android">Requires Android %s+</string>
     <string name="home_apk_no_compatible_versions_title">Not supported on this device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_apk_use_installed_unverified">Could not verify the signature of the installed app, so it may already be patched</string>
     <string name="home_unverified">Unverified</string>
+    <string name="home_app_info_install_unverified">Morphe cannot confirm that the installed app is the build it patched. Reinstall it from the saved APK to restore its actions</string>
     <string name="home_app_info_no_saved_apk">No saved APK. Patching will require selecting the APK file again</string>
     <string name="home_version_requires_android">Requires Android %s+</string>
     <string name="home_apk_no_compatible_versions_title">Not supported on this device</string>
@@ -530,6 +531,8 @@ Uninstalling will permanently erase all app data"</string>
     <string name="install_app_success">Installed successfully</string>
     <string name="install_app_fail">Failed to install app: %s</string>
     <string name="uninstall_app_fail">Failed to uninstall app: %s</string>
+    <string name="uninstall_app_unverified">Left in place: the installed app is no longer the patched build Morphe tracked</string>
+    <string name="launch_app_unverified">The installed app is no longer the patched build Morphe tracked</string>
     <string name="uninstall_timeout">Uninstall timed out</string>
     <string name="save_apk_success">APK Saved</string>
     <string name="saved_app_export_failed">Failed to export patched app</string>

--- a/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.apk
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TrackedPatchStateResolverTest {
+    @Test
+    fun `saved patched certificate identifies the tracked install`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolveTrackedPatchState(
+                installedHashes = setOf("patched"),
+                savedPatchedHashes = setOf("patched"),
+                originalHashes = setOf("stock"),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `different certificate from saved patched APK is a replacement`() {
+        assertEquals(
+            InstalledPatchState.NotPatched,
+            resolveTrackedPatchState(
+                installedHashes = setOf("stock"),
+                savedPatchedHashes = setOf("patched"),
+                originalHashes = emptySet(),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `original certificate identifies a stock reinstall`() {
+        assertEquals(
+            InstalledPatchState.NotPatched,
+            resolveTrackedPatchState(
+                installedHashes = setOf("stock"),
+                savedPatchedHashes = emptySet(),
+                originalHashes = setOf("stock"),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `certificate different from original identifies a patched install`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolveTrackedPatchState(
+                installedHashes = setOf("patched"),
+                savedPatchedHashes = emptySet(),
+                originalHashes = setOf("stock"),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `patch manager installer is a fallback when certificates are unavailable`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolveTrackedPatchState(
+                installedHashes = emptySet(),
+                savedPatchedHashes = emptySet(),
+                originalHashes = emptySet(),
+                installedByPatchManager = true
+            )
+        )
+    }
+
+    @Test
+    fun `unverified same-name package is not assumed patched`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolveTrackedPatchState(
+                installedHashes = emptySet(),
+                savedPatchedHashes = emptySet(),
+                originalHashes = setOf("stock"),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `unrecognized certificate without references remains unknown`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolveTrackedPatchState(
+                installedHashes = setOf("unrecognized"),
+                savedPatchedHashes = emptySet(),
+                originalHashes = emptySet(),
+                installedByPatchManager = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
@@ -9,15 +9,30 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TrackedPatchStateResolverTest {
+    private fun resolve(
+        installedHashes: Set<String> = emptySet(),
+        savedPatchedHashes: Set<String> = emptySet(),
+        originalHashes: Set<String> = emptySet(),
+        installedByPatchManager: Boolean = false,
+        installerAttributionMatches: Boolean = true,
+        installedAfterPatching: Boolean = false
+    ) = resolveTrackedPatchState(
+        installedHashes = installedHashes,
+        savedPatchedHashes = savedPatchedHashes,
+        originalHashes = originalHashes,
+        installedByPatchManager = installedByPatchManager,
+        installerAttributionMatches = installerAttributionMatches,
+        installedAfterPatching = installedAfterPatching
+    )
+
     @Test
     fun `saved patched certificate identifies the tracked install`() {
         assertEquals(
             InstalledPatchState.Patched,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("patched"),
                 savedPatchedHashes = setOf("patched"),
-                originalHashes = setOf("stock"),
-                installedByPatchManager = false
+                originalHashes = setOf("stock")
             )
         )
     }
@@ -26,11 +41,9 @@ class TrackedPatchStateResolverTest {
     fun `different certificate from saved patched APK remains unknown`() {
         assertEquals(
             InstalledPatchState.Unknown,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("unrecognized"),
-                savedPatchedHashes = setOf("patched"),
-                originalHashes = emptySet(),
-                installedByPatchManager = false
+                savedPatchedHashes = setOf("patched")
             )
         )
     }
@@ -39,11 +52,9 @@ class TrackedPatchStateResolverTest {
     fun `original certificate identifies a stock reinstall`() {
         assertEquals(
             InstalledPatchState.NotPatched,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("stock"),
-                savedPatchedHashes = emptySet(),
-                originalHashes = setOf("stock"),
-                installedByPatchManager = false
+                originalHashes = setOf("stock")
             )
         )
     }
@@ -52,11 +63,10 @@ class TrackedPatchStateResolverTest {
     fun `saved original certificate identifies stock when patched certificate differs`() {
         assertEquals(
             InstalledPatchState.NotPatched,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("stock"),
                 savedPatchedHashes = setOf("patched"),
-                originalHashes = setOf("stock"),
-                installedByPatchManager = false
+                originalHashes = setOf("stock")
             )
         )
     }
@@ -65,11 +75,9 @@ class TrackedPatchStateResolverTest {
     fun `certificate different from original remains unknown`() {
         assertEquals(
             InstalledPatchState.Unknown,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("unrecognized"),
-                savedPatchedHashes = emptySet(),
-                originalHashes = setOf("stock"),
-                installedByPatchManager = false
+                originalHashes = setOf("stock")
             )
         )
     }
@@ -78,12 +86,7 @@ class TrackedPatchStateResolverTest {
     fun `patch manager installer is a fallback when certificates are unavailable`() {
         assertEquals(
             InstalledPatchState.Patched,
-            resolveTrackedPatchState(
-                installedHashes = emptySet(),
-                savedPatchedHashes = emptySet(),
-                originalHashes = emptySet(),
-                installedByPatchManager = true
-            )
+            resolve(installedByPatchManager = true)
         )
     }
 
@@ -91,7 +94,7 @@ class TrackedPatchStateResolverTest {
     fun `patch manager installer identifies patched install when certificates differ`() {
         assertEquals(
             InstalledPatchState.Patched,
-            resolveTrackedPatchState(
+            resolve(
                 installedHashes = setOf("patched"),
                 savedPatchedHashes = setOf("old-patched"),
                 originalHashes = setOf("stock"),
@@ -104,12 +107,7 @@ class TrackedPatchStateResolverTest {
     fun `unverified same-name package is not assumed patched`() {
         assertEquals(
             InstalledPatchState.Unknown,
-            resolveTrackedPatchState(
-                installedHashes = emptySet(),
-                savedPatchedHashes = emptySet(),
-                originalHashes = setOf("stock"),
-                installedByPatchManager = false
-            )
+            resolve(originalHashes = setOf("stock"))
         )
     }
 
@@ -117,11 +115,68 @@ class TrackedPatchStateResolverTest {
     fun `unrecognized certificate without references remains unknown`() {
         assertEquals(
             InstalledPatchState.Unknown,
-            resolveTrackedPatchState(
+            resolve(installedHashes = setOf("unrecognized"))
+        )
+    }
+
+    @Test
+    fun `foreign installer on an installation newer than the patch identifies a replacement`() {
+        assertEquals(
+            InstalledPatchState.NotPatched,
+            resolve(
                 installedHashes = setOf("unrecognized"),
-                savedPatchedHashes = emptySet(),
-                originalHashes = emptySet(),
-                installedByPatchManager = false
+                installerAttributionMatches = false,
+                installedAfterPatching = true
+            )
+        )
+    }
+
+    @Test
+    fun `foreign installer alone does not identify a replacement`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolve(
+                installedHashes = setOf("unrecognized"),
+                installerAttributionMatches = false,
+                installedAfterPatching = false
+            )
+        )
+    }
+
+    @Test
+    fun `expected attribution keeps a newer installation unknown`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolve(
+                installedHashes = setOf("unrecognized"),
+                installerAttributionMatches = true,
+                installedAfterPatching = true
+            )
+        )
+    }
+
+    @Test
+    fun `patch manager attribution outweighs a newer installation`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolve(
+                installedHashes = setOf("patched"),
+                installedByPatchManager = true,
+                installerAttributionMatches = false,
+                installedAfterPatching = true
+            )
+        )
+    }
+
+    @Test
+    fun `saved patched certificate outweighs a foreign newer installation`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolve(
+                installedHashes = setOf("patched"),
+                savedPatchedHashes = setOf("patched"),
+                installerAttributionMatches = false,
+                installedAfterPatching = true
             )
         )
     }

--- a/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
@@ -23,11 +23,11 @@ class TrackedPatchStateResolverTest {
     }
 
     @Test
-    fun `different certificate from saved patched APK is a replacement`() {
+    fun `different certificate from saved patched APK remains unknown`() {
         assertEquals(
-            InstalledPatchState.NotPatched,
+            InstalledPatchState.Unknown,
             resolveTrackedPatchState(
-                installedHashes = setOf("stock"),
+                installedHashes = setOf("unrecognized"),
                 savedPatchedHashes = setOf("patched"),
                 originalHashes = emptySet(),
                 installedByPatchManager = false
@@ -49,11 +49,24 @@ class TrackedPatchStateResolverTest {
     }
 
     @Test
-    fun `certificate different from original identifies a patched install`() {
+    fun `saved original certificate identifies stock when patched certificate differs`() {
         assertEquals(
-            InstalledPatchState.Patched,
+            InstalledPatchState.NotPatched,
             resolveTrackedPatchState(
-                installedHashes = setOf("patched"),
+                installedHashes = setOf("stock"),
+                savedPatchedHashes = setOf("patched"),
+                originalHashes = setOf("stock"),
+                installedByPatchManager = false
+            )
+        )
+    }
+
+    @Test
+    fun `certificate different from original remains unknown`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolveTrackedPatchState(
+                installedHashes = setOf("unrecognized"),
                 savedPatchedHashes = emptySet(),
                 originalHashes = setOf("stock"),
                 installedByPatchManager = false
@@ -69,6 +82,19 @@ class TrackedPatchStateResolverTest {
                 installedHashes = emptySet(),
                 savedPatchedHashes = emptySet(),
                 originalHashes = emptySet(),
+                installedByPatchManager = true
+            )
+        )
+    }
+
+    @Test
+    fun `patch manager installer identifies patched install when certificates differ`() {
+        assertEquals(
+            InstalledPatchState.Patched,
+            resolveTrackedPatchState(
+                installedHashes = setOf("patched"),
+                savedPatchedHashes = setOf("old-patched"),
+                originalHashes = setOf("stock"),
                 installedByPatchManager = true
             )
         )

--- a/app/src/test/java/app/morphe/manager/domain/apk/TrackedRecordCleanupTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/TrackedRecordCleanupTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.apk
+
+import app.morphe.manager.data.room.apps.installed.InstallType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TrackedRecordCleanupTest {
+    private fun canRemove(
+        installType: InstallType = InstallType.DEFAULT,
+        patchState: InstalledPatchState? = InstalledPatchState.Patched,
+        hasSavedApk: Boolean = false
+    ) = canRemoveTrackedRecord(
+        installType = installType,
+        patchState = patchState,
+        hasSavedApk = hasSavedApk
+    )
+
+    @Test
+    fun `unverified install with nothing retained can still be cleaned up`() {
+        assertTrue(canRemove(patchState = InstalledPatchState.Unknown))
+    }
+
+    @Test
+    fun `unverified install with a retained APK can be cleaned up`() {
+        assertTrue(canRemove(patchState = InstalledPatchState.Unknown, hasSavedApk = true))
+    }
+
+    @Test
+    fun `replaced install can be cleaned up`() {
+        assertTrue(canRemove(patchState = InstalledPatchState.NotPatched))
+    }
+
+    @Test
+    fun `record without an installed package can be cleaned up`() {
+        assertTrue(canRemove(patchState = null))
+    }
+
+    @Test
+    fun `confirmed patched install with nothing retained has nothing to clean up`() {
+        assertFalse(canRemove(patchState = InstalledPatchState.Patched))
+    }
+
+    @Test
+    fun `confirmed patched install offers cleanup once an APK is retained`() {
+        assertTrue(canRemove(patchState = InstalledPatchState.Patched, hasSavedApk = true))
+    }
+
+    @Test
+    fun `saved records are cleanable regardless of the resolved state`() {
+        assertTrue(
+            canRemove(
+                installType = InstallType.SAVED,
+                patchState = InstalledPatchState.Patched
+            )
+        )
+    }
+}

--- a/app/src/test/java/app/morphe/manager/util/PatchSelectionExtensionsTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/PatchSelectionExtensionsTest.kt
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.util
+
+import app.morphe.manager.data.room.apps.installed.SelectionPayload
+import app.morphe.manager.domain.bundles.LocalPatchBundle
+import app.morphe.manager.domain.bundles.PatchBundleSource
+import app.morphe.manager.patcher.patch.Option
+import app.morphe.manager.patcher.patch.PatchInfo
+import app.morphe.manager.util.PatchSelectionUtils.applyAvailability
+import app.morphe.manager.util.PatchSelectionUtils.resetOptionsForPatch
+import app.morphe.manager.util.PatchSelectionUtils.sanitizeForPatcher
+import app.morphe.manager.util.PatchSelectionUtils.togglePatch
+import app.morphe.manager.util.PatchSelectionUtils.updateOption
+import app.morphe.manager.util.PatchSelectionUtils.validatePatchOptions
+import app.morphe.manager.util.PatchSelectionUtils.validatePatchSelection
+import app.morphe.patcher.patch.ApkArchitecture
+import app.morphe.patcher.patch.AvailabilityResolver
+import app.morphe.patcher.patch.InstallerType
+import app.morphe.patcher.patch.PatchAvailability
+import kotlinx.collections.immutable.toImmutableList
+import java.io.File
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * These functions decide what actually ends up in a patched APK, so a regression here produces a
+ * wrong build rather than a visible failure.
+ */
+class PatchSelectionExtensionsTest {
+    private val installer = InstallerType.STANDARD
+    private val architecture = ApkArchitecture.ARM64_V8A
+
+    private fun option(key: String) = Option(
+        title = key,
+        key = key,
+        description = "",
+        required = false,
+        type = typeOf<String>(),
+        default = null,
+        presets = null,
+        validator = { true }
+    )
+
+    private fun patch(
+        name: String,
+        options: List<Option<*>>? = null,
+        availability: AvailabilityResolver? = null
+    ) = PatchInfo(
+        name = name,
+        description = null,
+        include = true,
+        compatiblePackages = null,
+        options = options?.toImmutableList(),
+        availabilityResolver = availability
+    )
+
+    private fun source(uid: Int): PatchBundleSource = LocalPatchBundle(
+        name = "bundle-$uid",
+        uid = uid,
+        displayName = null,
+        createdAt = null,
+        updatedAt = null,
+        error = null,
+        // Never read: an absent patches.jar simply leaves the source in its missing state
+        directory = File("build/tmp/patch-bundle-$uid"),
+        enabled = true
+    )
+
+    private fun payload(vararg bundles: Pair<Int, List<String>>) = SelectionPayload(
+        bundles = bundles.map { (uid, patches) ->
+            SelectionPayload.BundleSelection(bundleUid = uid, patches = patches)
+        }
+    )
+
+    @Test
+    fun `payload conversion drops blank names and empty bundles`() {
+        val selection = payload(
+            0 to listOf("Patch A", "", "Patch B"),
+            1 to emptyList()
+        ).toPatchSelection()
+
+        assertEquals(mapOf(0 to setOf("Patch A", "Patch B")), selection)
+    }
+
+    @Test
+    fun `remapping keeps only bundles that still have a source`() {
+        val (remapped, selection) = payload(
+            0 to listOf("Patch A"),
+            2 to listOf("Patch B"),
+            5 to listOf("Patch C")
+        ).remapAndExtractSelection(listOf(source(0), source(2)))
+
+        assertEquals(listOf(0, 2), remapped.bundles.map { it.bundleUid })
+        assertEquals(
+            mapOf(
+                0 to setOf("Patch A"),
+                2 to setOf("Patch B")
+            ),
+            selection
+        )
+    }
+
+    @Test
+    fun `remapping returns an empty selection when no source matches`() {
+        val (remapped, selection) = payload(5 to listOf("Patch B"))
+            .remapAndExtractSelection(listOf(source(0)))
+
+        assertEquals(emptyList(), remapped.bundles)
+        assertEquals(emptyMap(), selection)
+    }
+
+    @Test
+    fun `toggling adds to a bundle that is not in the selection yet`() {
+        assertEquals(
+            mapOf(0 to setOf("Patch A")),
+            emptyMap<Int, Set<String>>().togglePatch(0, "Patch A")
+        )
+    }
+
+    @Test
+    fun `toggling the last patch off removes the bundle entry`() {
+        assertEquals(
+            emptyMap(),
+            mapOf(0 to setOf("Patch A")).togglePatch(0, "Patch A")
+        )
+        assertEquals(
+            mapOf(0 to setOf("Patch B")),
+            mapOf(0 to setOf("Patch A", "Patch B")).togglePatch(0, "Patch A")
+        )
+    }
+
+    @Test
+    fun `an option value is stored under its bundle and patch`() {
+        assertEquals(
+            mapOf(0 to mapOf("Patch A" to mapOf("key" to "value"))),
+            emptyMap<Int, Map<String, Map<String, Any?>>>().updateOption(0, "Patch A", "key", "value")
+        )
+    }
+
+    @Test
+    fun `clearing a field keeps the key so the default is not re-injected`() {
+        assertEquals(
+            mapOf(0 to mapOf("Patch A" to mapOf("key" to ""))),
+            emptyMap<Int, Map<String, Map<String, Any?>>>().updateOption(0, "Patch A", "key", "")
+        )
+    }
+
+    @Test
+    fun `resetting a single option prunes the maps it leaves empty`() {
+        val options = mapOf(0 to mapOf("Patch A" to mapOf("key" to "value")))
+
+        assertEquals(emptyMap(), options.updateOption(0, "Patch A", "key", null))
+    }
+
+    @Test
+    fun `resetting one option keeps the others`() {
+        val options = mapOf(0 to mapOf("Patch A" to mapOf("kept" to "value", "gone" to "value")))
+
+        assertEquals(
+            mapOf(0 to mapOf("Patch A" to mapOf("kept" to "value"))),
+            options.updateOption(0, "Patch A", "gone", null)
+        )
+    }
+
+    @Test
+    fun `blank strings are stripped before the options reach the patcher`() {
+        val options = mapOf(
+            0 to mapOf(
+                "Patch A" to mapOf("cleared" to "", "blank" to "   ", "kept" to "value"),
+                "Patch B" to mapOf("cleared" to "")
+            )
+        )
+
+        assertEquals(
+            mapOf(0 to mapOf("Patch A" to mapOf("kept" to "value"))),
+            options.sanitizeForPatcher()
+        )
+    }
+
+    @Test
+    fun `sanitizing keeps values that are not strings`() {
+        val options = mapOf(0 to mapOf("Patch A" to mapOf("flag" to true, "count" to 0)))
+
+        assertEquals(options, options.sanitizeForPatcher())
+    }
+
+    @Test
+    fun `resetting a patch removes its options and prunes the bundle`() {
+        val options = mapOf(0 to mapOf("Patch A" to mapOf("key" to "value")))
+
+        assertEquals(emptyMap(), options.resetOptionsForPatch(0, "Patch A"))
+    }
+
+    @Test
+    fun `resetting a patch of an unknown bundle changes nothing`() {
+        val options: Options = mapOf(0 to mapOf("Patch A" to mapOf("key" to "value")))
+
+        assertSame(options, options.resetOptionsForPatch(5, "Patch A"))
+    }
+
+    @Test
+    fun `validation drops bundles and patches that no longer exist`() {
+        val selection = mapOf(
+            0 to setOf("Patch A", "Removed patch"),
+            1 to setOf("Patch B"),
+            5 to setOf("Patch C")
+        )
+        val bundles = mapOf(
+            0 to mapOf("Patch A" to patch("Patch A")),
+            1 to mapOf("Other patch" to patch("Other patch"))
+        )
+
+        assertEquals(mapOf(0 to setOf("Patch A")), validatePatchSelection(selection, bundles))
+    }
+
+    @Test
+    fun `option validation drops unknown bundles patches and keys`() {
+        val options = mapOf(
+            0 to mapOf(
+                "Patch A" to mapOf("known" to "value", "unknown" to "value"),
+                "Removed patch" to mapOf("known" to "value")
+            ),
+            5 to mapOf("Patch A" to mapOf("known" to "value"))
+        )
+        // The patch also declares an option the user never set, which must not be invented here
+        val bundles = mapOf(
+            0 to mapOf(
+                "Patch A" to patch(
+                    name = "Patch A",
+                    options = listOf(option("known"), option("untouched"))
+                )
+            )
+        )
+
+        assertEquals(
+            mapOf(0 to mapOf("Patch A" to mapOf("known" to "value"))),
+            validatePatchOptions(options, bundles)
+        )
+    }
+
+    @Test
+    fun `a required patch is added even when the user did not pick it`() {
+        val bundles = mapOf(
+            0 to mapOf(
+                "Required patch" to patch("Required patch") { _, _ -> PatchAvailability.REQUIRED }
+            )
+        )
+
+        assertEquals(
+            mapOf(0 to setOf("Required patch")),
+            emptyMap<Int, Set<String>>().applyAvailability(installer, architecture, bundles)
+        )
+    }
+
+    @Test
+    fun `an unavailable patch is removed even when the user did pick it`() {
+        val bundles = mapOf(
+            0 to mapOf(
+                "Blocked patch" to patch("Blocked patch") { _, _ -> PatchAvailability.UNAVAILABLE }
+            )
+        )
+
+        assertEquals(
+            emptyMap(),
+            mapOf(0 to setOf("Blocked patch")).applyAvailability(installer, architecture, bundles)
+        )
+    }
+
+    @Test
+    fun `availability leaves the user's choice alone when it is not forced`() {
+        val bundles = mapOf(
+            0 to mapOf(
+                "Enabled patch" to patch("Enabled patch") { _, _ -> PatchAvailability.ENABLED },
+                "Disabled patch" to patch("Disabled patch") { _, _ -> PatchAvailability.DISABLED },
+                "Plain patch" to patch("Plain patch")
+            )
+        )
+        val selection = mapOf(0 to setOf("Disabled patch", "Plain patch"))
+
+        assertEquals(selection, selection.applyAvailability(installer, architecture, bundles))
+    }
+
+    @Test
+    fun `availability resolves against the current installer`() {
+        val bundles = mapOf(
+            0 to mapOf(
+                "GmsCore support" to patch("GmsCore support") { installerType, _ ->
+                    if (installerType == InstallerType.MOUNT) {
+                        PatchAvailability.UNAVAILABLE
+                    } else {
+                        PatchAvailability.REQUIRED
+                    }
+                }
+            )
+        )
+        val selection = mapOf(0 to setOf("GmsCore support"))
+
+        assertEquals(
+            selection,
+            selection.applyAvailability(InstallerType.STANDARD, architecture, bundles)
+        )
+        assertEquals(
+            emptyMap(),
+            selection.applyAvailability(InstallerType.MOUNT, architecture, bundles)
+        )
+    }
+}

--- a/app/src/test/java/app/morphe/manager/util/SavedApkRecordTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/SavedApkRecordTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The accepted archive becomes the certificate that decides whether an installed package is the
+ * tracked patched build, so anything reaching this predicate has to be the artifact the record
+ * was written for and not merely a file sitting at the expected path.
+ */
+class SavedApkRecordTest {
+    private fun matches(
+        archivePackageName: String? = "app.morphe.target",
+        archiveVersionName: String? = "1.2.3",
+        isSigned: Boolean = true,
+        trackedPackageNames: Collection<String> = listOf("app.morphe.target"),
+        trackedVersion: String = "1.2.3"
+    ) = matchesSavedApkRecord(
+        archivePackageName = archivePackageName,
+        archiveVersionName = archiveVersionName,
+        isSigned = isSigned,
+        trackedPackageNames = trackedPackageNames,
+        trackedVersion = trackedVersion
+    )
+
+    @Test
+    fun `the recorded package and version are accepted`() {
+        assertTrue(matches())
+    }
+
+    @Test
+    fun `a renamed app accepts only its current package`() {
+        assertTrue(
+            matches(
+                archivePackageName = "app.morphe.target.renamed",
+                trackedPackageNames = listOf("app.morphe.target.renamed")
+            )
+        )
+        assertFalse(
+            matches(
+                archivePackageName = "app.morphe.target",
+                trackedPackageNames = listOf("app.morphe.target.renamed")
+            )
+        )
+    }
+
+    @Test
+    fun `an archive for another version is rejected`() {
+        assertFalse(matches(archiveVersionName = "1.2.4"))
+        assertFalse(matches(archiveVersionName = "1.2"))
+    }
+
+    @Test
+    fun `a version-rewriting patch still matches its own record`() {
+        // The patcher persists the version it produced, so a spoofed one is what the record holds
+        assertTrue(matches(archiveVersionName = "18.0.0", trackedVersion = "18.0.0"))
+    }
+
+    @Test
+    fun `an unsigned or unreadable archive is rejected`() {
+        assertFalse(matches(isSigned = false))
+        assertFalse(matches(archivePackageName = null))
+        assertFalse(matches(archiveVersionName = null))
+    }
+}

--- a/app/src/test/java/app/morphe/manager/util/VersionUtilsTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/VersionUtilsTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Version strings reaching these functions come from GitHub tags, bundle manifests and the
+ * database, so the cases below use the shapes this project actually ships: `1.25.0` releases,
+ * `1.25.1-dev.1` pre-releases and `v`-prefixed tags.
+ */
+class VersionUtilsTest {
+    private fun assertOlder(older: String?, newer: String?) {
+        assertTrue(compareVersions(older, newer) < 0, "expected $older < $newer")
+        assertTrue(compareVersions(newer, older) > 0, "expected $newer > $older")
+    }
+
+    @Test
+    fun `missing versions sort below present ones`() {
+        assertEquals(0, compareVersions(null, null))
+        assertOlder(null, "1.25.0")
+    }
+
+    @Test
+    fun `identical versions compare equal`() {
+        assertEquals(0, compareVersions("1.25.0", "1.25.0"))
+    }
+
+    @Test
+    fun `tag prefix and whitespace do not affect the comparison`() {
+        assertEquals(0, compareVersions("v1.25.0", "1.25.0"))
+        assertEquals(0, compareVersions("1.25.0 ", "v1.25.0"))
+        assertEquals("1.25.0", "v1.25.0".normalizeVersion())
+        assertEquals("1.25.0", " 1.25.0 ".normalizeVersion())
+    }
+
+    @Test
+    fun `segments are compared numerically rather than as text`() {
+        assertOlder("1.9.0", "1.10.0")
+        assertOlder("1.25.9", "1.25.10")
+    }
+
+    @Test
+    fun `a missing trailing segment counts as zero`() {
+        assertEquals(0, compareVersions("1.25", "1.25.0"))
+        assertOlder("1.25", "1.25.1")
+    }
+
+    @Test
+    fun `a release outranks its own pre-releases`() {
+        assertOlder("1.25.1-dev.1", "1.25.1")
+    }
+
+    @Test
+    fun `pre-release counters are compared numerically`() {
+        assertOlder("1.25.1-dev.2", "1.25.1-dev.10")
+    }
+
+    @Test
+    fun `a newer base outranks an older release even as a pre-release`() {
+        assertOlder("1.25.0", "1.26.0-dev.1")
+    }
+
+    @Test
+    fun `isNewerVersion only reports a strict increase`() {
+        assertTrue(isNewerVersion("1.25.0", "1.25.1"))
+        assertTrue(isNewerVersion("1.25.1-dev.1", "1.25.1"))
+        assertFalse(isNewerVersion("1.25.1", "1.25.0"))
+        assertFalse(isNewerVersion("1.25.0", "1.25.0"))
+        assertFalse(isNewerVersion("1.25.0", "v1.25.0"))
+    }
+
+    @Test
+    fun `a bundle built for a newer patcher is reported as outdated`() {
+        assertTrue(isPatcherOutdated(required = "2.0.0", current = "1.8.0"))
+        assertFalse(isPatcherOutdated(required = "1.8.0", current = "1.8.0"))
+        assertFalse(isPatcherOutdated(required = "1.7.0", current = "1.8.0"))
+    }
+
+    @Test
+    fun `an unparseable requirement never blocks patching`() {
+        assertFalse(isPatcherOutdated(required = "not-a-version", current = "1.8.0"))
+        assertFalse(isPatcherOutdated(required = "", current = "1.8.0"))
+        assertFalse(isPatcherOutdated(required = "2.0.0", current = "unknown"))
+    }
+
+    @Test
+    fun `release links follow the host's tag layout`() {
+        assertEquals(
+            "https://github.com/MorpheApp/morphe-manager/releases/tag/v1.25.0",
+            releasePageUrl("https://github.com/MorpheApp/morphe-manager", "1.25.0")
+        )
+        assertEquals(
+            "https://gitlab.com/group/project/-/releases/v1.25.0",
+            releasePageUrl("https://gitlab.com/group/project", "v1.25.0")
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -147,6 +147,9 @@ semver-parser = { module = "io.github.z4kn4fein:semver", version.ref = "semver-p
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
+# Unit tests
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
## Summary

- validate retained patched APKs before offering install, export, or mount actions
- distinguish a tracked patched install from a stock app reinstalled under the same package name
- represent unverifiable installs explicitly and avoid destructive actions against them
- keep the added identity checks off the home screen's critical path

Fixes #830. Related to #786 and follows up on #791.

## Root cause

#791 handles the case where the tracked package is absent. The installed-app database row survives an uninstall, though, so a later stock reinstall under the same package name was still treated as the tracked patched build. That could make Morphe show the app as installed, reconcile the stale row to the stock version, and offer launch or uninstall actions for the stock app.

This was reproduced with Ampere: the patched build was uninstalled and the Play Store build was installed shortly afterward. ADB confirmed that the current package was installed by `com.android.vending`, while Morphe retained the old tracked record.

## Changes

### Identifying the tracked install

- Resolve tracked-install state from evidence rather than from package-name presence or the persisted row, in this order: a mounted-source signature mismatch, the saved patched APK's certificate, the retained original or bundle certificates, a patch-manager installer, and finally an installer that Morphe would not have set for the record combined with an installation newer than the record itself.
- The installer signals are read against the record's `installType`: Play Store-attributed, custom and mounted installs carry an attribution Morphe cannot rule anything out from, while the system-installer and Shizuku modes have a predictable one. This is what identifies the reported Ampere case without any archive being retained.
- Require a saved APK to be a regular, parseable, signed APK whose embedded package and version match the record. Both patch flows persist the version the patcher produced and reuse it in the retained file name, so version-rewriting patches still match their own record while an archive that reports something else is refused. The expected file name is not evidence of what the file contains, and the accepted archive goes on to supply the certificate that proves an install is patched.
- For renamed apps, search both retained-file paths but accept only an APK whose embedded package matches the current tracked package.

### Acting on it

- Treat a confirmed stock replacement as deleted from Morphe's perspective while leaving the stock app untouched; the stale tracking record can still be removed.
- Show an `Unverified` state when the available evidence cannot identify the installed build, suppress update badges, and withhold launch/uninstall actions. The notice explains the state and points at reinstalling from the saved APK.
- Reverify identity immediately before launch or uninstall, and tell the user when an action was skipped instead of failing silently.
- Unmounting is never gated: it removes the bind mount and the module directory only, so it stays available even when the underlying package can no longer be identified.
- Reconcile the recorded version with the running one only for a confirmed tracked install.
- Apply the same validated-file and verified-install gates in Settings → Patched APKs.
- Delete the APK stored under the original package name only when no other record owns that path.

### Keeping it cheap

- Certificate extraction verifies the whole archive, so `PM` now caches archive signature hashes keyed by path, size and modification time. The saved APK is parsed once and the resulting `PackageInfo` is carried in the snapshot, so identity, certificates, label and version no longer cost one archive read each.
- Refresh tracked-install state on package add, remove and replace broadcasts, but only for tracked packages and coalesced through a short debounce, so a store updating apps in the background no longer triggers a rebuild per broadcast. The receiver is registered as `RECEIVER_NOT_EXPORTED`.
- Home inspections stay capped by a semaphore, and the duplicate state resolution that ran during version reconciliation was removed.

## Known limitation

An install attributed to the Play Store with no retained patched APK stays `Unverified`: the attribution is the expected one and there is no certificate to compare against. The UI is honest about it and offers the way out, but confirming those installs would mean recording the artifact's certificate at install time, which needs a schema migration and belongs in a separate change. The default configuration retains patched APKs, so this affects users who turned that off.
