### PR TITLE
feat: Export per-source prerelease and experimental version toggles

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -215,7 +215,6 @@ class PreferencesManager(
 
     @Serializable
     data class SettingsSnapshot(
-        /** Retired flag, kept so pre-migration snapshots still deserialize into [themeStyle]. */
         val dynamicColor: Boolean? = null,
         val pureBlackTheme: Boolean? = null,
         val customAccentColor: String? = null,
@@ -244,10 +243,10 @@ class PreferencesManager(
         val firstLaunch: Boolean? = null,
         val showManagerUpdateDialogOnLaunch: Boolean? = null,
         val useManagerPrereleases: Boolean? = null,
-        /** Readable prerelease toggle for the official source (UID 0). */
         val officialBundlePrerelease: Boolean? = null,
-        /** Readable experimental-versions toggle for the official source (UID 0). */
         val officialBundleExperimentalVersions: Boolean? = null,
+        val bundlePrereleasesEnabled: Set<String>? = null,
+        val bundleExperimentalVersionsEnabled: Set<String>? = null,
         val disablePatchVersionCompatCheck: Boolean? = null,
         val disableSelectionWarning: Boolean? = null,
         val disableUniversalPatchCheck: Boolean? = null,
@@ -370,17 +369,21 @@ class PreferencesManager(
         snapshot.keystorePassword?.let { keystorePassword.value = it }
         snapshot.firstLaunch?.let { firstLaunch.value = it }
         snapshot.useManagerPrereleases?.let { useManagerPrereleases.value = it }
-        // Exports carry the official source's toggles as readable booleans
-        snapshot.officialBundlePrerelease?.let { official ->
+        // Exports carry the official source's toggles as readable booleans; older ones only have
+        // the UID sets, where the official source is the one UID that is stable across devices
+        val officialUid = DEFAULT_SOURCE_UID.toString()
+        val officialPrerelease = snapshot.officialBundlePrerelease
+            ?: snapshot.bundlePrereleasesEnabled?.contains(officialUid)
+        val officialExperimental = snapshot.officialBundleExperimentalVersions
+            ?: snapshot.bundleExperimentalVersionsEnabled?.contains(officialUid)
+        officialPrerelease?.let { enabled ->
             val current = bundlePrereleasesEnabled.value.toMutableSet()
-            val uidKey = DEFAULT_SOURCE_UID.toString()
-            if (official) current.add(uidKey) else current.remove(uidKey)
+            if (enabled) current.add(officialUid) else current.remove(officialUid)
             bundlePrereleasesEnabled.value = current
         }
-        snapshot.officialBundleExperimentalVersions?.let { experimental ->
+        officialExperimental?.let { enabled ->
             val current = bundleExperimentalVersionsEnabled.value.toMutableSet()
-            val uidKey = DEFAULT_SOURCE_UID.toString()
-            if (experimental) current.add(uidKey) else current.remove(uidKey)
+            if (enabled) current.add(officialUid) else current.remove(officialUid)
             bundleExperimentalVersionsEnabled.value = current
         }
         snapshot.disablePatchVersionCompatCheck?.let { disablePatchVersionCompatCheck.value = it }
@@ -410,9 +413,7 @@ class PreferencesManager(
     }
 
     companion object {
-        /**
-         * Check if current version is a development/prerelease version.
-         */
+        /** Check if current version is a development/prerelease version. */
         fun isDevVersion(): Boolean {
             return BuildConfig.VERSION_NAME.contains("-dev", ignoreCase = true)
         }

--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -244,8 +244,10 @@ class PreferencesManager(
         val firstLaunch: Boolean? = null,
         val showManagerUpdateDialogOnLaunch: Boolean? = null,
         val useManagerPrereleases: Boolean? = null,
-        val bundlePrereleasesEnabled: Set<String>? = null,
-        val bundleExperimentalVersionsEnabled: Set<String>? = null,
+        /** Readable prerelease toggle for the official source (UID 0). */
+        val officialBundlePrerelease: Boolean? = null,
+        /** Readable experimental-versions toggle for the official source (UID 0). */
+        val officialBundleExperimentalVersions: Boolean? = null,
         val disablePatchVersionCompatCheck: Boolean? = null,
         val disableSelectionWarning: Boolean? = null,
         val disableUniversalPatchCheck: Boolean? = null,
@@ -310,8 +312,11 @@ class PreferencesManager(
         keystorePassword = keystorePassword.get().takeIf { it.isNotEmpty() },
         firstLaunch = firstLaunch.get(),
         useManagerPrereleases = useManagerPrereleases.get(),
-        bundlePrereleasesEnabled = bundlePrereleasesEnabled.get(),
-        bundleExperimentalVersionsEnabled = bundleExperimentalVersionsEnabled.get(),
+        // Custom sources carry prerelease/experimental toggles in customBundles, and the official
+        // source (UID 0) gets readable booleans below - so raw UID sets are no longer exported
+        officialBundlePrerelease = bundlePrereleasesEnabled.get().contains(DEFAULT_SOURCE_UID.toString()),
+        officialBundleExperimentalVersions =
+            bundleExperimentalVersionsEnabled.get().contains(DEFAULT_SOURCE_UID.toString()),
         disablePatchVersionCompatCheck = disablePatchVersionCompatCheck.get(),
         showGreetingPhrases = showGreetingPhrases.get(),
         backgroundType = backgroundType.get(),
@@ -365,8 +370,19 @@ class PreferencesManager(
         snapshot.keystorePassword?.let { keystorePassword.value = it }
         snapshot.firstLaunch?.let { firstLaunch.value = it }
         snapshot.useManagerPrereleases?.let { useManagerPrereleases.value = it }
-        snapshot.bundlePrereleasesEnabled?.let { bundlePrereleasesEnabled.value = it }
-        snapshot.bundleExperimentalVersionsEnabled?.let { bundleExperimentalVersionsEnabled.value = it }
+        // Exports carry the official source's toggles as readable booleans
+        snapshot.officialBundlePrerelease?.let { official ->
+            val current = bundlePrereleasesEnabled.value.toMutableSet()
+            val uidKey = DEFAULT_SOURCE_UID.toString()
+            if (official) current.add(uidKey) else current.remove(uidKey)
+            bundlePrereleasesEnabled.value = current
+        }
+        snapshot.officialBundleExperimentalVersions?.let { experimental ->
+            val current = bundleExperimentalVersionsEnabled.value.toMutableSet()
+            val uidKey = DEFAULT_SOURCE_UID.toString()
+            if (experimental) current.add(uidKey) else current.remove(uidKey)
+            bundleExperimentalVersionsEnabled.value = current
+        }
         snapshot.disablePatchVersionCompatCheck?.let { disablePatchVersionCompatCheck.value = it }
         snapshot.showGreetingPhrases?.let { showGreetingPhrases.value = it }
         snapshot.backgroundType?.let { backgroundType.value = it }

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -2024,9 +2024,20 @@ class PatchBundleRepository(
     )
 
     /**
+     * Adds or removes [uid] from a set of bundle UID preference keys, reporting whether it changed.
+     */
+    private fun MutableSet<String>.toggleUid(uid: Int, enabled: Boolean) =
+        if (enabled) add(uid.toString()) else remove(uid.toString())
+
+    /**
      * Export all third-party remote bundles as a list of snapshots.
      */
     suspend fun exportCustomBundles(): List<BundleSnapshot> {
+        // Only the toggles the user set are exported. Prerelease implied by a "dev" endpoint is
+        // derived from the URL again on import, so it must not be baked into the snapshot
+        val prereleaseUids = prefs.bundlePrereleasesEnabled.get()
+        val experimentalUids = prefs.bundleExperimentalVersionsEnabled.get()
+
         return dao.all()
             .filter { it.uid != DEFAULT_SOURCE_UID && it.source !is Source.Local }
             .map { entity ->
@@ -2039,13 +2050,8 @@ class PatchBundleRepository(
                     sortOrder = entity.sortOrder,
                     createdAt = entity.createdAt,
                     updatedAt = entity.updatedAt,
-                    prerelease = when (val source = entity.source) {
-                        is SourceInfo.Remote -> shouldUsePrerelease(entity.uid, source.url.toString())
-                        else -> null
-                    },
-                    experimentalVersions = prefs.bundleExperimentalVersionsEnabled
-                        .getBlocking()
-                        .contains(entity.uid.toString()),
+                    prerelease = entity.uid.toString() in prereleaseUids,
+                    experimentalVersions = entity.uid.toString() in experimentalUids,
                 )
             }
     }
@@ -2089,6 +2095,12 @@ class PatchBundleRepository(
 
             var changedAny = false
 
+            // Toggles are collected here and written once at the end, so a backup with many
+            // sources does not commit the preference store twice per source
+            val prereleaseUids = prefs.bundlePrereleasesEnabled.get().toMutableSet()
+            val experimentalUids = prefs.bundleExperimentalVersionsEnabled.get().toMutableSet()
+            var togglesChanged = false
+
             // Replace mode: remove custom remotes whose endpoint is not in the backup
             if (mode == ImportMode.Replace) {
                 val toRemove = customRemotes
@@ -2099,6 +2111,10 @@ class PatchBundleRepository(
                         directoryOf(bundle.uid).deleteRecursively()
                     }
                     val removedUids = toRemove.map { it.uid }.toSet()
+                    removedUids.forEach { uid ->
+                        togglesChanged = prereleaseUids.toggleUid(uid, false) || togglesChanged
+                        togglesChanged = experimentalUids.toggleUid(uid, false) || togglesChanged
+                    }
                     metadataFetchErrorsFlow.update { it - removedUids }
                     val (affectedCount, remaining) = cancelRemoteUpdates(removedUids)
                     updateProgressAfterRemoval(affectedCount, remaining)
@@ -2128,31 +2144,11 @@ class PatchBundleRepository(
                     }
                     // Reconcile prerelease and experimental-version toggles by endpoint,
                     // so they survive a cross-device import
-                    snapshot.prerelease?.let { wantPrerelease ->
-                        val current = prefs.bundlePrereleasesEnabled.get().toMutableSet()
-                        val uidKey = bundle.uid.toString()
-                        if (wantPrerelease && uidKey !in current) {
-                            current.add(uidKey)
-                            prefs.bundlePrereleasesEnabled.update(current)
-                            changedAny = true
-                        } else if (!wantPrerelease && uidKey in current) {
-                            current.remove(uidKey)
-                            prefs.bundlePrereleasesEnabled.update(current)
-                            changedAny = true
-                        }
+                    snapshot.prerelease?.let {
+                        togglesChanged = prereleaseUids.toggleUid(bundle.uid, it) || togglesChanged
                     }
-                    snapshot.experimentalVersions?.let { wantExperimental ->
-                        val current = prefs.bundleExperimentalVersionsEnabled.get().toMutableSet()
-                        val uidKey = bundle.uid.toString()
-                        if (wantExperimental && uidKey !in current) {
-                            current.add(uidKey)
-                            prefs.bundleExperimentalVersionsEnabled.update(current)
-                            changedAny = true
-                        } else if (!wantExperimental && uidKey in current) {
-                            current.remove(uidKey)
-                            prefs.bundleExperimentalVersionsEnabled.update(current)
-                            changedAny = true
-                        }
+                    snapshot.experimentalVersions?.let {
+                        togglesChanged = experimentalUids.toggleUid(bundle.uid, it) || togglesChanged
                     }
                 }
             }
@@ -2176,16 +2172,18 @@ class PatchBundleRepository(
                 )
                 // New bundles get fresh UIDs, so carry the toggles over by UID
                 if (snapshot.prerelease == true) {
-                    val current = prefs.bundlePrereleasesEnabled.get().toMutableSet()
-                    if (current.add(created.uid.toString())) {
-                        prefs.bundlePrereleasesEnabled.update(current)
-                    }
+                    togglesChanged = prereleaseUids.toggleUid(created.uid, true) || togglesChanged
                 }
                 if (snapshot.experimentalVersions == true) {
-                    val current = prefs.bundleExperimentalVersionsEnabled.get().toMutableSet()
-                    if (current.add(created.uid.toString())) {
-                        prefs.bundleExperimentalVersionsEnabled.update(current)
-                    }
+                    togglesChanged = experimentalUids.toggleUid(created.uid, true) || togglesChanged
+                }
+                changedAny = true
+            }
+
+            if (togglesChanged) {
+                prefs.edit {
+                    prefs.bundlePrereleasesEnabled.value = prereleaseUids.toSet()
+                    prefs.bundleExperimentalVersionsEnabled.value = experimentalUids.toSet()
                 }
                 changedAny = true
             }

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -2039,6 +2039,13 @@ class PatchBundleRepository(
                     sortOrder = entity.sortOrder,
                     createdAt = entity.createdAt,
                     updatedAt = entity.updatedAt,
+                    prerelease = when (val source = entity.source) {
+                        is SourceInfo.Remote -> shouldUsePrerelease(entity.uid, source.url.toString())
+                        else -> null
+                    },
+                    experimentalVersions = prefs.bundleExperimentalVersionsEnabled
+                        .getBlocking()
+                        .contains(entity.uid.toString()),
                 )
             }
     }
@@ -2119,6 +2126,34 @@ class PatchBundleRepository(
                         updateDb(bundle.uid) { it.copy(enabled = snapshot.enabled) }
                         changedAny = true
                     }
+                    // Reconcile prerelease and experimental-version toggles by endpoint,
+                    // so they survive a cross-device import
+                    snapshot.prerelease?.let { wantPrerelease ->
+                        val current = prefs.bundlePrereleasesEnabled.get().toMutableSet()
+                        val uidKey = bundle.uid.toString()
+                        if (wantPrerelease && uidKey !in current) {
+                            current.add(uidKey)
+                            prefs.bundlePrereleasesEnabled.update(current)
+                            changedAny = true
+                        } else if (!wantPrerelease && uidKey in current) {
+                            current.remove(uidKey)
+                            prefs.bundlePrereleasesEnabled.update(current)
+                            changedAny = true
+                        }
+                    }
+                    snapshot.experimentalVersions?.let { wantExperimental ->
+                        val current = prefs.bundleExperimentalVersionsEnabled.get().toMutableSet()
+                        val uidKey = bundle.uid.toString()
+                        if (wantExperimental && uidKey !in current) {
+                            current.add(uidKey)
+                            prefs.bundleExperimentalVersionsEnabled.update(current)
+                            changedAny = true
+                        } else if (!wantExperimental && uidKey in current) {
+                            current.remove(uidKey)
+                            prefs.bundleExperimentalVersionsEnabled.update(current)
+                            changedAny = true
+                        }
+                    }
                 }
             }
 
@@ -2129,7 +2164,7 @@ class PatchBundleRepository(
 
                 if (normalizedUrl.lowercase(Locale.US) in keptEndpoints) return@forEach
 
-                createEntity(
+                val created = createEntity(
                     name = snapshot.name,
                     source = Source.from(normalizedUrl),
                     autoUpdate = snapshot.autoUpdate,
@@ -2139,6 +2174,19 @@ class PatchBundleRepository(
                     updatedAt = snapshot.updatedAt,
                     enabled = snapshot.enabled,
                 )
+                // New bundles get fresh UIDs, so carry the toggles over by UID
+                if (snapshot.prerelease == true) {
+                    val current = prefs.bundlePrereleasesEnabled.get().toMutableSet()
+                    if (current.add(created.uid.toString())) {
+                        prefs.bundlePrereleasesEnabled.update(current)
+                    }
+                }
+                if (snapshot.experimentalVersions == true) {
+                    val current = prefs.bundleExperimentalVersionsEnabled.get().toMutableSet()
+                    if (current.add(created.uid.toString())) {
+                        prefs.bundleExperimentalVersionsEnabled.update(current)
+                    }
+                }
                 changedAny = true
             }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -98,6 +98,10 @@ data class BundleSnapshot(
     val sortOrder: Int,
     val createdAt: Long? = null,
     val updatedAt: Long? = null,
+    /** Whether the dev/prerelease branch is enabled for this source. */
+    val prerelease: Boolean? = null,
+    /** Whether experimental app versions are preferred for this source. */
+    val experimentalVersions: Boolean? = null,
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -640,6 +644,9 @@ class ImportExportViewModel(
         private val json = Json {
             ignoreUnknownKeys = true
             prettyPrint = true // Make exports human-readable
+            // Skip null and default-valued fields so exports stay lean and readable
+            explicitNulls = false
+            encodeDefaults = false
         }
 
         val knownPasswords = arrayOf("Morphe", "s3cur3p@ssw0rd")

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ImportExportViewModel.kt
@@ -70,6 +70,8 @@ data class PatchBundleDataExportFile(
     // Map<PackageName, List<PatchName>>
     val selections: Map<String, List<String>>,
     // Map<PackageName, Map<PatchName, Map<OptionKey, OptionValue>>>
+    // Deliberately without a default: the field has always been written out, and giving it one
+    // would drop it from the file for versions that still require it
     val options: Map<String, Map<String, Map<String, String>>>?
 )
 
@@ -98,10 +100,10 @@ data class BundleSnapshot(
     val sortOrder: Int,
     val createdAt: Long? = null,
     val updatedAt: Long? = null,
-    /** Whether the dev/prerelease branch is enabled for this source. */
+    // Prerelease toggle. Null in backups written before per-source toggles were exported
     val prerelease: Boolean? = null,
-    /** Whether experimental app versions are preferred for this source. */
-    val experimentalVersions: Boolean? = null,
+    // Experimental versions toggle. Null in backups written before per-source toggles were exported
+    val experimentalVersions: Boolean? = null
 )
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -215,7 +217,7 @@ class ImportExportViewModel(
         uiSafe(app, R.string.settings_system_import_manager_settings_fail, "Failed to import manager settings") {
             val exportFile = withContext(Dispatchers.IO) {
                 contentResolver.openInputStream(source)!!.use {
-                    json.decodeFromStream<ManagerSettingsExportFile>(it)
+                    settingsJson.decodeFromStream<ManagerSettingsExportFile>(it)
                 }
             }
 
@@ -249,7 +251,7 @@ class ImportExportViewModel(
 
             withContext(Dispatchers.IO) {
                 contentResolver.openOutputStream(target, "wt")!!.use { output ->
-                    json.encodeToStream(
+                    settingsJson.encodeToStream(
                         ManagerSettingsExportFile(
                             settings = snapshot.copy(
                                 customBundles = bundles.ifEmpty { null },
@@ -608,7 +610,7 @@ class ImportExportViewModel(
                 val stream = openDownloadsOutputStream("morphe_manager_settings.json", JSON_MIMETYPE)
                     ?: throw IllegalStateException("Cannot open Downloads output stream")
                 stream.use {
-                    json.encodeToStream(
+                    settingsJson.encodeToStream(
                         ManagerSettingsExportFile(
                             settings = snapshot.copy(
                                 customBundles = bundles.ifEmpty { null },
@@ -639,17 +641,21 @@ class ImportExportViewModel(
         cancelKeystoreImport()
     }
 
-    private companion object {
-        // Reusable JSON instances to avoid redundant creation
-        private val json = Json {
+    companion object {
+        // Reusable JSON instances to avoid redundant creation. Both are internal so the export
+        // format stays under test instead of the tests rebuilding their own configuration
+        internal val json = Json {
             ignoreUnknownKeys = true
             prettyPrint = true // Make exports human-readable
-            // Skip null and default-valued fields so exports stay lean and readable
-            explicitNulls = false
-            encodeDefaults = false
         }
 
-        val knownPasswords = arrayOf("Morphe", "s3cur3p@ssw0rd")
-        val aliases = arrayOf(KeystoreManager.DEFAULT, "alias", "Morphe Key")
+        /**
+         * Settings exports omit unset fields instead of writing a wall of nulls. Every field in
+         * that file has a default, so older manager versions still read the trimmed form.
+         */
+        internal val settingsJson = Json(json) { explicitNulls = false }
+
+        private val knownPasswords = arrayOf("Morphe", "s3cur3p@ssw0rd")
+        private val aliases = arrayOf(KeystoreManager.DEFAULT, "alias", "Morphe Key")
     }
 }

--- a/app/src/test/java/app/morphe/manager/ui/viewmodel/ImportExportSerializationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/viewmodel/ImportExportSerializationTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.viewmodel
+
+import kotlin.test.*
+
+/**
+ * Backup files outlive the manager version that wrote them: users restore a year-old export on a
+ * new device. These cases pin the two export formats against each other, because settings exports
+ * drop unset fields while selection exports must keep writing them.
+ */
+class ImportExportSerializationTest {
+    private val json = ImportExportViewModel.json
+    private val settingsJson = ImportExportViewModel.settingsJson
+
+    private fun bundleSnapshot(
+        prerelease: Boolean? = null,
+        experimentalVersions: Boolean? = null,
+    ) = BundleSnapshot(
+        name = "Custom patches",
+        source = "https://example.com/patches/dev",
+        autoUpdate = true,
+        sortOrder = 1,
+        prerelease = prerelease,
+        experimentalVersions = experimentalVersions,
+    )
+
+    @Test
+    fun `per-source toggles survive a settings round trip`() {
+        val original = bundleSnapshot(prerelease = true, experimentalVersions = false)
+
+        val decoded = settingsJson.decodeFromString<BundleSnapshot>(
+            settingsJson.encodeToString(original)
+        )
+
+        assertEquals(original, decoded)
+        assertEquals(true, decoded.prerelease)
+        assertEquals(false, decoded.experimentalVersions)
+    }
+
+    @Test
+    fun `settings exports omit unset fields`() {
+        val encoded = settingsJson.encodeToString(bundleSnapshot())
+
+        assertFalse(encoded.contains("displayName"), "unset fields must not reach the file: $encoded")
+        assertFalse(encoded.contains("prerelease"), "unset toggles must not reach the file: $encoded")
+        assertTrue(encoded.contains("sortOrder"), "required fields are always written: $encoded")
+    }
+
+    @Test
+    fun `backups written before per-source toggles decode as unset`() {
+        val legacy = """
+            {
+              "name": "Custom patches",
+              "source": "https://example.com/patches",
+              "autoUpdate": false,
+              "sortOrder": 0
+            }
+        """.trimIndent()
+
+        val decoded = settingsJson.decodeFromString<BundleSnapshot>(legacy)
+
+        // Null is what keeps Merge from touching toggles the backup never spoke about
+        assertNull(decoded.prerelease)
+        assertNull(decoded.experimentalVersions)
+    }
+
+    @Test
+    fun `unknown fields from newer backups are ignored`() {
+        val forwardLooking = """
+            {
+              "name": "Custom patches",
+              "source": "https://example.com/patches",
+              "autoUpdate": false,
+              "sortOrder": 0,
+              "somethingAddedLater": true
+            }
+        """.trimIndent()
+
+        assertEquals("Custom patches", settingsJson.decodeFromString<BundleSnapshot>(forwardLooking).name)
+    }
+
+    @Test
+    fun `selection exports keep writing null options`() {
+        val encoded = json.encodeToString(
+            PatchBundleDataExportFile(
+                bundleUid = 0,
+                exportDate = "2026-08-11T12:00:00",
+                selections = mapOf("com.example.app" to listOf("Some patch")),
+                options = null,
+            )
+        )
+
+        // Older manager versions require the field, so this format must not follow the settings one
+        assertTrue(encoded.contains("\"options\": null"), "options must stay explicit: $encoded")
+    }
+
+    @Test
+    fun `selection exports round trip through the null options they write`() {
+        val original = PatchBundleDataExportFile(
+            bundleUid = 0,
+            exportDate = "2026-08-11T12:00:00",
+            selections = mapOf("com.example.app" to listOf("Some patch")),
+            options = null,
+        )
+
+        val decoded = json.decodeFromString<PatchBundleDataExportFile>(json.encodeToString(original))
+
+        assertEquals(original, decoded)
+        assertNull(decoded.options)
+    }
+}


### PR DESCRIPTION
## Summary

Makes the settings export carry prerelease and experimental-version toggles in a readable, per-source form instead of raw device-specific bundle UIDs. This fixes exports being unreadable and toggles not surviving a cross-device import.

## Problem

The exported settings file contained `bundlePrereleasesEnabled` and `bundleExperimentalVersionsEnabled` as arrays of integer bundle UIDs (e.g. `["0", "-1286375345"]`). UIDs are random per device, so:
- the export is unreadable  you can't tell which patch source had prerelease enabled
- importing on another device points at wrong sources or nothing at all

## Changes

- **`BundleSnapshot`** now carries `prerelease` and `experimentalVersions` booleans per custom source, alongside the existing name/source/autoUpdate fields
- **Export** (`exportCustomBundles`) populates both flags from the source's current state; the raw UID sets are no longer written to the settings block
- **Import** (`importCustomBundles`) restores both toggles by endpoint URL (stable across devices) instead of UID, for both kept and newly created sources
- **Official source** (UID 0) gets readable `officialBundlePrerelease` and `officialBundleExperimentalVersions` booleans in the settings block
- Export JSON now omits null/default fields (`explicitNulls = false`, `encodeDefaults = false`) so exports stay lean