### PR TITLE
fix: Stage universal patches behind a second "Enable all" tap

### DIFF
--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -1,19 +1,8 @@
 package app.morphe.manager.patcher.patch
 
 import androidx.compose.runtime.Immutable
-import app.morphe.patcher.patch.ApkArchitecture
-import app.morphe.patcher.patch.AppTarget
-import app.morphe.patcher.patch.AvailabilityResolver
-import app.morphe.patcher.patch.InstallerType
-import app.morphe.patcher.patch.Patch
-import app.morphe.patcher.patch.PatchAvailability
-import app.morphe.patcher.patch.ApkFileType
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableMap
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toImmutableMap
-import kotlinx.collections.immutable.toImmutableSet
+import app.morphe.patcher.patch.*
+import kotlinx.collections.immutable.*
 import kotlin.reflect.KType
 import app.morphe.patcher.patch.ColorOption as PatchColorOption
 import app.morphe.patcher.patch.FilePathOption as PatchFilePathOption
@@ -124,6 +113,9 @@ data class PatchInfo(
             PatchAvailability.DISABLED    -> PatchLockState.NONE
         }
     }
+
+    /** Universal patches declare no compatible packages and therefore apply to any app. */
+    val isUniversal get() = compatiblePackages.isNullOrEmpty()
 
     fun compatibleWith(packageName: String) =
         compatiblePackages == null ||

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -36,13 +36,7 @@ import app.morphe.manager.R
 import app.morphe.manager.domain.batch.*
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
-import app.morphe.manager.ui.screen.home.ApkAvailabilityDialog
-import app.morphe.manager.ui.screen.home.DownloadInstructionsDialog
-import app.morphe.manager.ui.screen.home.ExpertModeDialog
-import app.morphe.manager.ui.screen.home.ExpertPatchActions
-import app.morphe.manager.ui.screen.home.FilePickerPromptDialog
-import app.morphe.manager.ui.screen.home.SimpleBundleCandidate
-import app.morphe.manager.ui.screen.home.SimpleBundleSelectDialog
+import app.morphe.manager.ui.screen.home.*
 import app.morphe.manager.ui.screen.patcher.ExpertPatchingInProgress
 import app.morphe.manager.ui.screen.patcher.PatcherErrorDialog
 import app.morphe.manager.ui.screen.patcher.PatcherErrorInfo
@@ -52,13 +46,7 @@ import app.morphe.manager.ui.screen.settings.system.InstallerFlowDialogs
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.BatchPatcherViewModel
 import app.morphe.manager.ui.viewmodel.InstallViewModel
-import app.morphe.manager.util.APK_FILE_MIME_TYPES
-import app.morphe.manager.util.APK_MIMETYPE
-import app.morphe.manager.util.ExportNameFormatter
-import app.morphe.manager.util.KnownApps
-import app.morphe.manager.util.PatchedAppExportData
-import app.morphe.manager.util.rememberAdaptiveFilePicker
-import app.morphe.manager.util.toast
+import app.morphe.manager.util.*
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -184,6 +172,7 @@ fun BatchPatcherScreen(
             ),
             savedPatches = edit.savedSelection,
             lockStateOf = edit::lockStateOf,
