### PR TITLE
feat: Accept helper installed-app results

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ApkDownloadHelper.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ApkDownloadHelper.kt
@@ -44,6 +44,7 @@ fun rememberApkDownloadHelperAction(
     val context = LocalContext.current
     val noResultMessage = stringResource(R.string.home_apk_helper_no_result)
     val noAccessMessage = stringResource(R.string.home_apk_helper_no_access)
+    val noPackageMessage = stringResource(R.string.home_apk_helper_no_package)
     var helpers by remember { mutableStateOf(emptyList<ApkDownloadHelperContract.Helper>()) }
     var showPicker by remember { mutableStateOf(false) }
 
@@ -61,7 +62,13 @@ fun rememberApkDownloadHelperAction(
     ) { result ->
         if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
 
-        ApkDownloadHelperContract.resultInstalledPackageName(result.data)?.let { packageName ->
+        if (ApkDownloadHelperContract.isInstalledAppResult(result.data)) {
+            val packageName = ApkDownloadHelperContract.resultInstalledPackageName(result.data)
+            if (packageName == null) {
+                context.toast(noPackageMessage)
+                return@rememberLauncherForActivityResult
+            }
+
             homeViewModel.showDownloadInstructionsDialog = false
             homeViewModel.showFilePickerPromptDialog = false
             homeViewModel.handleHelperInstalledAppSelection(packageName)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ApkDownloadHelper.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ApkDownloadHelper.kt
@@ -61,6 +61,13 @@ fun rememberApkDownloadHelperAction(
     ) { result ->
         if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
 
+        ApkDownloadHelperContract.resultInstalledPackageName(result.data)?.let { packageName ->
+            homeViewModel.showDownloadInstructionsDialog = false
+            homeViewModel.showFilePickerPromptDialog = false
+            homeViewModel.handleHelperInstalledAppSelection(packageName)
+            return@rememberLauncherForActivityResult
+        }
+
         val uri = ApkDownloadHelperContract.resultUri(result.data)
         if (uri == null) {
             context.toast(noResultMessage)

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1881,6 +1881,34 @@ class HomeViewModel(
     }
 
     /**
+     * Handles a helper result where the user installed the target app outside Morphe.
+     */
+    fun handleHelperInstalledAppSelection(packageName: String) {
+        val pending = pendingPackageName
+        if (pending == null || pending != packageName) {
+            app.toast(app.getString(R.string.home_apk_helper_installed_unavailable))
+            cleanupPendingData()
+            return
+        }
+
+        viewModelScope.launch {
+            val (installed, info) = withContext(Dispatchers.IO) {
+                localApkSources.installed(packageName)
+            }
+            pendingTargetAppInstalled = installed
+            pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version, it.versionCode) }
+
+            if (pendingInstalledApkInfo == null) {
+                app.toast(app.getString(R.string.home_apk_helper_installed_unavailable))
+                cleanupPendingData()
+                return@launch
+            }
+
+            handleInstalledApkSelection()
+        }
+    }
+
+    /**
      * Loads all user-installed apps and opens the picker dialog.
      * Called from the "Other apps" file-picker prompt when the user taps "Use installed app".
      */

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -19,6 +19,7 @@ import android.os.StatFs
 import android.provider.OpenableColumns
 import android.util.Log
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -1699,6 +1700,15 @@ class HomeViewModel(
      *   - Simple mode + saved APK == recommended version
      */
     fun showPatchDialog(packageName: String) {
+        preparePendingFlow(packageName)
+
+        // Guard: if there is a pending bundle update on metered data, show the outdated-patches
+        // dialog before proceeding with the actual APK selection flow.
+        guardPatching { showPatchDialogInternal(packageName) }
+    }
+
+    /** Seeds the pending APK selection state for [packageName] from the current bundle data. */
+    private fun preparePendingFlow(packageName: String) {
         pendingPackageName = packageName
         pendingAppName = bundleAppMetadataFlow.value[packageName]?.displayName
             ?: KnownApps.getAppName(packageName)
@@ -1710,10 +1720,6 @@ class HomeViewModel(
         pendingSavedApkInfo = null
         pendingInstalledApkInfo = null
         pendingTargetAppInstalled = null
-
-        // Guard: if there is a pending bundle update on metered data, show the outdated-patches
-        // dialog before proceeding with the actual APK selection flow.
-        guardPatching { showPatchDialogInternal(packageName) }
     }
 
     private suspend fun showPatchDialogInternal(packageName: String) {
@@ -1781,10 +1787,7 @@ class HomeViewModel(
                 async(Dispatchers.IO) { localApkSources.installed(packageName) }
             } else null
             savedJob?.await()?.let { pendingSavedApkInfo = it }
-            installedJob?.await()?.let { (installed, info) ->
-                pendingTargetAppInstalled = installed
-                pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version, it.versionCode) }
-            }
+            installedJob?.await()?.let { (installed, info) -> applyInstalledApkInfo(installed, info) }
         }
 
         val recommendedVersion = pendingRecommendedVersion
@@ -1801,6 +1804,15 @@ class HomeViewModel(
             // Show dialog
             showApkAvailabilityDialog = true
         }
+    }
+
+    /**
+     * Stores the installed-app lookup, keeping the APK only when its version can be patched
+     * so every caller offers the installed source under the same condition.
+     */
+    private fun applyInstalledApkInfo(installed: Boolean, info: InstalledApkInfo?) {
+        pendingTargetAppInstalled = installed
+        pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version, it.versionCode) }
     }
 
     /**
@@ -1882,30 +1894,74 @@ class HomeViewModel(
 
     /**
      * Handles a helper result where the user installed the target app outside Morphe.
+     *
+     * Reached in simple mode too, where the installed source is otherwise hidden: the helper is
+     * opt-in and the hand-off was confirmed, so the app store is the whole point of the request.
      */
     fun handleHelperInstalledAppSelection(packageName: String) {
-        val pending = pendingPackageName
-        if (pending == null || pending != packageName) {
-            app.toast(app.getString(R.string.home_apk_helper_installed_unavailable))
-            cleanupPendingData()
-            return
-        }
-
         viewModelScope.launch {
+            val pending = pendingPackageName
+            if (pending != null && pending != packageName) {
+                // The helper answered about an app the user never asked to patch
+                stopHelperHandoff(pending, R.string.home_apk_helper_wrong_package)
+                return@launch
+            }
+
+            // A hand-off through an app store can outlive Morphe, so the flow is rebuilt from the
+            // bundle data. Unknown packages are refused because without their compatible versions
+            // there is nothing left to check the installed build against
+            if (pending == null) {
+                if (packageName !in compatibleVersions) {
+                    app.toast(app.getString(R.string.home_apk_helper_installed_unavailable))
+                    cleanupPendingData()
+                    return@launch
+                }
+                preparePendingFlow(packageName)
+            }
+
+            processingApkSelection = true
             val (installed, info) = withContext(Dispatchers.IO) {
                 localApkSources.installed(packageName)
             }
-            pendingTargetAppInstalled = installed
-            pendingInstalledApkInfo = info?.takeIf { isInstalledVersionCompatible(it.version, it.versionCode) }
+            applyInstalledApkInfo(installed, info)
 
-            if (pendingInstalledApkInfo == null) {
-                app.toast(app.getString(R.string.home_apk_helper_installed_unavailable))
-                cleanupPendingData()
+            val installedInfo = pendingInstalledApkInfo
+            if (installedInfo == null) {
+                // An app store hands out the newest build, which is regularly one no bundle covers
+                stopHelperHandoff(
+                    packageName,
+                    if (info == null) {
+                        R.string.home_apk_helper_installed_unavailable
+                    } else {
+                        R.string.home_apk_helper_installed_incompatible
+                    }
+                )
+                return@launch
+            }
+
+            // Continuing here would swallow the warning the availability dialog carries when the
+            // certificate could not be read, so that case goes back to the user
+            if (installedInfo.patchStateUnknown) {
+                stopHelperHandoff(packageName)
                 return@launch
             }
 
             handleInstalledApkSelection()
         }
+    }
+
+    /**
+     * Ends a helper hand-off at the APK availability dialog, so the remaining sources stay one tap
+     * away instead of the user landing back on the home screen with nothing to act on.
+     */
+    private suspend fun stopHelperHandoff(packageName: String, @StringRes message: Int? = null) {
+        processingApkSelection = false
+        message?.let { app.toast(app.getString(it)) }
+
+        if (pendingSavedApkInfo == null) {
+            pendingSavedApkInfo = withContext(Dispatchers.IO) { localApkSources.saved(packageName) }
+        }
+        showApkAvailabilityDialog = true
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
+++ b/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
@@ -34,8 +34,11 @@ import android.os.Build
 object ApkDownloadHelperContract {
     const val ACTION_DOWNLOAD_ORIGINAL_APK = "app.morphe.manager.action.DOWNLOAD_ORIGINAL_APK"
 
-    /** Bumped whenever the extras below change in a way helpers have to react to. */
-    const val PROTOCOL_VERSION = 1
+    /**
+     * Bumped whenever the extras below change in a way helpers have to react to.
+     * Version 2 added the installed-app result, so a helper can tell whether Morphe accepts one.
+     */
+    const val PROTOCOL_VERSION = 2
 
     const val EXTRA_PROTOCOL_VERSION = "app.morphe.manager.extra.PROTOCOL_VERSION"
     const val EXTRA_CALLER_PACKAGE = "app.morphe.manager.extra.CALLER_PACKAGE"
@@ -62,7 +65,7 @@ object ApkDownloadHelperContract {
 
     /**
      * Informational hint that the unpatched app still has to be installed for a mount install.
-     * Morphe performs that installation itself; helpers must not install anything.
+     * Morphe performs that installation itself; a helper may only hand the user to an app store.
      */
     const val EXTRA_STOCK_INSTALL_REQUIRED = "app.morphe.manager.extra.STOCK_INSTALL_REQUIRED"
 
@@ -76,7 +79,13 @@ object ApkDownloadHelperContract {
     const val FILE_TYPE_APKS = "apks"
     const val FILE_TYPE_XAPK = "xapk"
 
+    /**
+     * Set by a helper that handed the user to an app store instead of downloading a file,
+     * asking Morphe to continue from the package the user installed there.
+     */
     const val EXTRA_RESULT_USE_INSTALLED_APP = "app.morphe.manager.extra.RESULT_USE_INSTALLED_APP"
+
+    /** The package an installed-app result refers to. Must be the one Morphe asked for. */
     const val EXTRA_RESULT_PACKAGE_NAME = "app.morphe.manager.extra.RESULT_PACKAGE_NAME"
 
     /** An installed activity that can serve [ACTION_DOWNLOAD_ORIGINAL_APK]. */
@@ -163,9 +172,16 @@ object ApkDownloadHelperContract {
     fun grantsReadAccess(intent: Intent?): Boolean =
         intent != null && intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0
 
+    /** Whether the helper answered with an installed app rather than a file. */
+    fun isInstalledAppResult(intent: Intent?): Boolean =
+        intent != null && intent.getBooleanExtra(EXTRA_RESULT_USE_INSTALLED_APP, false)
+
+    /**
+     * The package an installed-app result names, or null when the helper named none.
+     *
+     * Read only after [isInstalledAppResult], so a helper that sets the flag without a package
+     * gets a message naming the real cause instead of one about a missing file.
+     */
     fun resultInstalledPackageName(intent: Intent?): String? =
-        intent
-            ?.takeIf { it.getBooleanExtra(EXTRA_RESULT_USE_INSTALLED_APP, false) }
-            ?.getStringExtra(EXTRA_RESULT_PACKAGE_NAME)
-            ?.takeIf { it.isNotBlank() }
+        intent?.getStringExtra(EXTRA_RESULT_PACKAGE_NAME)?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
+++ b/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
@@ -41,7 +41,13 @@ object ApkDownloadHelperContract {
     const val PROTOCOL_VERSION = 2
 
     const val EXTRA_PROTOCOL_VERSION = "app.morphe.manager.extra.PROTOCOL_VERSION"
+
+    /**
+     * Informational only. Any app can send this action, so a helper that gates on who asked has to
+     * read `Activity.getCallingPackage()` instead of trusting this value.
+     */
     const val EXTRA_CALLER_PACKAGE = "app.morphe.manager.extra.CALLER_PACKAGE"
+
     const val EXTRA_PACKAGE_NAME = "app.morphe.manager.extra.PACKAGE_NAME"
     const val EXTRA_APP_NAME = "app.morphe.manager.extra.APP_NAME"
 
@@ -118,10 +124,26 @@ object ApkDownloadHelperContract {
                 val activity = info.activityInfo ?: return@mapNotNull null
                 Helper(
                     componentName = ComponentName(activity.packageName, activity.name),
-                    label = info.loadLabel(packageManager).toString()
+                    label = info.loadLabel(packageManager).toString().asHelperLabel(activity.packageName)
                 )
             }
             .sortedBy { it.label.lowercase() }
+    }
+
+    private const val MAX_LABEL_LENGTH = 50
+    private val LABEL_WHITESPACE = Regex("\\s+")
+
+    /**
+     * Bounds the name a helper gave itself, because the picker weighs it against a warning that an
+     * oversized label would push out of view. Falls back to [packageName] when nothing is left.
+     */
+    private fun String.asHelperLabel(packageName: String): String {
+        val collapsed = replace(LABEL_WHITESPACE, " ").trim()
+        return when {
+            collapsed.isEmpty() -> packageName
+            collapsed.length > MAX_LABEL_LENGTH -> collapsed.take(MAX_LABEL_LENGTH).trimEnd() + "…"
+            else -> collapsed
+        }
     }
 
     fun createRequestIntent(

--- a/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
+++ b/app/src/main/java/app/morphe/manager/util/ApkDownloadHelperContract.kt
@@ -17,13 +17,15 @@ import android.os.Build
  * Public intent contract for optional third-party APK download helpers.
  *
  * Morphe only describes the original APK it needs. The helper owns provider lookup,
- * download UI, and file sharing, then returns the downloaded archive.
+ * download UI, and file sharing, then returns either the downloaded archive or a request to use
+ * the package that the user installed outside Morphe.
  *
  * A helper declares an exported activity with an intent filter for
  * `ACTION_DOWNLOAD_ORIGINAL_APK` and [Intent.CATEGORY_DEFAULT]. It answers with
- * [android.app.Activity.RESULT_OK] and the archive in `Intent.setData`, granting read access via
- * [Intent.FLAG_GRANT_READ_URI_PERMISSION]. Without that flag Morphe cannot open the file and
- * reports the selection as unreadable.
+ * [android.app.Activity.RESULT_OK]. File results put the archive in `Intent.setData` and grant
+ * read access via [Intent.FLAG_GRANT_READ_URI_PERMISSION]. Installed-app results set
+ * [EXTRA_RESULT_USE_INSTALLED_APP] and [EXTRA_RESULT_PACKAGE_NAME], after which Morphe re-checks
+ * the installed package before patching.
  *
  * Requests go to the explicit component the user picked, and everything a helper returns still
  * runs through the normal package, version and signature checks. A helper is a download
@@ -73,6 +75,9 @@ object ApkDownloadHelperContract {
     const val FILE_TYPE_APKM = "apkm"
     const val FILE_TYPE_APKS = "apks"
     const val FILE_TYPE_XAPK = "xapk"
+
+    const val EXTRA_RESULT_USE_INSTALLED_APP = "app.morphe.manager.extra.RESULT_USE_INSTALLED_APP"
+    const val EXTRA_RESULT_PACKAGE_NAME = "app.morphe.manager.extra.RESULT_PACKAGE_NAME"
 
     /** An installed activity that can serve [ACTION_DOWNLOAD_ORIGINAL_APK]. */
     data class Helper(
@@ -157,4 +162,10 @@ object ApkDownloadHelperContract {
      */
     fun grantsReadAccess(intent: Intent?): Boolean =
         intent != null && intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0
+
+    fun resultInstalledPackageName(intent: Intent?): String? =
+        intent
+            ?.takeIf { it.getBooleanExtra(EXTRA_RESULT_USE_INSTALLED_APP, false) }
+            ?.getStringExtra(EXTRA_RESULT_PACKAGE_NAME)
+            ?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,7 +182,10 @@
     <string name="home_apk_helper_warning_unverified">Only continue if you trust this helper app. Morphe cannot verify the signature of this APK, so a modified file would not be detected</string>
     <string name="home_apk_helper_no_result">The helper app did not return an APK</string>
     <string name="home_apk_helper_no_access">The helper app did not grant access to the APK it returned</string>
+    <string name="home_apk_helper_no_package">The helper app did not say which installed app to use</string>
+    <string name="home_apk_helper_wrong_package">The helper app returned a different app than the one being patched</string>
     <string name="home_apk_helper_installed_unavailable">Morphe could not use the installed app</string>
+    <string name="home_apk_helper_installed_incompatible">The installed version cannot be patched</string>
     <string name="home_apk_use_saved">Use saved APK</string>
     <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_apk_use_installed_unverified">Could not verify the signature of the installed app, so it may already be patched</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="home_apk_helper_warning_unverified">Only continue if you trust this helper app. Morphe cannot verify the signature of this APK, so a modified file would not be detected</string>
     <string name="home_apk_helper_no_result">The helper app did not return an APK</string>
     <string name="home_apk_helper_no_access">The helper app did not grant access to the APK it returned</string>
+    <string name="home_apk_helper_installed_unavailable">Morphe could not use the installed app</string>
     <string name="home_apk_use_saved">Use saved APK</string>
     <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_apk_use_installed_unverified">Could not verify the signature of the installed app, so it may already be patched</string>


### PR DESCRIPTION
Extend the APK download helper contract with an installed-app result for Store handoffs.

When a helper returns that result, refresh the target package info and continue through Morphe's existing Use installed APK flow instead of expecting a returned file URI.