### PR TITLE
feat: Add search and A-Z sorting to APK, patch selections, and patch sources screens

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -65,7 +65,10 @@ class PatchBundleRepository(
     val bundleState: StateFlow<BundleState> = store.state
         .stateIn(scope, SharingStarted.Eagerly, BundleState.Loading)
 
-    val sources = store.state.map { (it as? BundleState.Ready)?.sources?.values?.toList() ?: emptyList() }
+    // Hot so collectors see the loaded sources on their first frame instead of an empty list
+    val sources = store.state
+        .map { (it as? BundleState.Ready)?.sources?.values?.toList() ?: emptyList() }
+        .stateIn(scope, SharingStarted.Eagerly, emptyList())
     val bundles = store.state.map {
         (it as? BundleState.Ready)?.sources?.mapNotNull { (uid, src) ->
             uid to (src.patchBundle ?: return@mapNotNull null)

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -380,7 +380,7 @@ fun BatchPatcherScreen(
         title = stringResource(R.string.batch_patch_title),
         titleTrailingContent = if (current?.phase == BatchPhase.FINISHED && hasUnfinished) {
             {
-                DialogTitleAction(
+                TitleAction(
                     icon = Icons.Outlined.Refresh,
                     contentDescription = stringResource(R.string.retry),
                     onClick = viewModel::retryUnfinished

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -129,11 +129,11 @@ fun ExpertModeDialog(
                 tone = if (totalSelectedCount > 0) SemanticTone.Primary else SemanticTone.Neutral
             )
 
-            DialogTitleAction(
+            TitleAction(
                 icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
                 contentDescription = stringResource(R.string.expert_mode_search),
                 onClick = { search.toggle() },
-                style = DialogTitleActionStyle.Toggle,
+                style = TitleActionStyle.Toggle,
                 active = search.visible
             )
         },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -5,7 +5,6 @@
 
 package app.morphe.manager.ui.screen.home
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.*
@@ -77,8 +76,7 @@ fun ExpertModeDialog(
     onProceed: () -> Unit
 ) {
     val selectedPatchForOptions = remember { mutableStateOf<Pair<Int, PatchInfo>?>(null) }
-    var searchQuery by remember { mutableStateOf("") }
-    var searchVisible by remember { mutableStateOf(false) }
+    val search = rememberSearchFieldState()
     val showMultipleSourcesWarning = remember { mutableStateOf(false) }
     val context = LocalContext.current
 
@@ -108,14 +106,14 @@ fun ExpertModeDialog(
     }
 
     // Filter patches based on search query
-    val filteredPatchesInfo = remember(allPatchesInfo, searchQuery) {
-        if (searchQuery.isBlank()) {
+    val filteredPatchesInfo = remember(allPatchesInfo, search.query) {
+        if (search.query.isBlank()) {
             allPatchesInfo
         } else {
             allPatchesInfo.mapNotNull { (bundle, patches) ->
                 val filtered = patches.filter { (patch, _) ->
-                    patch.displayName.contains(searchQuery, ignoreCase = true) ||
-                            patch.description?.contains(searchQuery, ignoreCase = true) == true
+                    patch.displayName.contains(search.query, ignoreCase = true) ||
+                            patch.description?.contains(search.query, ignoreCase = true) == true
                 }
                 if (filtered.isEmpty()) null else bundle to filtered
             }
@@ -126,51 +124,25 @@ fun ExpertModeDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.expert_mode_title),
         titleTrailingContent = {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Count badge
-                StatusBadge(
-                    text = "$totalSelectedCount/$totalPatchesCount",
-                    tone = if (totalSelectedCount > 0) SemanticTone.Primary else SemanticTone.Neutral
-                )
+            StatusBadge(
+                text = "$totalSelectedCount/$totalPatchesCount",
+                tone = if (totalSelectedCount > 0) SemanticTone.Primary else SemanticTone.Neutral
+            )
 
-                // Search toggle button
-                FilledTonalIconButton(
-                    onClick = {
-                        if (searchVisible) searchQuery = ""
-                        searchVisible = !searchVisible
-                    },
-                    modifier = Modifier.size(36.dp),
-                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = if (searchVisible)
-                            MaterialTheme.colorScheme.primaryContainer
-                        else
-                            MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = if (searchVisible)
-                            MaterialTheme.colorScheme.onPrimaryContainer
-                        else
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Icon(
-                        imageVector = if (searchVisible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
-                        contentDescription = stringResource(R.string.expert_mode_search),
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
-            }
+            DialogTitleAction(
+                icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                contentDescription = stringResource(R.string.expert_mode_search),
+                onClick = { search.toggle() },
+                style = DialogTitleActionStyle.Toggle,
+                active = search.visible
+            )
         },
         dismissOnClickOutside = false,
         footer = null,
         padding = DialogPadding.Compact,
         scrollable = false
     ) {
-        BackHandler(enabled = searchVisible) {
-            searchQuery = ""
-            searchVisible = false
-        }
+        SearchFieldBackHandler(search)
 
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -178,7 +150,7 @@ fun ExpertModeDialog(
         ) {
             // Search bar
             AnimatedVisibility(
-                visible = searchVisible,
+                visible = search.visible,
                 enter = Animations.expandFadeEnter,
                 exit = Animations.shrinkFadeExit
             ) {
@@ -189,15 +161,16 @@ fun ExpertModeDialog(
                     keyboardController?.show()
                 }
                 AppDialogTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
+                    value = search.query,
+                    onValueChange = { search.query = it },
                     label = {
                         Text(stringResource(R.string.expert_mode_search))
                     },
                     leadingIcon = {
+                        // The label already announces the field, so the icon stays decorative
                         Icon(
                             imageVector = Icons.Outlined.Search,
-                            contentDescription = stringResource(R.string.expert_mode_search)
+                            contentDescription = null
                         )
                     },
                     showClearButton = true,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchOptions.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchOptions.kt
@@ -173,7 +173,7 @@ internal fun PatchOptionsDialog(
         onDismissRequest = onDismiss,
         title = patch.displayName,
         titleTrailingContent = {
-            DialogTitleAction(
+            TitleAction(
                 icon = Icons.Outlined.Restore,
                 contentDescription = stringResource(R.string.reset),
                 onClick = onReset

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
@@ -6,6 +6,7 @@
 package app.morphe.manager.ui.screen.home
 
 import android.view.HapticFeedbackConstants
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
@@ -115,13 +116,7 @@ fun AppPatchesDialog(
     }
 
     AppDialog(
-        onDismissRequest = {
-            when {
-                searchQuery.value.isNotBlank() -> searchQuery.value = ""
-                selectedBundle.value != null -> selectedBundle.value = null
-                else -> onDismiss()
-            }
-        },
+        onDismissRequest = onDismiss,
         dismissOnClickOutside = true,
         title = null,
         padding = DialogPadding.Compact,
@@ -135,6 +130,11 @@ fun AppPatchesDialog(
             )
         }
     ) {
+        // Back unwinds the active filters before the dialog itself. Registered last so the
+        // query clears first, and kept off onDismissRequest so an outside tap still dismisses.
+        BackHandler(enabled = selectedBundle.value != null) { selectedBundle.value = null }
+        BackHandler(enabled = searchQuery.value.isNotBlank()) { searchQuery.value = "" }
+
         val listState = rememberLazyListState()
         val activeBundleLabel = remember { mutableStateOf("") }
         LaunchedEffect(selectedBundle.value) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -1132,7 +1132,9 @@ private fun InstalledAppPickerDialog(
                 AppFilter.UserOnly -> Icons.Outlined.Person to labelUser
                 AppFilter.SystemOnly -> Icons.Outlined.Android to labelSystem
             }
-            FilledTonalIconButton(
+            DialogTitleAction(
+                icon = icon,
+                contentDescription = description,
                 onClick = {
                     appFilter = when (appFilter) {
                         AppFilter.All -> AppFilter.UserOnly
@@ -1147,17 +1149,9 @@ private fun InstalledAppPickerDialog(
                         }
                     )
                 },
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = description,
-                    modifier = Modifier.size(Defaults.IconSizeSmall)
-                )
-            }
+                style = DialogTitleActionStyle.Toggle,
+                active = appFilter != AppFilter.All
+            )
         },
         footer = {
             AppDialogOutlinedButton(
@@ -1178,24 +1172,12 @@ private fun InstalledAppPickerDialog(
                 userScrollEnabled = !isLoading
             ) {
                 stickyHeader {
-                    Surface(
-                        modifier = Modifier.fillMaxWidth(),
-                        color = MaterialTheme.colorScheme.surface
-                    ) {
-                        AppDialogTextField(
-                            value = searchQuery.value,
-                            onValueChange = { searchQuery.value = it },
-                            placeholder = { Text(stringResource(R.string.search)) },
-                            leadingIcon = {
-                                Icon(imageVector = Icons.Outlined.Search, contentDescription = null)
-                            },
-                            showClearButton = true,
-                            enabled = !isLoading,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = 4.dp)
-                        )
-                    }
+                    AppDialogSearchTextField(
+                        value = searchQuery.value,
+                        onValueChange = { searchQuery.value = it },
+                        label = stringResource(R.string.search),
+                        enabled = !isLoading
+                    )
                 }
 
                 if (isLoading) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -1132,7 +1132,7 @@ private fun InstalledAppPickerDialog(
                 AppFilter.UserOnly -> Icons.Outlined.Person to labelUser
                 AppFilter.SystemOnly -> Icons.Outlined.Android to labelSystem
             }
-            DialogTitleAction(
+            TitleAction(
                 icon = icon,
                 contentDescription = description,
                 onClick = {
@@ -1149,7 +1149,7 @@ private fun InstalledAppPickerDialog(
                         }
                     )
                 },
-                style = DialogTitleActionStyle.Toggle,
+                style = TitleActionStyle.Toggle,
                 active = appFilter != AppFilter.All
             )
         },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeSearch.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeSearch.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
 import app.morphe.manager.ui.model.HomeAppItem
-import app.morphe.manager.ui.screen.shared.LocalDialogTextColor
-import app.morphe.manager.ui.screen.shared.Defaults
 import app.morphe.manager.ui.screen.shared.AppDialogTextField
+import app.morphe.manager.ui.screen.shared.Defaults
+import app.morphe.manager.ui.screen.shared.LocalDialogTextColor
 
 /**
  * Wraps [AppDialogTextField] with [LocalDialogTextColor] set to onSurface
@@ -69,9 +69,10 @@ internal fun HomeSearchTextField(
             onValueChange = onValueChange,
             label = { Text(label) },
             leadingIcon = {
+                // The label already announces the field, so the icon stays decorative
                 Icon(
                     imageVector = Icons.Outlined.Search,
-                    contentDescription = label
+                    contentDescription = null
                 )
             },
             showClearButton = true,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeSearch.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeSearch.kt
@@ -50,6 +50,7 @@ internal fun HomeSearchTextField(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
+    label: String = stringResource(R.string.home_search_apps),
     requestFocus: Boolean = false
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -66,11 +67,11 @@ internal fun HomeSearchTextField(
         AppDialogTextField(
             value = value,
             onValueChange = onValueChange,
-            label = { Text(stringResource(R.string.home_search_apps)) },
+            label = { Text(label) },
             leadingIcon = {
                 Icon(
                     imageVector = Icons.Outlined.Search,
-                    contentDescription = stringResource(R.string.home_search_apps)
+                    contentDescription = label
                 )
             },
             showClearButton = true,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -93,7 +93,7 @@ fun BundleManagementSheet(
     val prefs: PreferencesManager = koinInject()
     val scope = rememberCoroutineScope()
 
-    val sources by patchBundleRepository.sources.collectAsStateWithLifecycle(emptyList())
+    val sources by patchBundleRepository.sources.collectAsStateWithLifecycle()
     val patchCounts by patchBundleRepository.patchCountsFlow.collectAsStateWithLifecycle(emptyMap())
     val manualUpdateInfo by patchBundleRepository.manualUpdateInfo.collectAsStateWithLifecycle(emptyMap())
     val activeUpdateUids by patchBundleRepository.activeUpdateUidsFlow.collectAsStateWithLifecycle(emptySet())

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -106,8 +106,9 @@ fun BundleManagementSheet(
 
     val bundleToDelete = remember { mutableStateOf<PatchBundleSource?>(null) }
     var showSortDialog by remember { mutableStateOf(false) }
-    var searchQuery by remember { mutableStateOf("") }
-    var searchVisible by remember { mutableStateOf(false) }
+    // Search is offered from two sources up
+    val isSearchable = sources.size >= 2
+    val search = rememberSearchFieldState(searchable = isSearchable)
     // Expanded state lifted out of LazyColumn so it survives scroll-off-screen recomposition
     var expandedBundleUids by remember { mutableStateOf<Set<Int>>(emptySet()) }
 
@@ -142,20 +143,20 @@ fun BundleManagementSheet(
     val orderedSources = remember(localOrder, sources, sourceSortMode) {
         sources.sortedForSourceSort(sourceSortMode, localOrder)
     }
-    val visibleSources = remember(orderedSources, searchQuery) {
-        if (searchQuery.isBlank()) orderedSources
+    val visibleSources = remember(orderedSources, search.query) {
+        if (search.query.isBlank()) orderedSources
         else orderedSources.filter { source ->
-            source.displayTitle.contains(searchQuery, ignoreCase = true) ||
-                    source.name.contains(searchQuery, ignoreCase = true)
+            source.displayTitle.contains(search.query, ignoreCase = true) ||
+                    source.name.contains(search.query, ignoreCase = true)
         }
     }
     val alphabetScrollMode = sourceSortMode == SourceBundleSortMode.NAME_ASC ||
             sourceSortMode == SourceBundleSortMode.NAME_DESC
-    val sourceScrollTargets = remember(alphabetScrollMode, orderedSources) {
+    val sourceScrollTargets = remember(alphabetScrollMode, visibleSources) {
         if (!alphabetScrollMode) {
             emptyList()
         } else {
-            buildIndexedScrollTargets(orderedSources) { source -> source.displayTitle }
+            buildIndexedScrollTargets(visibleSources) { source -> source.displayTitle }
         }
     }
     val haptic = LocalHapticFeedback.current
@@ -195,6 +196,9 @@ fun BundleManagementSheet(
         val uriHandler = LocalUriHandler.current
         val failedToOpenUrlText = stringResource(R.string.sources_management_failed_to_open_url)
 
+        // Registered inside the sheet content so it outranks the sheet's own dismiss handler
+        SearchFieldBackHandler(search)
+
         Box {
             Column(Modifier.fillMaxWidth()) {
                 // Header - outside scrollable area
@@ -224,48 +228,55 @@ fun BundleManagementSheet(
                         }
 
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            AnimatedVisibility(visible = sources.size >= 2) {
-                                FilledIconButton(
-                                    onClick = {
-                                        if (searchVisible) searchQuery = ""
-                                        searchVisible = !searchVisible
-                                    },
-                                    colors = IconButtonDefaults.filledIconButtonColors(
-                                        containerColor = if (searchVisible)
-                                            MaterialTheme.colorScheme.primary
-                                        else
-                                            MaterialTheme.colorScheme.primaryContainer
-                                    )
+                            AnimatedVisibility(visible = isSearchable) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
+                                    verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Icon(
-                                        imageVector = if (searchVisible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
-                                        contentDescription = stringResource(R.string.search)
-                                    )
-                                }
-                            }
-                            AnimatedVisibility(visible = sources.size >= 2) {
-                                val activeSortLabel = stringResource(sourceSortMode.labelRes)
-                                FilledIconButton(
-                                    onClick = { showSortDialog = true },
-                                    modifier = Modifier.semantics {
-                                        role = Role.Button
-                                        stateDescription = activeSortLabel
-                                    },
-                                    colors = IconButtonDefaults.filledIconButtonColors(
-                                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                                    )
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Outlined.Sort,
-                                        contentDescription = stringResource(R.string.sort)
-                                    )
+                                    FilledIconButton(
+                                        onClick = { search.toggle() },
+                                        // Pinned to the container the button already draws, otherwise
+                                        // it reserves the 48dp touch target and doubles the row spacing
+                                        modifier = Modifier.size(IconButtonDefaults.smallContainerSize()),
+                                        colors = IconButtonDefaults.filledIconButtonColors(
+                                            containerColor = if (search.visible)
+                                                MaterialTheme.colorScheme.primary
+                                            else
+                                                MaterialTheme.colorScheme.primaryContainer
+                                        )
+                                    ) {
+                                        Icon(
+                                            imageVector = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                                            contentDescription = stringResource(R.string.search)
+                                        )
+                                    }
+
+                                    val activeSortLabel = stringResource(sourceSortMode.labelRes)
+                                    FilledIconButton(
+                                        onClick = { showSortDialog = true },
+                                        modifier = Modifier
+                                            .size(IconButtonDefaults.smallContainerSize())
+                                            .semantics {
+                                                role = Role.Button
+                                                stateDescription = activeSortLabel
+                                            },
+                                        colors = IconButtonDefaults.filledIconButtonColors(
+                                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                                        )
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.AutoMirrored.Outlined.Sort,
+                                            contentDescription = stringResource(R.string.sort)
+                                        )
+                                    }
                                 }
                             }
                             FilledIconButton(
                                 onClick = onAddSource,
+                                modifier = Modifier.size(IconButtonDefaults.smallContainerSize()),
                                 colors = IconButtonDefaults.filledIconButtonColors(
                                     containerColor = MaterialTheme.colorScheme.primaryContainer
                                 )
@@ -279,13 +290,13 @@ fun BundleManagementSheet(
                     }
 
                     AnimatedVisibility(
-                        visible = searchVisible && sources.size >= 2,
+                        visible = search.visible,
                         enter = Animations.expandFadeEnter,
                         exit = Animations.shrinkFadeExit
                     ) {
                         HomeSearchTextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
+                            value = search.query,
+                            onValueChange = { search.query = it },
                             label = stringResource(R.string.sources_search),
                             requestFocus = true,
                             modifier = Modifier
@@ -316,7 +327,7 @@ fun BundleManagementSheet(
                             bottom = 16.dp
                         )
                     ) {
-                        if (visibleSources.isEmpty() && searchQuery.isNotBlank()) {
+                        if (search.isFiltering && visibleSources.isEmpty()) {
                             item(key = "search_empty") {
                                 EmptyState(
                                     message = stringResource(R.string.search_no_results),
@@ -415,7 +426,9 @@ fun BundleManagementSheet(
                                     },
                                     forceExpanded = isSingleDefaultBundle,
                                     isDragging = itemIsDragging,
-                                    longPressModifier = if (isManualSort) {
+                                    // Reorder maps list positions onto the full order, so a
+                                    // filtered list would move the wrong sources
+                                    longPressModifier = if (isManualSort && !search.isFiltering) {
                                         Modifier.longPressDraggableHandle(
                                             onDragStarted = {
                                                 isDragging = true

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -106,6 +106,8 @@ fun BundleManagementSheet(
 
     val bundleToDelete = remember { mutableStateOf<PatchBundleSource?>(null) }
     var showSortDialog by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    var searchVisible by remember { mutableStateOf(false) }
     // Expanded state lifted out of LazyColumn so it survives scroll-off-screen recomposition
     var expandedBundleUids by remember { mutableStateOf<Set<Int>>(emptySet()) }
 
@@ -139,6 +141,13 @@ fun BundleManagementSheet(
     val isManualSort = sourceSortMode == SourceBundleSortMode.MANUAL
     val orderedSources = remember(localOrder, sources, sourceSortMode) {
         sources.sortedForSourceSort(sourceSortMode, localOrder)
+    }
+    val visibleSources = remember(orderedSources, searchQuery) {
+        if (searchQuery.isBlank()) orderedSources
+        else orderedSources.filter { source ->
+            source.displayTitle.contains(searchQuery, ignoreCase = true) ||
+                    source.name.contains(searchQuery, ignoreCase = true)
+        }
     }
     val alphabetScrollMode = sourceSortMode == SourceBundleSortMode.NAME_ASC ||
             sourceSortMode == SourceBundleSortMode.NAME_DESC
@@ -219,6 +228,25 @@ fun BundleManagementSheet(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             AnimatedVisibility(visible = sources.size >= 2) {
+                                FilledIconButton(
+                                    onClick = {
+                                        if (searchVisible) searchQuery = ""
+                                        searchVisible = !searchVisible
+                                    },
+                                    colors = IconButtonDefaults.filledIconButtonColors(
+                                        containerColor = if (searchVisible)
+                                            MaterialTheme.colorScheme.primary
+                                        else
+                                            MaterialTheme.colorScheme.primaryContainer
+                                    )
+                                ) {
+                                    Icon(
+                                        imageVector = if (searchVisible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                                        contentDescription = stringResource(R.string.search)
+                                    )
+                                }
+                            }
+                            AnimatedVisibility(visible = sources.size >= 2) {
                                 val activeSortLabel = stringResource(sourceSortMode.labelRes)
                                 FilledIconButton(
                                     onClick = { showSortDialog = true },
@@ -250,6 +278,22 @@ fun BundleManagementSheet(
                         }
                     }
 
+                    AnimatedVisibility(
+                        visible = searchVisible && sources.size >= 2,
+                        enter = Animations.expandFadeEnter,
+                        exit = Animations.shrinkFadeExit
+                    ) {
+                        HomeSearchTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            label = stringResource(R.string.sources_search),
+                            requestFocus = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 8.dp)
+                        )
+                    }
+
                     Spacer(Modifier.height(8.dp))
                 }
 
@@ -272,7 +316,16 @@ fun BundleManagementSheet(
                             bottom = 16.dp
                         )
                     ) {
-                        items(orderedSources, key = { bundle -> bundle.uid }) { bundle ->
+                        if (visibleSources.isEmpty() && searchQuery.isNotBlank()) {
+                            item(key = "search_empty") {
+                                EmptyState(
+                                    message = stringResource(R.string.search_no_results),
+                                    icon = Icons.Outlined.SearchOff
+                                )
+                            }
+                        }
+
+                        items(visibleSources, key = { bundle -> bundle.uid }) { bundle ->
                             val hasExperimentalVersions = remember(bundle.uid, bundleInfo) {
                                 bundleInfo[bundle.uid]?.patches?.any { patch ->
                                     patch.compatiblePackages?.any { pkg ->
@@ -282,7 +335,7 @@ fun BundleManagementSheet(
                             }
                             val useExperimentalVersions = bundle.uid.toString() in experimentalVersionsEnabled
 
-                            val isFirstCard = bundle.uid == orderedSources.firstOrNull()?.uid
+                            val isFirstCard = bundle.uid == visibleSources.firstOrNull()?.uid
                             ReorderableItem(
                                 reorderableState,
                                 key = bundle.uid,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -236,56 +236,33 @@ fun BundleManagementSheet(
                                     horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    FilledIconButton(
+                                    TitleAction(
+                                        icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                                        contentDescription = stringResource(R.string.search),
                                         onClick = { search.toggle() },
-                                        // Pinned to the container the button already draws, otherwise
-                                        // it reserves the 48dp touch target and doubles the row spacing
-                                        modifier = Modifier.size(IconButtonDefaults.smallContainerSize()),
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = if (search.visible)
-                                                MaterialTheme.colorScheme.primary
-                                            else
-                                                MaterialTheme.colorScheme.primaryContainer
-                                        )
-                                    ) {
-                                        Icon(
-                                            imageVector = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
-                                            contentDescription = stringResource(R.string.search)
-                                        )
-                                    }
+                                        style = TitleActionStyle.AccentToggle,
+                                        active = search.visible
+                                    )
 
                                     val activeSortLabel = stringResource(sourceSortMode.labelRes)
-                                    FilledIconButton(
+                                    TitleAction(
+                                        icon = Icons.AutoMirrored.Outlined.Sort,
+                                        contentDescription = stringResource(R.string.sort),
                                         onClick = { showSortDialog = true },
-                                        modifier = Modifier
-                                            .size(IconButtonDefaults.smallContainerSize())
-                                            .semantics {
-                                                role = Role.Button
-                                                stateDescription = activeSortLabel
-                                            },
-                                        colors = IconButtonDefaults.filledIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.primaryContainer
-                                        )
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Outlined.Sort,
-                                            contentDescription = stringResource(R.string.sort)
-                                        )
-                                    }
+                                        modifier = Modifier.semantics {
+                                            role = Role.Button
+                                            stateDescription = activeSortLabel
+                                        },
+                                        style = TitleActionStyle.Accent
+                                    )
                                 }
                             }
-                            FilledIconButton(
+                            TitleAction(
+                                icon = Icons.Default.Add,
+                                contentDescription = stringResource(R.string.add),
                                 onClick = onAddSource,
-                                modifier = Modifier.size(IconButtonDefaults.smallContainerSize()),
-                                colors = IconButtonDefaults.filledIconButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer
-                                )
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = stringResource(R.string.add)
-                                )
-                            }
+                                style = TitleActionStyle.Accent
+                            )
                         }
                     }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/PatchOptionsDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/PatchOptionsDialogs.kt
@@ -75,7 +75,7 @@ fun ThemeColorDialog(
         onDismissRequest = onDismiss,
         title = stringResource(R.string.settings_advanced_patch_options_theme_colors),
         titleTrailingContent = {
-            DialogTitleAction(
+            TitleAction(
                 icon = Icons.Outlined.Restore,
                 contentDescription = stringResource(R.string.reset),
                 onClick = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -776,20 +776,20 @@ private fun ApkManagementDialogContent(
         titleTrailingContent = if (isSearchable || canDeleteAll) {
             {
                 if (isSearchable) {
-                    DialogTitleAction(
+                    TitleAction(
                         icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
                         contentDescription = stringResource(R.string.search),
                         onClick = { search.toggle() },
-                        style = DialogTitleActionStyle.Toggle,
+                        style = TitleActionStyle.Toggle,
                         active = search.visible
                     )
                 }
                 if (canDeleteAll) {
-                    DialogTitleAction(
+                    TitleAction(
                         icon = Icons.Outlined.DeleteForever,
                         contentDescription = stringResource(R.string.delete_all),
                         onClick = { showDeleteAllConfirmation = true },
-                        style = DialogTitleActionStyle.Destructive
+                        style = TitleActionStyle.Destructive
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -22,10 +22,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -714,13 +712,15 @@ private fun ApkManagementDialogContent(
     var itemToUninstallConfirm by remember { mutableStateOf<ApkItemData?>(null) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
     var isExporting by remember { mutableStateOf(false) }
-    var searchQuery by remember { mutableStateOf("") }
     val selection = rememberSelectionState<String>()
-    val filteredItems = remember(items, searchQuery) {
-        if (searchQuery.isBlank()) items
+    // Nothing to narrow down while loading or with a single entry
+    val isSearchable = !meta.isLoading && items.size >= 2
+    val search = rememberSearchFieldState(searchable = isSearchable)
+    val filteredItems = remember(items, search.query) {
+        if (search.query.isBlank()) items
         else items.filter {
-            it.displayName.contains(searchQuery, ignoreCase = true) ||
-                    it.packageName.contains(searchQuery, ignoreCase = true)
+            it.displayName.contains(search.query, ignoreCase = true) ||
+                    it.packageName.contains(search.query, ignoreCase = true)
         }
     }
     val selectedItems = items.filter { selection.contains(it.selectionKey) }
@@ -735,6 +735,8 @@ private fun ApkManagementDialogContent(
     val canInstallSelected = selectedItems.isNotEmpty() &&
             selectedInstallableItems.size == selectedItems.size &&
             actions.onInstallSelected != null
+    val canDeleteAll = selectedItems.isEmpty() && items.isNotEmpty() &&
+            actions.onDeleteAllConfirm != null
     val selectedTotalSize = selectedItems.sumOf { it.fileSize }
     val zipExportSuccessText = stringResource(R.string.settings_system_apks_export_zip_success)
     val zipExportFailedText = stringResource(R.string.settings_system_apks_export_zip_failed)
@@ -771,14 +773,25 @@ private fun ApkManagementDialogContent(
             if (isMultiSelectMode) { selection.clear(); isMultiSelectMode = false } else onDismissRequest()
         },
         title = meta.title,
-        titleTrailingContent = if (selectedItems.isEmpty() && items.isNotEmpty() && actions.onDeleteAllConfirm != null) {
+        titleTrailingContent = if (isSearchable || canDeleteAll) {
             {
-                DialogTitleAction(
-                    icon = Icons.Outlined.DeleteForever,
-                    contentDescription = stringResource(R.string.delete_all),
-                    onClick = { showDeleteAllConfirmation = true },
-                    style = DialogTitleActionStyle.Destructive
-                )
+                if (isSearchable) {
+                    DialogTitleAction(
+                        icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                        contentDescription = stringResource(R.string.search),
+                        onClick = { search.toggle() },
+                        style = DialogTitleActionStyle.Toggle,
+                        active = search.visible
+                    )
+                }
+                if (canDeleteAll) {
+                    DialogTitleAction(
+                        icon = Icons.Outlined.DeleteForever,
+                        contentDescription = stringResource(R.string.delete_all),
+                        onClick = { showDeleteAllConfirmation = true },
+                        style = DialogTitleActionStyle.Destructive
+                    )
+                }
             }
         } else {
             null
@@ -789,12 +802,13 @@ private fun ApkManagementDialogContent(
                     SelectionActionBar(
                         modifier = Modifier.padding(horizontal = Defaults.ContentPadding, vertical = Defaults.ItemSpacing),
                         selectedCount = selectedItems.size,
-                        totalCount = items.size,
+                        // Scoped to the filtered list so "select all" never reaches hidden entries
+                        totalCount = filteredItems.size,
                         subtitle = stringResource(
                             R.string.settings_system_apks_size,
                             formatBytes(selectedTotalSize)
                         ),
-                        onSelectAll = { selection.setAll(items.map { it.selectionKey }) },
+                        onSelectAll = { selection.setAll(filteredItems.map { it.selectionKey }) },
                         onDeselectAll = { selection.clear() },
                         onCancel = { selection.clear(); isMultiSelectMode = false }
                     ) {
@@ -880,6 +894,8 @@ private fun ApkManagementDialogContent(
         padding = DialogPadding.Compact,
         contentArrangement = Arrangement.Top
     ) {
+        SearchFieldBackHandler(search)
+
         val listState = rememberLazyListState()
         Box(modifier = Modifier.fillMaxWidth()) {
             LazyColumn(
@@ -887,25 +903,13 @@ private fun ApkManagementDialogContent(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)
             ) {
-                stickyHeader(key = "search") {
-                    Surface(
-                        modifier = Modifier.fillMaxWidth(),
-                        color = MaterialTheme.colorScheme.surface
-                    ) {
-                        AppDialogTextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
-                            label = { Text(stringResource(R.string.home_search_apps)) },
-                            leadingIcon = {
-                                Icon(
-                                    imageVector = Icons.Outlined.Search,
-                                    contentDescription = stringResource(R.string.home_search_apps)
-                                )
-                            },
-                            showClearButton = true,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = 4.dp)
+                if (isSearchable) {
+                    stickyHeader(key = "search") {
+                        AppDialogSearchHeader(
+                            visible = search.visible,
+                            value = search.query,
+                            onValueChange = { search.query = it },
+                            label = stringResource(R.string.home_search_apps)
                         )
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -712,7 +714,15 @@ private fun ApkManagementDialogContent(
     var itemToUninstallConfirm by remember { mutableStateOf<ApkItemData?>(null) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
     var isExporting by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
     val selection = rememberSelectionState<String>()
+    val filteredItems = remember(items, searchQuery) {
+        if (searchQuery.isBlank()) items
+        else items.filter {
+            it.displayName.contains(searchQuery, ignoreCase = true) ||
+                    it.packageName.contains(searchQuery, ignoreCase = true)
+        }
+    }
     val selectedItems = items.filter { selection.contains(it.selectionKey) }
     val selectedFiles = selectedItems.mapNotNull { item -> item.file?.takeIf { it.exists() } }
     val selectedInstalledItems = selectedItems.filter { it.isInstalledOnDevice }
@@ -877,6 +887,29 @@ private fun ApkManagementDialogContent(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)
             ) {
+                stickyHeader(key = "search") {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.surface
+                    ) {
+                        AppDialogTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            label = { Text(stringResource(R.string.home_search_apps)) },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Search,
+                                    contentDescription = stringResource(R.string.home_search_apps)
+                                )
+                            },
+                            showClearButton = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 4.dp)
+                        )
+                    }
+                }
+
                 if (retentionToggle != null) {
                     item(key = "retention") {
                         Column(verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)) {
@@ -937,7 +970,13 @@ private fun ApkManagementDialogContent(
                     // Show shimmer while loading
                     meta.isLoading -> items(3) { ShimmerApkItem() }
                     meta.isEmpty -> item { EmptyState(message = meta.emptyMessage) }
-                    else -> items(items = items, key = { it.selectionKey }) { item ->
+                    filteredItems.isEmpty() -> item(key = "search_empty") {
+                        EmptyState(
+                            message = stringResource(R.string.search_no_results),
+                            icon = Icons.Outlined.SearchOff
+                        )
+                    }
+                    else -> items(items = filteredItems, key = { it.selectionKey }) { item ->
                         val selected = selection.contains(item.selectionKey)
                         ApkItemCard(
                             data = item,

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import java.io.File
+import java.util.Locale
 
 /** Type of APKs to manage. */
 enum class ApkManagementType {
@@ -86,6 +87,9 @@ private val ApkItemData.selectionKey: String
 
 private val ApkItemData.isInstallableFromStorage: Boolean
     get() = file?.exists() == true && installType != InstallType.MOUNT
+
+private fun List<ApkItemData>.sortedByDisplayName(): List<ApkItemData> =
+    sortedBy { it.displayName.lowercase(Locale.ROOT) }
 
 private val ApkItemData.installLabelRes: Int
     get() = when (installType) {
@@ -251,7 +255,7 @@ private fun PatchedApksContent(
     var deleteDisplayName by remember { mutableStateOf("") }
 
     // Look up by selectionKey to avoid index shifts on concurrent list updates
-    val displayItems = remember(state) { apkItems.map { it.toApkItemData() } }
+    val displayItems = remember(state) { apkItems.map { it.toApkItemData() }.sortedByDisplayName() }
     val appByKey = remember(state) {
         apkItems.associate { it.toApkItemData().selectionKey to it.installedApp }
     }
@@ -514,7 +518,7 @@ private fun OriginalApksContent(
 
     val isLoading = state is ApkLoadState.Loading
     val entries = (state as? ApkLoadState.Loaded)?.items ?: emptyList()
-    val apkItems = remember(state) { entries.map { it.data } }
+    val apkItems = remember(state) { entries.map { it.data }.sortedByDisplayName() }
     val apkByKey = remember(state) { entries.associate { it.data.selectionKey to it.apk } }
     val totalSize = remember(state) { apkItems.sumOf { it.fileSize } }
     val itemToDelete = remember { mutableStateOf<OriginalApk?>(null) }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -304,19 +304,36 @@ private fun PatchSelectionManagementDialogContent(
         uri?.let { importExportViewModel.exportAllSelections(it) }
     }
 
+    // Nothing to narrow down with a single entry
+    val isSearchable = selections.size >= 2
+    // Hoisted out of the list so the title action can drive it
+    val search = rememberSearchFieldState(searchable = isSearchable)
+    val canResetAll = !multiSelect.isSelectionMode && selections.isNotEmpty()
+
     AppDialog(
         onDismissRequest = {
             if (multiSelect.isSelectionMode) onExitSelection() else onDismiss()
         },
         title = stringResource(R.string.settings_system_patch_selections_title),
-        titleTrailingContent = if (!multiSelect.isSelectionMode && selections.isNotEmpty()) {
+        titleTrailingContent = if (isSearchable || canResetAll) {
             {
-                DialogTitleAction(
-                    icon = Icons.Outlined.Restore,
-                    contentDescription = stringResource(R.string.reset),
-                    onClick = onShowResetAllConfirmation,
-                    style = DialogTitleActionStyle.Destructive
-                )
+                if (isSearchable) {
+                    DialogTitleAction(
+                        icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
+                        contentDescription = stringResource(R.string.search),
+                        onClick = { search.toggle() },
+                        style = DialogTitleActionStyle.Toggle,
+                        active = search.visible
+                    )
+                }
+                if (canResetAll) {
+                    DialogTitleAction(
+                        icon = Icons.Outlined.Restore,
+                        contentDescription = stringResource(R.string.reset),
+                        onClick = onShowResetAllConfirmation,
+                        style = DialogTitleActionStyle.Destructive
+                    )
+                }
             }
         } else {
             null
@@ -383,6 +400,8 @@ private fun PatchSelectionManagementDialogContent(
         padding = DialogPadding.Compact,
         contentArrangement = Arrangement.Top
     ) {
+        SearchFieldBackHandler(search)
+
         if (selections.isEmpty()) {
             EmptyState(message = stringResource(R.string.settings_system_no_patches_or_options))
         } else {
@@ -391,6 +410,7 @@ private fun PatchSelectionManagementDialogContent(
                 multiSelect = multiSelect,
                 settingsViewModel = settingsViewModel,
                 importExportViewModel = importExportViewModel,
+                search = search,
                 onSetResetTarget = onSetResetTarget,
                 onShowPatchDetails = onShowPatchDetails,
                 onOpenCopyFromBundle = onOpenCopyFromBundle,
@@ -409,6 +429,7 @@ private fun SelectionList(
     multiSelect: PatchSelectionMultiSelect,
     settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel,
+    search: SearchFieldState,
     onSetResetTarget: (ResetTarget) -> Unit,
     onShowPatchDetails: (PatchDetailsTarget) -> Unit,
     onOpenCopyFromBundle: (CopyTarget) -> Unit,
@@ -417,33 +438,33 @@ private fun SelectionList(
     val selections = data.selections
     val listState = rememberLazyListState()
     val expandedPackages = remember { mutableStateOf<Set<String>>(emptySet()) }
-    var searchQuery by remember { mutableStateOf("") }
 
-    // Resolve display names once so the list can be sorted A-Z by app name.
-    // Falls back to the package name while a resolution is still in flight.
-    val displayNameByPackage = remember(selections) { mutableStateMapOf<String, String>() }
+    // Resolved here rather than per row: the list sorts by these names, and each row would
+    // otherwise repeat the same lookup. Falls back to the package name while one is in flight.
+    val resolvedApps = remember(selections) {
+        mutableStateMapOf<String, Pair<String, AppDataSource>>()
+    }
     LaunchedEffect(selections) {
-        displayNameByPackage.clear()
+        resolvedApps.clear()
         selections.keys.forEach { packageName ->
-            val (name, _) = settingsViewModel.resolveAppDisplayName(packageName)
-            displayNameByPackage[packageName] = name
+            launch { resolvedApps[packageName] = settingsViewModel.resolveAppDisplayName(packageName) }
         }
     }
 
-    // Filter by app/package name, then sort A-Z by display name.
-    // Derived state so the list re-sorts as display names finish resolving.
-    val displayEntries by remember(selections, searchQuery, displayNameByPackage) {
+    // Derived so the list re-filters and re-sorts as display names finish resolving
+    val displayEntries by remember(selections) {
         derivedStateOf {
+            val query = search.query
+            val displayNameOf = { packageName: String ->
+                resolvedApps[packageName]?.first ?: packageName
+            }
             selections.entries
                 .filter { (packageName, _) ->
-                    searchQuery.isBlank() ||
-                        packageName.contains(searchQuery, ignoreCase = true) ||
-                        (displayNameByPackage[packageName] ?: packageName)
-                            .contains(searchQuery, ignoreCase = true)
+                    query.isBlank() ||
+                        packageName.contains(query, ignoreCase = true) ||
+                        displayNameOf(packageName).contains(query, ignoreCase = true)
                 }
-                .sortedBy { (packageName, _) ->
-                    (displayNameByPackage[packageName] ?: packageName).lowercase(Locale.ROOT)
-                }
+                .sortedBy { (packageName, _) -> displayNameOf(packageName).lowercase(Locale.ROOT) }
         }
     }
 
@@ -453,28 +474,13 @@ private fun SelectionList(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)
         ) {
-            // Sticky search bar
             stickyHeader(key = "search") {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.surface
-                ) {
-                    AppDialogTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        label = { Text(stringResource(R.string.home_search_apps)) },
-                        leadingIcon = {
-                            Icon(
-                                imageVector = Icons.Outlined.Search,
-                                contentDescription = stringResource(R.string.home_search_apps)
-                            )
-                        },
-                        showClearButton = true,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 4.dp)
-                    )
-                }
+                AppDialogSearchHeader(
+                    visible = search.visible,
+                    value = search.query,
+                    onValueChange = { search.query = it },
+                    label = stringResource(R.string.home_search_apps)
+                )
             }
 
             // Summary box
@@ -489,7 +495,7 @@ private fun SelectionList(
                     subtitle = {
                         Text(
                             text = pluralStringResource(
-                                R.plurals.patch_selection_total_patches,
+                                R.plurals.patch_count,
                                 data.totalSelections,
                                 data.totalSelections
                             ),
@@ -514,34 +520,37 @@ private fun SelectionList(
                     items = displayEntries,
                     key = { it.key }
                 ) { (packageName, bundleMap) ->
-                PackageSelectionItem(
-                    packageName = packageName,
-                    bundleMap = bundleMap,
-                    bundleNames = data.bundleNames,
-                    settingsViewModel = settingsViewModel,
-                    importExportViewModel = importExportViewModel,
-                    onResetPackage = {
-                        onSetResetTarget(ResetTarget.Package(packageName))
-                    },
-                    onResetPackageBundle = { bundleUid ->
-                        onSetResetTarget(ResetTarget.PackageBundle(packageName, bundleUid))
-                    },
-                    onShowPatchDetails = onShowPatchDetails,
-                    onOpenCopyFromBundle = onOpenCopyFromBundle,
-                    onImport = onImport,
-                    isSelected = multiSelect.selectedPackages.contains(packageName),
-                    isSelectionMode = multiSelect.isSelectionMode,
-                    onEnterSelection = { multiSelect.onEnterSelection(packageName) },
-                    onToggleSelection = { multiSelect.onToggleSelection(packageName) },
-                    expanded = packageName in expandedPackages.value,
-                    onToggleExpanded = {
-                        expandedPackages.value = if (packageName in expandedPackages.value) {
-                            expandedPackages.value - packageName
-                        } else {
-                            expandedPackages.value + packageName
+                    val (displayName, appDataSource) = resolvedApps[packageName]
+                        ?: (packageName to AppDataSource.INSTALLED)
+                    PackageSelectionItem(
+                        packageName = packageName,
+                        displayName = displayName,
+                        appDataSource = appDataSource,
+                        bundleMap = bundleMap,
+                        bundleNames = data.bundleNames,
+                        importExportViewModel = importExportViewModel,
+                        onResetPackage = {
+                            onSetResetTarget(ResetTarget.Package(packageName))
+                        },
+                        onResetPackageBundle = { bundleUid ->
+                            onSetResetTarget(ResetTarget.PackageBundle(packageName, bundleUid))
+                        },
+                        onShowPatchDetails = onShowPatchDetails,
+                        onOpenCopyFromBundle = onOpenCopyFromBundle,
+                        onImport = onImport,
+                        isSelected = multiSelect.selectedPackages.contains(packageName),
+                        isSelectionMode = multiSelect.isSelectionMode,
+                        onEnterSelection = { multiSelect.onEnterSelection(packageName) },
+                        onToggleSelection = { multiSelect.onToggleSelection(packageName) },
+                        expanded = packageName in expandedPackages.value,
+                        onToggleExpanded = {
+                            expandedPackages.value = if (packageName in expandedPackages.value) {
+                                expandedPackages.value - packageName
+                            } else {
+                                expandedPackages.value + packageName
+                            }
                         }
-                    }
-                )
+                    )
                 }
             }
         }
@@ -564,9 +573,10 @@ private fun SelectionList(
 @Composable
 private fun PackageSelectionItem(
     packageName: String,
+    displayName: String,
+    appDataSource: AppDataSource,
     bundleMap: Map<Int, Int>,
     bundleNames: Map<Int, String>,
-    settingsViewModel: SettingsViewModel,
     importExportViewModel: ImportExportViewModel,
     onResetPackage: () -> Unit,
     onResetPackageBundle: (Int) -> Unit,
@@ -580,16 +590,7 @@ private fun PackageSelectionItem(
     expanded: Boolean,
     onToggleExpanded: () -> Unit
 ) {
-    var displayName by remember { mutableStateOf(packageName) }
-    var appDataSource by remember { mutableStateOf(AppDataSource.INSTALLED) }
     val view = LocalView.current
-
-    // Resolve app name and source
-    LaunchedEffect(packageName) {
-        val (name, source) = settingsViewModel.resolveAppDisplayName(packageName)
-        displayName = name
-        appDataSource = source
-    }
 
     val totalPatches = remember(bundleMap) { bundleMap.values.sum() }
     // In selection mode force cards closed so nested bundle taps do not race with tap-to-toggle

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -37,6 +37,7 @@ import app.morphe.manager.ui.viewmodel.ImportExportViewModel
 import app.morphe.manager.ui.viewmodel.SettingsViewModel
 import app.morphe.manager.util.*
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 /** Snapshot of package/bundle selection counts. */
 @Immutable
@@ -416,12 +417,66 @@ private fun SelectionList(
     val selections = data.selections
     val listState = rememberLazyListState()
     val expandedPackages = remember { mutableStateOf<Set<String>>(emptySet()) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    // Resolve display names once so the list can be sorted A-Z by app name.
+    // Falls back to the package name while a resolution is still in flight.
+    val displayNameByPackage = remember(selections) { mutableStateMapOf<String, String>() }
+    LaunchedEffect(selections) {
+        displayNameByPackage.clear()
+        selections.keys.forEach { packageName ->
+            val (name, _) = settingsViewModel.resolveAppDisplayName(packageName)
+            displayNameByPackage[packageName] = name
+        }
+    }
+
+    // Filter by app/package name, then sort A-Z by display name.
+    // Derived state so the list re-sorts as display names finish resolving.
+    val displayEntries by remember(selections, searchQuery, displayNameByPackage) {
+        derivedStateOf {
+            selections.entries
+                .filter { (packageName, _) ->
+                    searchQuery.isBlank() ||
+                        packageName.contains(searchQuery, ignoreCase = true) ||
+                        (displayNameByPackage[packageName] ?: packageName)
+                            .contains(searchQuery, ignoreCase = true)
+                }
+                .sortedBy { (packageName, _) ->
+                    (displayNameByPackage[packageName] ?: packageName).lowercase(Locale.ROOT)
+                }
+        }
+    }
+
     Box(modifier = Modifier.fillMaxWidth()) {
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)
         ) {
+            // Sticky search bar
+            stickyHeader(key = "search") {
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surface
+                ) {
+                    AppDialogTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        label = { Text(stringResource(R.string.home_search_apps)) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = stringResource(R.string.home_search_apps)
+                            )
+                        },
+                        showClearButton = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 4.dp)
+                    )
+                }
+            }
+
             // Summary box
             item(key = "summary") {
                 HeroInfoCard(
@@ -445,11 +500,20 @@ private fun SelectionList(
                 )
             }
 
-            // List of packages with selections
-            items(
-                items = selections.entries.toList(),
-                key = { it.key }
-            ) { (packageName, bundleMap) ->
+            if (displayEntries.isEmpty()) {
+                // No matches for the current search query
+                item(key = "search_empty") {
+                    EmptyState(
+                        message = stringResource(R.string.search_no_results),
+                        icon = Icons.Outlined.SearchOff
+                    )
+                }
+            } else {
+                // List of packages with selections
+                items(
+                    items = displayEntries,
+                    key = { it.key }
+                ) { (packageName, bundleMap) ->
                 PackageSelectionItem(
                     packageName = packageName,
                     bundleMap = bundleMap,
@@ -478,6 +542,7 @@ private fun SelectionList(
                         }
                     }
                 )
+                }
             }
         }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/PatchSelectionManagementDialog.kt
@@ -318,20 +318,20 @@ private fun PatchSelectionManagementDialogContent(
         titleTrailingContent = if (isSearchable || canResetAll) {
             {
                 if (isSearchable) {
-                    DialogTitleAction(
+                    TitleAction(
                         icon = if (search.visible) Icons.Outlined.SearchOff else Icons.Outlined.Search,
                         contentDescription = stringResource(R.string.search),
                         onClick = { search.toggle() },
-                        style = DialogTitleActionStyle.Toggle,
+                        style = TitleActionStyle.Toggle,
                         active = search.visible
                     )
                 }
                 if (canResetAll) {
-                    DialogTitleAction(
+                    TitleAction(
                         icon = Icons.Outlined.Restore,
                         contentDescription = stringResource(R.string.reset),
                         onClick = onShowResetAllConfirmation,
-                        style = DialogTitleActionStyle.Destructive
+                        style = TitleActionStyle.Destructive
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/StorageManagementDialog.kt
@@ -81,7 +81,7 @@ fun StorageManagementDialog(
         title = stringResource(R.string.settings_system_storage_management_title),
         padding = DialogPadding.Compact,
         titleTrailingContent = {
-            DialogTitleAction(
+            TitleAction(
                 icon = Icons.Outlined.Refresh,
                 contentDescription = stringResource(R.string.refresh),
                 onClick = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -228,7 +228,7 @@ fun AdaptiveIconCreatorDialog(
         onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.adaptive_icon_create),
         titleTrailingContent = {
-            DialogTitleAction(
+            TitleAction(
                 icon = Icons.Outlined.Info,
                 contentDescription = stringResource(R.string.adaptive_icon_guide),
                 onClick = { showInfoDialog.value = true }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
@@ -50,16 +50,6 @@ enum class DialogPadding {
     None
 }
 
-/** Visual style of a [DialogTitleAction]. */
-enum class DialogTitleActionStyle {
-    /** Flat [IconButton], 24dp icon, dialog text tint. Use for info/reset actions */
-    Plain,
-    /** Tonal 36dp circle with errorContainer palette, 20dp icon. Use for bulk destructive actions */
-    Destructive,
-    /** Tonal 36dp circle that fills with the primary palette while active. Use for search and filter toggles */
-    Toggle
-}
-
 /**
  * Unified fullscreen dialog component.
  *
@@ -224,81 +214,6 @@ fun BoxScope.ContentOverlay(
             contentAlignment = Alignment.Center,
             content = content
         )
-    }
-}
-
-/**
- * Icon action rendered inside the [AppDialog] title trailing slot. Uniforms the
- * button styles used across dialogs so callers only pick an icon and a semantic style.
- *
- * @param active Whether a [DialogTitleActionStyle.Toggle] action is currently engaged.
- */
-@Composable
-fun DialogTitleAction(
-    icon: ImageVector,
-    contentDescription: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    style: DialogTitleActionStyle = DialogTitleActionStyle.Plain,
-    active: Boolean = false
-) {
-    // Pinned to the container the button already draws, otherwise it reserves the 48dp touch
-    // target around it and doubles the gap the title row asks for
-    val sizedModifier = modifier.size(IconButtonDefaults.smallContainerSize())
-
-    when (style) {
-        DialogTitleActionStyle.Plain -> {
-            IconButton(onClick = onClick, modifier = sizedModifier) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = contentDescription,
-                    modifier = Modifier.size(Defaults.IconSize),
-                    tint = LocalDialogTextColor.current
-                )
-            }
-        }
-
-        DialogTitleActionStyle.Destructive -> {
-            FilledTonalIconButton(
-                onClick = onClick,
-                modifier = sizedModifier,
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                )
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = contentDescription,
-                    modifier = Modifier.size(Defaults.IconSize)
-                )
-            }
-        }
-
-        DialogTitleActionStyle.Toggle -> {
-            FilledTonalIconButton(
-                onClick = onClick,
-                modifier = sizedModifier,
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = if (active) {
-                        MaterialTheme.colorScheme.primaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.surfaceVariant
-                    },
-                    contentColor = if (active) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    }
-                )
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = contentDescription,
-                    modifier = Modifier.size(Defaults.IconSize)
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
@@ -55,7 +55,9 @@ enum class DialogTitleActionStyle {
     /** Flat [IconButton], 24dp icon, dialog text tint. Use for info/reset actions */
     Plain,
     /** Tonal 36dp circle with errorContainer palette, 20dp icon. Use for bulk destructive actions */
-    Destructive
+    Destructive,
+    /** Tonal 36dp circle that fills with the primary palette while active. Use for search and filter toggles */
+    Toggle
 }
 
 /**
@@ -63,7 +65,7 @@ enum class DialogTitleActionStyle {
  *
  * @param onDismissRequest Called when user dismisses the dialog.
  * @param title Optional title displayed at the top.
- * @param titleTrailingContent Optional content displayed after the title.
+ * @param titleTrailingContent Optional actions displayed after the title, laid out in a row.
  * @param footer Optional footer content.
  * @param dismissOnClickOutside Whether clicking outside dismisses the dialog.
  * @param scrollable Whether to wrap content in verticalScroll and draw a [ListScrollbar] and [ScrollToTopButton] over it.
@@ -76,7 +78,7 @@ enum class DialogTitleActionStyle {
 fun AppDialog(
     onDismissRequest: () -> Unit,
     title: String? = null,
-    titleTrailingContent: (@Composable () -> Unit)? = null,
+    titleTrailingContent: (@Composable RowScope.() -> Unit)? = null,
     footer: (@Composable () -> Unit)? = null,
     dismissOnClickOutside: Boolean = false,
     scrollable: Boolean = true,
@@ -226,8 +228,10 @@ fun BoxScope.ContentOverlay(
 }
 
 /**
- * Icon action rendered inside the [AppDialog] title trailing slot. Uniforms the two
+ * Icon action rendered inside the [AppDialog] title trailing slot. Uniforms the
  * button styles used across dialogs so callers only pick an icon and a semantic style.
+ *
+ * @param active Whether a [DialogTitleActionStyle.Toggle] action is currently engaged.
  */
 @Composable
 fun DialogTitleAction(
@@ -235,15 +239,20 @@ fun DialogTitleAction(
     contentDescription: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    style: DialogTitleActionStyle = DialogTitleActionStyle.Plain
+    style: DialogTitleActionStyle = DialogTitleActionStyle.Plain,
+    active: Boolean = false
 ) {
+    // Pinned to the container the button already draws, otherwise it reserves the 48dp touch
+    // target around it and doubles the gap the title row asks for
+    val sizedModifier = modifier.size(IconButtonDefaults.smallContainerSize())
+
     when (style) {
         DialogTitleActionStyle.Plain -> {
-            IconButton(onClick = onClick, modifier = modifier) {
+            IconButton(onClick = onClick, modifier = sizedModifier) {
                 Icon(
                     imageVector = icon,
                     contentDescription = contentDescription,
-                    modifier = Modifier.size(24.dp),
+                    modifier = Modifier.size(Defaults.IconSize),
                     tint = LocalDialogTextColor.current
                 )
             }
@@ -252,7 +261,7 @@ fun DialogTitleAction(
         DialogTitleActionStyle.Destructive -> {
             FilledTonalIconButton(
                 onClick = onClick,
-                modifier = modifier.size(36.dp),
+                modifier = sizedModifier,
                 colors = IconButtonDefaults.filledTonalIconButtonColors(
                     containerColor = MaterialTheme.colorScheme.errorContainer,
                     contentColor = MaterialTheme.colorScheme.onErrorContainer
@@ -261,7 +270,32 @@ fun DialogTitleAction(
                 Icon(
                     imageVector = icon,
                     contentDescription = contentDescription,
-                    modifier = Modifier.size(Defaults.IconSizeSmall)
+                    modifier = Modifier.size(Defaults.IconSize)
+                )
+            }
+        }
+
+        DialogTitleActionStyle.Toggle -> {
+            FilledTonalIconButton(
+                onClick = onClick,
+                modifier = sizedModifier,
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = if (active) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant
+                    },
+                    contentColor = if (active) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                )
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(Defaults.IconSize)
                 )
             }
         }
@@ -274,7 +308,7 @@ fun DialogTitleAction(
 @Composable
 private fun DialogContent(
     title: String?,
-    titleTrailingContent: (@Composable () -> Unit)?,
+    titleTrailingContent: (@Composable RowScope.() -> Unit)?,
     footer: (@Composable () -> Unit)?,
     isDarkTheme: Boolean,
     scrollable: Boolean,
@@ -374,7 +408,13 @@ private fun DialogContent(
                                 modifier = Modifier.fillMaxWidth()
                             )
                         }
-                        if (titleTrailingContent != null) titleTrailingContent()
+                        if (titleTrailingContent != null) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
+                                verticalAlignment = Alignment.CenterVertically,
+                                content = titleTrailingContent
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialogTextField.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialogTextField.kt
@@ -5,6 +5,7 @@
 
 package app.morphe.manager.ui.screen.shared
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -23,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -169,6 +171,84 @@ fun AppDialogTextField(
         shape = RoundedCornerShape(Defaults.CompactCornerRadius),
         colors = morpheDialogTextFieldColors(textColor)
     )
+}
+
+/**
+ * Search field for dialog lists, backed by an opaque surface so list items
+ * scrolling underneath a sticky header stay hidden.
+ *
+ * @param requestFocus Opens the keyboard on first composition, for fields revealed by a toggle.
+ */
+@Composable
+fun AppDialogSearchTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    requestFocus: Boolean = false
+) {
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    LaunchedEffect(requestFocus) {
+        if (requestFocus) {
+            focusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface
+    ) {
+        AppDialogTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = { Text(label) },
+            leadingIcon = {
+                // The label already announces the field, so the icon stays decorative
+                Icon(
+                    imageVector = Icons.Outlined.Search,
+                    contentDescription = null
+                )
+            },
+            showClearButton = true,
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 4.dp)
+                .focusRequester(focusRequester)
+        )
+    }
+}
+
+/**
+ * Collapsible [AppDialogSearchTextField] for the sticky header of a dialog list.
+ *
+ * Kept as its own composable so no layout scope is in scope at the [AnimatedVisibility] call:
+ * inside `stickyHeader` the innermost receiver is `LazyItemScope`, and an enclosing `ColumnScope`
+ * would otherwise pull in the scoped overload, which cannot be called there.
+ */
+@Composable
+fun AppDialogSearchHeader(
+    visible: Boolean,
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = Animations.expandFadeEnter,
+        exit = Animations.shrinkFadeExit
+    ) {
+        AppDialogSearchTextField(
+            value = value,
+            onValueChange = onValueChange,
+            label = label,
+            requestFocus = true
+        )
+    }
 }
 
 /**

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -225,7 +225,7 @@ fun HeaderCreatorDialog(
         onDismissRequest = { if (!isCreating) onDismiss() },
         title = stringResource(R.string.header_creator_create),
         titleTrailingContent = {
-            DialogTitleAction(
+            TitleAction(
                 icon = Icons.Outlined.Info,
                 contentDescription = stringResource(R.string.header_creator_guide),
                 onClick = { showInfoDialog.value = true }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SearchFieldState.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SearchFieldState.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.*
+
+/**
+ * Toggle and query behind the search fields in dialog and sheet lists. Collapsing always
+ * clears the query, so a field the user can no longer reach cannot leave a list filtered.
+ */
+@Stable
+class SearchFieldState internal constructor() {
+    var visible by mutableStateOf(false)
+        private set
+
+    var query by mutableStateOf("")
+
+    /** Whether the query currently narrows the list. */
+    val isFiltering: Boolean get() = query.isNotBlank()
+
+    fun toggle() {
+        if (visible) collapse() else visible = true
+    }
+
+    fun collapse() {
+        query = ""
+        visible = false
+    }
+}
+
+/**
+ * Remembers a [SearchFieldState]. Pair it with [SearchFieldBackHandler] inside the dialog
+ * or sheet content to make the back gesture close the field.
+ *
+ * @param searchable Whether the caller still offers the toggle. Turning it off collapses the field.
+ */
+@Composable
+fun rememberSearchFieldState(searchable: Boolean = true): SearchFieldState {
+    val state = remember { SearchFieldState() }
+
+    LaunchedEffect(searchable) {
+        if (!searchable) state.collapse()
+    }
+
+    return state
+}
+
+/**
+ * Routes the back gesture to close [state] before the surrounding dialog or sheet reacts to it.
+ *
+ * Compose it inside the dialog or sheet content, not next to [rememberSearchFieldState]:
+ * both host their own back dispatcher, and a handler registered outside that window never runs.
+ */
+@Composable
+fun SearchFieldBackHandler(state: SearchFieldState) {
+    BackHandler(enabled = state.visible) { state.collapse() }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/TitleAction.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/TitleAction.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/** Visual style of a [TitleAction]. */
+enum class TitleActionStyle {
+    /** Flat [IconButton] with the surrounding text tint. Use for info and reset actions */
+    Plain,
+    /** Tonal circle in the primary palette. Use for standing actions such as add or sort */
+    Accent,
+    /** Tonal circle in the error palette. Use for bulk destructive actions */
+    Destructive,
+    /** Neutral tonal circle that fills with the primary palette while active */
+    Toggle,
+    /** Toggle for headers whose other actions are already [Accent], so it lifts a further step */
+    AccentToggle
+}
+
+/**
+ * Icon action rendered in the title row of an [AppDialog] or [AppBottomSheet]. Uniforms the
+ * button styles used across headers so callers only pick an icon and a semantic style.
+ *
+ * @param active Whether a [TitleActionStyle.Toggle] or [TitleActionStyle.AccentToggle] is engaged.
+ */
+@Composable
+fun TitleAction(
+    icon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    style: TitleActionStyle = TitleActionStyle.Plain,
+    active: Boolean = false
+) {
+    // Pinned to the container the button already draws, otherwise it reserves the 48dp touch
+    // target around it and doubles the gap the title row asks for
+    val sizedModifier = modifier.size(IconButtonDefaults.smallContainerSize())
+
+    // Null marks the flat variant, which draws no circle at all
+    val containerColor = when (style) {
+        TitleActionStyle.Plain -> null
+        TitleActionStyle.Accent -> MaterialTheme.colorScheme.primaryContainer
+        TitleActionStyle.Destructive -> MaterialTheme.colorScheme.errorContainer
+        TitleActionStyle.Toggle -> if (active) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant
+        }
+
+        TitleActionStyle.AccentToggle -> if (active) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.primaryContainer
+        }
+    }
+
+    if (containerColor == null) {
+        IconButton(onClick = onClick, modifier = sizedModifier) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(Defaults.IconSize),
+                tint = LocalDialogTextColor.current
+            )
+        }
+    } else {
+        FilledTonalIconButton(
+            onClick = onClick,
+            modifier = sizedModifier,
+            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = containerColor)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                modifier = Modifier.size(Defaults.IconSize)
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -60,10 +60,6 @@
         <item quantity="one">%s source installed</item>
         <item quantity="other">%s sources installed</item>
     </plurals>
-    <plurals name="patch_selection_total_patches">
-        <item quantity="one">%s patch</item>
-        <item quantity="other">%s patches</item>
-    </plurals>
     <plurals name="home_app_show_hidden_count">
         <item quantity="one">%s hidden app</item>
         <item quantity="other">%s hidden apps</item>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -61,8 +61,8 @@
         <item quantity="other">%s sources installed</item>
     </plurals>
     <plurals name="patch_selection_total_patches">
-        <item quantity="one">%s patch selected</item>
-        <item quantity="other">%s patches selected</item>
+        <item quantity="one">%s patch</item>
+        <item quantity="other">%s patches</item>
     </plurals>
     <plurals name="home_app_show_hidden_count">
         <item quantity="one">%s hidden app</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
 
     <!-- Home Screen - Sources Management -->
     <string name="sources_management_title">Patch sources</string>
+    <string name="sources_search">Search sources</string>
     <string name="sources_sort_title">Sort patch sources</string>
     <string name="sources_sort_manual">Manual order</string>
     <string name="sources_sort_manual_hint">Long-press a source to reorder</string>


### PR DESCRIPTION
## Summary

Adds search bars and alphabetical sorting to the APK and patch management screens, so large lists are easier to navigate.

## Changes

- **APK management dialog** - search bar (filters by app name and package name) with a sticky header and a no-results state; saved and patched APK lists now sort A-Z by app name
- **Patch selections dialog** (Settings → System) - same search bar + A-Z sort by resolved app name (list re-sorts as names resolve), plus a no-results state
- **Patch sources sheet** - search icon next to the sort button reveals a search field (matches sources by name/title); hidden when only one source exists, matching the sort button's behavior