+            holdsUniversalPatches = edit::selectAllHoldsUniversal,
             proceedText = stringResource(R.string.save),
             // The queue combines sources by design, and the tabs make it plain enough
             warnOnMultipleBundles = false,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -68,6 +68,8 @@ fun ExpertModeDialog(
     patchActions: ExpertPatchActions,
     savedPatches: PatchSelection = emptyMap(),
     lockStateOf: (PatchInfo) -> PatchLockState = { PatchLockState.NONE },
+    /** True while "Enable all" still holds the universal patches of the given list back. */
+    holdsUniversalPatches: (bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) -> Boolean = { _, _ -> false },
     proceedText: String = stringResource(R.string.expert_mode_proceed),
     /** Off where mixing sources is the norm rather than something the user just did. */
     warnOnMultipleBundles: Boolean = true,
@@ -237,6 +239,7 @@ fun ExpertModeDialog(
                 BundlePatchControls(
                     enabledCount = enabledCount,
                     totalCount = totalCount,
+                    holdsUniversalPatches = holdsUniversalPatches(bundle.uid, displayPatches),
                     onSelectAll = { patchActions.onSelectAll(bundle.uid, displayPatches) },
                     onDeselectAll = { patchActions.onDeselectAll(bundle.uid, displayPatches) },
                     onResetToDefault = { patchActions.onResetToDefault(bundle.uid, allPatches) },
@@ -372,6 +375,7 @@ fun ExpertModeDialog(
                         BundlePatchControls(
                             enabledCount = currentFiltered.count { it.second },
                             totalCount = currentFiltered.size,
+                            holdsUniversalPatches = holdsUniversalPatches(currentBundle.uid, currentFiltered),
                             onSelectAll = { patchActions.onSelectAll(currentBundle.uid, currentFiltered) },
                             onDeselectAll = { patchActions.onDeselectAll(currentBundle.uid, currentFiltered) },
                             onResetToDefault = { patchActions.onResetToDefault(currentBundle.uid, currentAllPatches) },
@@ -522,7 +526,7 @@ private fun PatchListWithUniversalSection(
     onConfigureOptions: (PatchInfo) -> Unit,
 ) {
     val (regular, universal) = remember(patches) {
-        patches.partition { (patch, _) -> !patch.compatiblePackages.isNullOrEmpty() }
+        patches.partition { (patch, _) -> !patch.isUniversal }
     }
 
     // New patches float to the top; within each group order is alphabetical

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -34,6 +34,7 @@ import app.morphe.manager.util.toast
 internal fun BundlePatchControls(
     enabledCount: Int,
     totalCount: Int,
+    holdsUniversalPatches: Boolean,
     onSelectAll: () -> Unit,
     onDeselectAll: () -> Unit,
     onResetToDefault: () -> Unit,
@@ -56,7 +57,12 @@ internal fun BundlePatchControls(
     val copyLabel = stringResource(R.string.expert_mode_copy_from_bundle)
     val deselectAllLabel = stringResource(R.string.expert_mode_disable_all)
 
-    val enabledDone = stringResource(R.string.expert_mode_enable_all_done)
+    // Universal patches stay off until a second tap, so the first one must not claim otherwise
+    val enabledDone = if (holdsUniversalPatches) {
+        stringResource(R.string.expert_mode_enable_all_universal_pending)
+    } else {
+        stringResource(R.string.expert_mode_enable_all_done)
+    }
     val disabledDone = stringResource(R.string.expert_mode_disable_all_done)
     val resetDone = stringResource(R.string.expert_mode_reset_to_default_done)
     val restoredDone = stringResource(R.string.expert_mode_restore_saved_done)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
@@ -57,12 +57,12 @@ fun AppPatchesDialog(
         patchesByBundle.entries
             .sortedWith(
                 compareBy(
-                    { (_, patches) -> patches.all { it.compatiblePackages == null } },
+                    { (_, patches) -> patches.all { it.isUniversal } },
                     { (uid, _) -> bundleNames[uid] ?: uid.toString() }
                 )
             )
             .flatMap { (uid, patches) ->
-                val (universal, specific) = patches.partition { it.compatiblePackages == null }
+                val (universal, specific) = patches.partition { it.isUniversal }
                 (specific.sortedBy { it.name } + universal.sortedBy { it.name })
                     .map { patch -> uid to patch }
             }
@@ -244,15 +244,15 @@ fun AppPatchesDialog(
                         }
 
                         if (uid !in collapsedBundles.value) {
-                            val firstUniversal = bundlePatches.firstOrNull { it.compatiblePackages == null }
-                            val hasSpecificInBundle = bundlePatches.any { it.compatiblePackages != null }
+                            val firstUniversal = bundlePatches.firstOrNull { it.isUniversal }
+                            val hasSpecificInBundle = bundlePatches.any { !it.isUniversal }
                             items(
                                 bundlePatches,
                                 key = { patch ->
                                     "$uid:${patch.name}:${patch.compatiblePackages?.joinToString { it.packageName.orEmpty() }.orEmpty()}"
                                 }
                             ) { patch ->
-                                val isUniversal = patch.compatiblePackages == null
+                                val isUniversal = patch.isUniversal
                                 val isFirstUniversalOfBundle = isUniversal && patch === firstUniversal
                                 Column(
                                     modifier = Modifier.animateItem(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -45,18 +45,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
-import app.morphe.manager.domain.bundles.BundleSourceType
 import app.morphe.manager.domain.apk.InstalledApkInfo
 import app.morphe.manager.domain.apk.SavedApkInfo
-import app.morphe.manager.domain.bundles.BundleRecommendation
-import app.morphe.manager.domain.bundles.BundledAppTarget
-import app.morphe.manager.domain.bundles.experimentalVersions
+import app.morphe.manager.domain.bundles.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.sourceType
-import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.model.HomeAppItem
 import app.morphe.manager.ui.screen.shared.*
-import app.morphe.manager.ui.viewmodel.*
+import app.morphe.manager.ui.viewmodel.HomeViewModel
+import app.morphe.manager.ui.viewmodel.InstalledAppInfoViewModel
+import app.morphe.manager.ui.viewmodel.InstalledAppPickerItem
 import app.morphe.manager.util.*
 import app.morphe.patcher.patch.AppTarget
 import kotlinx.coroutines.delay
@@ -437,6 +435,7 @@ fun HomeDialogs(
             lockStateOf = { patch ->
                 patch.lockState(homeViewModel.currentInstallerType, homeViewModel.currentApkArchitecture)
             },
+            holdsUniversalPatches = homeViewModel::expertModeSelectAllHoldsUniversal,
             onDismiss = {
                 homeViewModel.cleanupExpertModeData()
             },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -841,7 +841,7 @@ fun PatchItemCard(
             }
 
             // Compatibility info
-            if (patch.compatiblePackages.isNullOrEmpty()) {
+            if (patch.isUniversal) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -859,7 +859,7 @@ fun PatchItemCard(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    patch.compatiblePackages.forEach { compatiblePackage ->
+                    patch.compatiblePackages.orEmpty().forEach { compatiblePackage ->
                         val anyString = stringResource(R.string.any_version)
                         val appName = compatiblePackage.displayName ?: compatiblePackage.packageName ?: anyString
                         val versions = compatiblePackage.versions.orEmpty()

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
@@ -28,17 +28,15 @@ import app.morphe.manager.domain.manager.DownloadUrlResolver
 import app.morphe.manager.domain.repository.InstalledAppRepository
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.domain.repository.PatchSelectionRepository
-import app.morphe.manager.patcher.patch.PatchBundleInfo
-import app.morphe.manager.patcher.patch.PatchInfo
-import app.morphe.manager.patcher.patch.PatchLockState
-import app.morphe.manager.patcher.patch.SELECTION_APK_ARCHITECTURE
-import app.morphe.manager.patcher.patch.installerTypeFor
+import app.morphe.manager.patcher.patch.*
 import app.morphe.manager.util.*
-import app.morphe.patcher.patch.InstallerType
+import app.morphe.manager.util.PatchSelectionUtils.bulkEnableHoldsUniversal
+import app.morphe.manager.util.PatchSelectionUtils.bulkEnablePatches
 import app.morphe.manager.util.PatchSelectionUtils.resetOptionsForPatch
 import app.morphe.manager.util.PatchSelectionUtils.togglePatch
 import app.morphe.manager.util.PatchSelectionUtils.updateOption
 import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.InstallerType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -67,6 +65,10 @@ class BatchPatchEdit(
 
     var options by mutableStateOf(initialOptions)
         private set
+
+    // Bundle and selection left behind by the last "Enable all". Universal patches are applied
+    // only while this still matches the live selection, so any other edit disarms them again
+    private var universalArmedFor by mutableStateOf<Pair<Int, Set<String>>?>(null)
 
     val allPatchesInfo: List<Pair<PatchBundleInfo.Scoped, List<Pair<PatchInfo, Boolean>>>>
         get() = bundles.map { bundle ->
@@ -98,12 +100,26 @@ class BatchPatchEdit(
         selection = selection.togglePatch(bundleUid, patchName)
     }
 
-    fun selectAll(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) =
-        replaceBundle(
-            bundleUid,
-            patches.filterNot { (patch, _) -> lockStateOf(patch) == PatchLockState.LOCKED_OFF }
-                .mapTo(mutableSetOf()) { (patch, _) -> patch.name }
-        )
+    /**
+     * Select all patches shown for a bundle, staging universal patches behind the regular ones
+     * exactly like the single-app flow does, see [PatchSelectionUtils.bulkEnablePatches].
+     */
+    fun selectAll(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) {
+        val selected = selection[bundleUid].orEmpty()
+        val updated = bulkEnablePatches(patches, selected, universalArmed(bundleUid, selected), ::lockStateOf)
+
+        replaceBundle(bundleUid, updated)
+        universalArmedFor = bundleUid to updated
+    }
+
+    /** True when the next [selectAll] holds universal patches back for another tap. */
+    fun selectAllHoldsUniversal(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>): Boolean {
+        val selected = selection[bundleUid].orEmpty()
+        return bulkEnableHoldsUniversal(patches, universalArmed(bundleUid, selected), ::lockStateOf)
+    }
+
+    private fun universalArmed(bundleUid: Int, selected: Set<String>) =
+        universalArmedFor == (bundleUid to selected)
 
     fun deselectAll(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) {
         val removed = patches

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -62,6 +62,8 @@ import app.morphe.manager.ui.model.SelectedApp
 import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
 import app.morphe.manager.util.*
 import app.morphe.manager.util.PatchSelectionUtils.applyAvailability
+import app.morphe.manager.util.PatchSelectionUtils.bulkEnableHoldsUniversal
+import app.morphe.manager.util.PatchSelectionUtils.bulkEnablePatches
 import app.morphe.manager.util.PatchSelectionUtils.filterGmsCore
 import app.morphe.manager.util.PatchSelectionUtils.resetOptionsForPatch
 import app.morphe.manager.util.PatchSelectionUtils.sanitizeForPatcher
@@ -294,6 +296,9 @@ class HomeViewModel(
     var expertModeOptions by mutableStateOf<Options>(emptyMap())
     // Patches that are new in the current bundle version relative to the last saved selection
     var expertModeNewPatches by mutableStateOf<Map<Int, Set<String>>>(emptyMap())
+    // Bundle and selection left behind by the last "Enable all". Universal patches are applied
+    // only while this still matches the live selection, so any other edit disarms them again
+    private var expertModeUniversalArmedFor by mutableStateOf<Pair<Int, Set<String>>?>(null)
 
     /** Target bundle uid for the in-flight copy-from-another-bundle picker; null while the picker is closed. */
     var expertModeCopyTargetBundleUid by mutableStateOf<Int?>(null)
@@ -2733,25 +2738,38 @@ class HomeViewModel(
      * Select all given patches for a bundle.
      * Only adds patches that are not already selected. LOCKED_OFF patches are skipped.
      *
-     * Universal patches are selected in a second pass: the first tap selects regular
-     * patches only, and a later tap includes universal patches if the regular patches
-     * in the current scope are already selected.
+     * Universal patches are staged behind the regular ones and need a second call, see
+     * [PatchSelectionUtils.bulkEnablePatches]. [patches] is the list the dialog currently
+     * shows, so an active search narrows the scope of both stages.
      */
     fun expertModeSelectAll(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) {
-        val current = expertModePatches.toMutableMap()
-        val set = current[bundleUid]?.toMutableSet() ?: mutableSetOf()
-        val selectablePatches = patches
-            .filter { (patch, _) -> patch.lockState(currentInstallerType, currentApkArchitecture) != PatchLockState.LOCKED_OFF }
-        val regularPatches = selectablePatches.filter { (patch, _) -> !patch.compatiblePackages.isNullOrEmpty() }
-        val hasUnselectedRegularPatch = regularPatches.any { (patch, enabled) -> !enabled && patch.name !in set }
-        val patchesToSelect = if (hasUnselectedRegularPatch) regularPatches else selectablePatches
+        val selected = expertModePatches[bundleUid].orEmpty()
+        val updated = bulkEnablePatches(
+            patches,
+            selected,
+            expertModeUniversalArmed(bundleUid, selected),
+            ::expertModeLockState
+        )
 
-        patchesToSelect.forEach { (patch, enabled) ->
-            if (!enabled) set.add(patch.name)
-        }
-        current[bundleUid] = set
-        expertModePatches = current
+        expertModePatches = expertModePatches.toMutableMap().apply { put(bundleUid, updated) }
+        expertModeUniversalArmedFor = bundleUid to updated
     }
+
+    /** True when the next [expertModeSelectAll] holds universal patches back for another tap. */
+    fun expertModeSelectAllHoldsUniversal(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>): Boolean {
+        val selected = expertModePatches[bundleUid].orEmpty()
+        return bulkEnableHoldsUniversal(
+            patches,
+            expertModeUniversalArmed(bundleUid, selected),
+            ::expertModeLockState
+        )
+    }
+
+    private fun expertModeLockState(patch: PatchInfo) =
+        patch.lockState(currentInstallerType, currentApkArchitecture)
+
+    private fun expertModeUniversalArmed(bundleUid: Int, selected: Set<String>) =
+        expertModeUniversalArmedFor == (bundleUid to selected)
 
     /**
      * Deselect all given patches for a bundle.
@@ -2823,6 +2841,7 @@ class HomeViewModel(
         expertModeInitialPatches = emptyMap()
         expertModeOptions = emptyMap()
         expertModeNewPatches = emptyMap()
+        expertModeUniversalArmedFor = null
         closeExpertModeCopyDialog()
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -2732,12 +2732,21 @@ class HomeViewModel(
     /**
      * Select all given patches for a bundle.
      * Only adds patches that are not already selected. LOCKED_OFF patches are skipped.
+     *
+     * Universal patches are selected in a second pass: the first tap selects regular
+     * patches only, and a later tap includes universal patches if the regular patches
+     * in the current scope are already selected.
      */
     fun expertModeSelectAll(bundleUid: Int, patches: List<Pair<PatchInfo, Boolean>>) {
         val current = expertModePatches.toMutableMap()
         val set = current[bundleUid]?.toMutableSet() ?: mutableSetOf()
-        patches.forEach { (patch, enabled) ->
-            if (patch.lockState(currentInstallerType, currentApkArchitecture) == PatchLockState.LOCKED_OFF) return@forEach
+        val selectablePatches = patches
+            .filter { (patch, _) -> patch.lockState(currentInstallerType, currentApkArchitecture) != PatchLockState.LOCKED_OFF }
+        val regularPatches = selectablePatches.filter { (patch, _) -> !patch.compatiblePackages.isNullOrEmpty() }
+        val hasUnselectedRegularPatch = regularPatches.any { (patch, enabled) -> !enabled && patch.name !in set }
+        val patchesToSelect = if (hasUnselectedRegularPatch) regularPatches else selectablePatches
+
+        patchesToSelect.forEach { (patch, enabled) ->
             if (!enabled) set.add(patch.name)
         }
         current[bundleUid] = set

--- a/app/src/main/java/app/morphe/manager/util/PatchSelectionExtensions.kt
+++ b/app/src/main/java/app/morphe/manager/util/PatchSelectionExtensions.kt
@@ -3,6 +3,9 @@ package app.morphe.manager.util
 import app.morphe.manager.data.room.apps.installed.SelectionPayload
 import app.morphe.manager.domain.bundles.PatchBundleSource
 import app.morphe.manager.patcher.patch.PatchInfo
+import app.morphe.manager.patcher.patch.PatchLockState
+import app.morphe.manager.util.PatchSelectionUtils.bulkEnablePatches
+import app.morphe.manager.util.PatchSelectionUtils.filterGmsCore
 import app.morphe.manager.util.PatchSelectionUtils.sanitizeForPatcher
 import app.morphe.patcher.patch.ApkArchitecture
 import app.morphe.patcher.patch.InstallerType
@@ -75,6 +78,47 @@ object PatchSelectionUtils {
 
         return current
     }
+
+    /**
+     * Patch names a bulk enable adds to the [selected] patches of one bundle.
+     *
+     * Universal patches are staged behind the regular ones: applying them blindly is a common
+     * cause of failed patching, so they join the selection only once every regular patch is on
+     * and [universalArmed] confirms that a previous bulk enable already left it that way.
+     * [patches] is the list the user currently sees, so an active search narrows both stages.
+     */
+    fun bulkEnablePatches(
+        patches: List<Pair<PatchInfo, Boolean>>,
+        selected: Set<String>,
+        universalArmed: Boolean,
+        lockStateOf: (PatchInfo) -> PatchLockState
+    ): Set<String> {
+        val selectable = patches.selectable(lockStateOf)
+        val staged = if (universalArmed && selectable.allRegularSelected()) {
+            selectable
+        } else {
+            selectable.filterNot { (patch, _) -> patch.isUniversal }
+        }
+        return selected + staged.map { (patch, _) -> patch.name }
+    }
+
+    /** True when [bulkEnablePatches] leaves universal patches of [patches] for another tap. */
+    fun bulkEnableHoldsUniversal(
+        patches: List<Pair<PatchInfo, Boolean>>,
+        universalArmed: Boolean,
+        lockStateOf: (PatchInfo) -> PatchLockState
+    ): Boolean {
+        val selectable = patches.selectable(lockStateOf)
+        val hasUnselectedUniversal = selectable.any { (patch, enabled) -> patch.isUniversal && !enabled }
+        return hasUnselectedUniversal && !(universalArmed && selectable.allRegularSelected())
+    }
+
+    /** Patches the user is allowed to turn on, i.e. everything except the locked off ones. */
+    private fun List<Pair<PatchInfo, Boolean>>.selectable(lockStateOf: (PatchInfo) -> PatchLockState) =
+        filterNot { (patch, _) -> lockStateOf(patch) == PatchLockState.LOCKED_OFF }
+
+    private fun List<Pair<PatchInfo, Boolean>>.allRegularSelected() =
+        none { (patch, enabled) -> !patch.isUniversal && !enabled }
 
     /**
      * Update a single option value in an options map.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
     <string name="expert_mode_disable_all_done">All patches disabled</string>
     <string name="expert_mode_enable_all">Enable all</string>
     <string name="expert_mode_enable_all_done">All patches enabled</string>
+    <string name="expert_mode_enable_all_universal_pending">Tap again for universal patches</string>
     <string name="expert_mode_reset_to_default">Enable recommended patches</string>
     <string name="expert_mode_reset_to_default_done">Recommended patches applied</string>
     <string name="expert_mode_restore_saved">Restore saved selection</string>


### PR DESCRIPTION
## Summary

* Change expert-mode patch selection so the first **Select all** tap selects only regular visible patches.
* Allow a second **Select all** tap to include universal patches when all regular patches in the current scope are already selected.
* Keep locked-off patches excluded from bulk selection.

## Why

Applying all universal patches may cause patching failures when users blindly tap **Select all**. This makes the default action safer while still allowing users to intentionally select every patch.

This also makes it easier for users who only want to select all regular patches without including universal patches. Previously, **Select all** would select both regular and universal patches at once, meaning users had to manually deselect the universal patches afterward. The new behavior makes the first selection more practical while still providing a simple way to select universal patches with a second tap.