### PR TITLE
fix: show actual APK download source (Addresses part of #411)

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -843,10 +843,10 @@ internal fun DownloadInstructionsDialog(
 ) {
     val context = LocalContext.current
     val downloadHost = remember(downloadUrl) {
-    downloadUrl
-        ?.takeUnless { it.contains("/v2/web-search/") }
-        ?.let { runCatching { URI(it).host }.getOrNull() }
-        ?.removePrefix("www.")
+        downloadUrl
+            ?.takeUnless { it.contains("/v2/web-search/") }
+            ?.let { runCatching { URI(it).host }.getOrNull() }
+            ?.removePrefix("www.")
         ?.let { host ->
             val parts = host.split('.')
             when {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -176,6 +176,7 @@ fun HomeDialogs(
             targetAppInstalled = homeViewModel.pendingTargetAppInstalled == true,
             downloadColor = downloadColor,
             isApkBundle = isApkBundle,
+            downloadUrl = homeViewModel.resolvedDownloadUrl,
             onDismiss = {
                 homeViewModel.showDownloadInstructionsDialog = false
                 homeViewModel.cleanupPendingData()
@@ -835,11 +836,36 @@ internal fun DownloadInstructionsDialog(
     targetAppInstalled: Boolean,
     downloadColor: Color,
     isApkBundle: Boolean,
+    downloadUrl: String? = null,
     onDismiss: () -> Unit,
     onOpenApkDownloadHelper: (() -> Unit)? = null,
     onContinue: () -> Unit
 ) {
     val context = LocalContext.current
+    val downloadHost = remember(downloadUrl) {
+    downloadUrl
+        ?.takeUnless { it.contains("/v2/web-search/") }
+        ?.let { runCatching { URI(it).host }.getOrNull() }
+        ?.removePrefix("www.")
+        ?.let { host ->
+            val parts = host.split('.')
+            when {
+                parts.size <= 2 -> host
+                parts.takeLast(2).joinToString(".") in setOf(
+                    "co.uk",
+                    "org.uk",
+                    "ac.uk",
+                    "com.au",
+                    "net.au",
+                    "org.au",
+                    "co.in",
+                    "com.br",
+                    "co.jp"
+                ) -> parts.takeLast(3).joinToString(".")
+                else -> parts.takeLast(2).joinToString(".")
+            }
+        }
+    }
     val downloadButtonToasts = listOf(
         stringResource(R.string.home_download_instructions_download_button_toast),
         stringResource(R.string.home_download_instructions_download_button_toast_2),
@@ -856,7 +882,9 @@ internal fun DownloadInstructionsDialog(
         footer = {
             if (onOpenApkDownloadHelper != null) {
                 AppDialogButtonRow(
-                    primaryText = stringResource(R.string.home_download_instructions_continue),
+                    primaryText = downloadHost?.let {
+                        stringResource(R.string.home_download_instructions_continue_to, it)
+                    } ?: stringResource(R.string.home_download_instructions_continue_generic),
                     onPrimaryClick = onContinue,
                     primaryIcon = Icons.AutoMirrored.Outlined.OpenInNew,
                     secondaryText = stringResource(R.string.home_apk_helper_download),
@@ -866,7 +894,9 @@ internal fun DownloadInstructionsDialog(
                 )
             } else {
                 AppDialogButton(
-                    text = stringResource(R.string.home_download_instructions_continue),
+                    text = downloadHost?.let {
+                        stringResource(R.string.home_download_instructions_continue_to, it)
+                    } ?: stringResource(R.string.home_download_instructions_continue_generic),
                     onClick = onContinue,
                     icon = Icons.AutoMirrored.Outlined.OpenInNew,
                     modifier = Modifier.fillMaxWidth()

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -866,6 +866,9 @@ internal fun DownloadInstructionsDialog(
             }
         }
     }
+    val continueLabel = downloadHost?.let {
+        stringResource(R.string.home_download_instructions_continue_to, it)
+    } ?: stringResource(R.string.home_download_instructions_continue_generic)
     val downloadButtonToasts = listOf(
         stringResource(R.string.home_download_instructions_download_button_toast),
         stringResource(R.string.home_download_instructions_download_button_toast_2),
@@ -882,9 +885,7 @@ internal fun DownloadInstructionsDialog(
         footer = {
             if (onOpenApkDownloadHelper != null) {
                 AppDialogButtonRow(
-                    primaryText = downloadHost?.let {
-                        stringResource(R.string.home_download_instructions_continue_to, it)
-                    } ?: stringResource(R.string.home_download_instructions_continue_generic),
+                    primaryText = continueLabel,
                     onPrimaryClick = onContinue,
                     primaryIcon = Icons.AutoMirrored.Outlined.OpenInNew,
                     secondaryText = stringResource(R.string.home_apk_helper_download),
@@ -894,9 +895,7 @@ internal fun DownloadInstructionsDialog(
                 )
             } else {
                 AppDialogButton(
-                    text = downloadHost?.let {
-                        stringResource(R.string.home_download_instructions_continue_to, it)
-                    } ?: stringResource(R.string.home_download_instructions_continue_generic),
+                    text = continueLabel,
                     onClick = onContinue,
                     icon = Icons.AutoMirrored.Outlined.OpenInNew,
                     modifier = Modifier.fillMaxWidth()
@@ -922,7 +921,7 @@ internal fun DownloadInstructionsDialog(
                 number = "1",
                 text = stringResource(
                     R.string.home_download_instructions_step1,
-                    stringResource(R.string.home_download_instructions_continue)
+                    continueLabel
                 ),
                 textColor = textColor,
                 secondaryColor = secondaryColor

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,8 @@
     <string name="home_download_instructions_step4">After the download finishes, return to Morphe</string>
     <string name="home_download_instructions_step4_mount">After installing the original APK, return to Morphe</string>
     <string name="home_download_instructions_continue">Continue to APKMirror.com</string>
+    <string name="home_download_instructions_continue_to">Continue to %1$s</string>
+    <string name="home_download_instructions_continue_generic">Continue</string>
 
     <!-- Home Screen - Dialog 3: File Picker Prompt -->
     <string name="home_file_picker_prompt_title">Select downloaded APK</string>


### PR DESCRIPTION
## What does this PR do?

Updates the original APK download button to display the actual download source instead of always displaying "APKMirror.com," regardless of where the download URL actually points.

For example:
- APKMirror → "Continue to apkmirror.com"
- Uptodown → "Continue to uptodown.com"

The download URL itself is unchanged — this only fixes the displayed source name so it matches where the user is actually about to be sent. Falls back to a generic "Continue" label if the host can't be resolved.

Addresses part of #411 (the button previously always said "Continue to APKMirror.com" regardless of the actual source).
<img width="1272" height="2772" alt="31960" src="https://github.com/user-attachments/assets/f6f028f0-a593-435b-b1f3-7017fede94fd" />
<img width="1272" height="2772" alt="31961" src="https://github.com/user-attachments/assets/321c9e24-6b9a-46da-a9f8-31a6e473fb05" />
<img width="1272" height="2772" alt="31962" src="https://github.com/user-attachments/assets/bf241262-cf02-4fad-9766-71e1dc89cb6b" />