### PR TITLE
feat: Match the download instructions to the website the APK link leads to

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/DownloadUrlResolver.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/DownloadUrlResolver.kt
@@ -12,6 +12,7 @@ import app.morphe.manager.util.KnownApps
 import app.morphe.manager.util.MORPHE_API_URL
 import app.morphe.manager.util.tag
 import io.ktor.http.encodeURLPath
+import java.net.URI
 import java.net.URLEncoder
 
 /**
@@ -21,21 +22,30 @@ class DownloadUrlResolver(private val morpheAPI: MorpheAPI) {
 
     /**
      * Resolves the download page for [packageName] at [version], falling back to a plain web
-     * search when the API cannot point anywhere.
+     * search when the API cannot point anywhere useful.
      *
-     * The API answers with a redirect, and occasionally redirects to itself once more, so the
-     * result is followed twice before giving up on it.
+     * Every redirect along the way is followed: the API sometimes points at itself once more,
+     * and the download sites redirect for reasons of their own, so only the end of the chain
+     * says what the user will actually get.
      */
     suspend fun resolve(packageName: String, version: String?): String {
         val searchUrl = apiSearchUrl(packageName, version)
         Log.d(tag, "Using search url: $searchUrl")
 
-        var resolved = followRedirect(searchUrl, packageName, version)
-        if (resolved.startsWith(MORPHE_API_URL)) {
-            Log.i(tag, "Redirect still on API host, resolving again")
-            resolved = followRedirect(resolved, packageName, version)
+        var resolved = morpheAPI.resolveRedirect(searchUrl) ?: run {
+            Log.w(tag, "No redirect location for: $searchUrl")
+            return webSearchUrl(packageName, version)
         }
-        return resolved
+
+        repeat(MAX_REDIRECTS) {
+            // A URL that redirects nowhere is the end of the chain
+            val next = morpheAPI.resolveRedirect(resolved) ?: return finalUrl(resolved, packageName, version)
+            Log.i(tag, "Following redirect to: $next")
+            resolved = next
+        }
+
+        Log.w(tag, "Gave up after $MAX_REDIRECTS redirects")
+        return webSearchUrl(packageName, version)
     }
 
     /** The unresolved API URL, usable immediately while [resolve] is still working. */
@@ -52,14 +62,32 @@ class DownloadUrlResolver(private val morpheAPI: MorpheAPI) {
             "nodpi"
         }
         val versionPart = version?.let { "\"$it\"" } ?: ""
-        val query = "\"$packageName\" $versionPart $architecture site:APKMirror.com"
+        val query = "\"$packageName\" $versionPart $architecture $SEARCH_SITES"
         Log.d(tag, "Using search query: $query")
         return "https://google.com/search?q=${URLEncoder.encode(query, "UTF-8")}"
     }
 
-    private suspend fun followRedirect(url: String, packageName: String, version: String?): String =
-        morpheAPI.resolveRedirect(url) ?: run {
-            Log.w(tag, "No redirect location for: $url")
-            webSearchUrl(packageName, version)
+    /** Hands back [url], or a web search when it cannot lead to the version that was asked for. */
+    private fun finalUrl(url: String, packageName: String, version: String?): String {
+        // Uptodown answers a retired download id with its "latest version" page, which is not
+        // the build the patches need. Only its per-build pages end in "-x"
+        val uri = runCatching { URI(url) }.getOrNull() ?: return url
+        val onUptodown = uri.host?.lowercase()?.endsWith("uptodown.com") == true
+        if (onUptodown && !uri.path.orEmpty().trimEnd('/').endsWith("-x")) {
+            Log.w(tag, "Uptodown link lost its build, searching instead: $url")
+            return webSearchUrl(packageName, version)
         }
+        return url
+    }
+
+    private companion object {
+        // Enough for the API pointing at itself and a site or two moving the page, while still
+        // ending a redirect loop
+        const val MAX_REDIRECTS = 5
+
+        // Kept in step with the mirrors the API falls back to, so a search started here and one
+        // started by the API lead to the same set of sites
+        const val SEARCH_SITES =
+            "(site:apkmirror.com OR site:uptodown.com OR site:apkpure.com OR site:apkcombo.com)"
+    }
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -215,6 +215,8 @@ fun BatchPatcherScreen(
         val metadata = bundleMetadata[search.item.packageName]
 
         DownloadInstructionsDialog(
+            downloadUrl = search.url,
+            requestedVersion = search.version,
             usingMountInstall = false,
             targetAppInstalled = search.item.source is BatchApkSource.Installed,
             downloadColor = metadata?.downloadColor ?: KnownApps.DEFAULT_DOWNLOAD_COLOR,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/DownloadInstructions.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/DownloadInstructions.kt
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.home
+
+import android.widget.Toast
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.util.*
+import java.net.URI
+
+/**
+ * The site a download link leads to, and the instructions that match what it puts on screen.
+ *
+ * The API answers the version lookup with a single redirect and picks the host itself, so the
+ * destination is read off the resolved URL instead of assuming everything comes from APKMirror.
+ *
+ * @param label Site name shown to the user. Null while the destination is not known yet.
+ */
+sealed class ApkDownloadSource(val label: String?) {
+    /**
+     * @param onDownloadPage True for the page carrying the download button. A release page stops
+     * short of it, with the APK variants still to be picked from.
+     */
+    data class ApkMirror(val onDownloadPage: Boolean) : ApkDownloadSource("APKMirror.com")
+
+    data object Uptodown : ApkDownloadSource("Uptodown.com")
+
+    /** Search results rather than one app page, used when the API knows no direct link. */
+    data object WebSearch : ApkDownloadSource("Google")
+
+    /** A link to the APK itself, which the browser downloads without putting up a page. */
+    data class DirectFile(val host: String) : ApkDownloadSource(host)
+
+    /** Any other host the API points at, named after itself so the button never promises the wrong site. */
+    data class Other(val host: String) : ApkDownloadSource(host)
+
+    /** The redirect has not been followed yet, so nothing site specific can be shown. */
+    data object Unresolved : ApkDownloadSource(null)
+
+    companion object {
+        private val DOWNLOADABLE_EXTENSIONS = setOf("apk", "apkm", "apks", "xapk")
+
+        /**
+         * Works out where [url] leads.
+         *
+         * Until the redirect is followed the URL still points at the API, which says nothing
+         * about where the user will end up, so that case resolves to [Unresolved].
+         */
+        fun from(url: String?): ApkDownloadSource {
+            if (url == null || url.startsWith(MORPHE_API_URL)) return Unresolved
+
+            val uri = runCatching { URI(url) }.getOrNull() ?: return Unresolved
+            val host = uri.host?.lowercase()?.removePrefix("www.") ?: return Unresolved
+            val path = uri.path.orEmpty().trimEnd('/')
+            val extension = path.substringAfterLast('/').substringAfterLast('.', "").lowercase()
+
+            return when {
+                extension in DOWNLOADABLE_EXTENSIONS -> DirectFile(host)
+                host.endsWith("apkmirror.com") ->
+                    ApkMirror(onDownloadPage = path.endsWith("-android-apk-download"))
+                host.endsWith("uptodown.com") -> Uptodown
+                host.endsWith("google.com") -> WebSearch
+                else -> Other(host)
+            }
+        }
+    }
+}
+
+/** Where the continue button leads, worded generically while the destination is still unknown. */
+@Composable
+private fun ApkDownloadSource.destinationLabel(): String =
+    label ?: stringResource(R.string.home_download_instructions_destination)
+
+/** Site button an instruction step points at, redrawn below the step so it can be recognized. */
+private enum class SiteButton { ApkMirror, Uptodown }
+
+private val UptodownBrandColor = Color(0xFF4CB050)
+
+/**
+ * One numbered instruction line.
+ *
+ * @param button Button to redraw below the text, when the step tells the user to press one.
+ * @param note Caveat about the page, shown below the step.
+ */
+private data class DownloadStep(
+    val text: AnnotatedString,
+    val button: SiteButton? = null,
+    val note: String? = null
+)
+
+/**
+ * Builds the numbered instructions for this source.
+ *
+ * Only the middle of the list is site specific: every source is reached the same way and,
+ * once the file is downloaded, ends in the same two steps back inside Morphe.
+ */
+@Composable
+private fun ApkDownloadSource.instructionSteps(
+    requestedVersion: String?,
+    mountInstallRequired: Boolean
+): List<DownloadStep> {
+    val openSite = DownloadStep(
+        AnnotatedString(
+            stringResource(
+                R.string.home_download_instructions_step1,
+                stringResource(R.string.home_download_instructions_continue_to, destinationLabel())
+            )
+        )
+    )
+
+    val onSite: List<DownloadStep> = when (this) {
+        is ApkDownloadSource.ApkMirror -> buildList {
+            // A release page lists the variants of one version, and only the variant's own page
+            // carries the download button the next step points at
+            if (!onDownloadPage) {
+                add(
+                    DownloadStep(
+                        htmlAnnotatedString(stringResource(R.string.home_download_instructions_step2_variant))
+                    )
+                )
+            }
+            add(
+                DownloadStep(
+                    text = AnnotatedString(stringResource(R.string.home_download_instructions_step2_part1)),
+                    button = SiteButton.ApkMirror
+                )
+            )
+        }
+
+        // The browser is handed the file itself, so there is no page to find anything on
+        is ApkDownloadSource.DirectFile -> emptyList()
+
+        ApkDownloadSource.Uptodown -> listOf(
+            DownloadStep(
+                text = AnnotatedString(stringResource(R.string.home_download_instructions_step2_part1)),
+                button = SiteButton.Uptodown
+            )
+        )
+
+        ApkDownloadSource.WebSearch -> listOf(
+            DownloadStep(
+                text = AnnotatedString(stringResource(R.string.home_download_instructions_step2_search)),
+                note = stringResource(R.string.home_download_instructions_step2_search_note)
+            ),
+            DownloadStep(
+                htmlAnnotatedString(
+                    // Results are ordered by the website, not by version, so the one to pick has
+                    // to be named again here. Without a requested version any of them will do
+                    if (requestedVersion == null) {
+                        stringResource(R.string.home_download_instructions_step3_search_any)
+                    } else {
+                        stringResource(R.string.home_download_instructions_step3_search, requestedVersion)
+                    }
+                )
+            )
+        )
+
+        // Nothing is known about the page, so the wording stops at what every download page has
+        is ApkDownloadSource.Other, ApkDownloadSource.Unresolved -> listOf(
+            DownloadStep(AnnotatedString(stringResource(R.string.home_download_instructions_step2_generic)))
+        )
+    }
+
+    val backInMorphe = listOf(
+        DownloadStep(
+            htmlAnnotatedString(
+                stringResource(
+                    if (mountInstallRequired) {
+                        R.string.home_download_instructions_step3_mount
+                    } else {
+                        R.string.home_download_instructions_step3
+                    }
+                )
+            )
+        ),
+        DownloadStep(
+            AnnotatedString(
+                stringResource(
+                    if (mountInstallRequired) {
+                        R.string.home_download_instructions_step4_mount
+                    } else {
+                        R.string.home_download_instructions_step4
+                    }
+                )
+            )
+        )
+    )
+
+    return listOf(openSite) + onSite + backInMorphe
+}
+
+/**
+ * Dialog 2: Download instructions dialog.
+ *
+ * @param downloadUrl Best link known so far. Null or still unresolved keeps the wording generic.
+ * @param requestedVersion Version the APK has to be. Null when any version can be patched.
+ * @param downloadColor App accent color, which APKMirror tints its download button with.
+ * @param isApkBundle Whether the bundle requires a split archive, which APKMirror labels differently.
+ */
+@Composable
+internal fun DownloadInstructionsDialog(
+    downloadUrl: String?,
+    requestedVersion: String?,
+    usingMountInstall: Boolean,
+    targetAppInstalled: Boolean,
+    downloadColor: Color,
+    isApkBundle: Boolean,
+    onDismiss: () -> Unit,
+    onOpenApkDownloadHelper: (() -> Unit)? = null,
+    onContinue: () -> Unit
+) {
+    // Never falls back to unresolved once the destination is known, so the instructions stay
+    // put while the dialog animates out and the pending download data is already cleared
+    var source by remember { mutableStateOf<ApkDownloadSource>(ApkDownloadSource.Unresolved) }
+    LaunchedEffect(downloadUrl) {
+        ApkDownloadSource.from(downloadUrl)
+            .takeIf { it != ApkDownloadSource.Unresolved }
+            ?.let { source = it }
+    }
+
+    val continueText = stringResource(
+        R.string.home_download_instructions_continue_to,
+        source.destinationLabel()
+    )
+
+    AppDialog(
+        onDismissRequest = onDismiss,
+        title = stringResource(R.string.home_download_instructions_title),
+        footer = {
+            if (onOpenApkDownloadHelper != null) {
+                AppDialogButtonRow(
+                    primaryText = continueText,
+                    onPrimaryClick = onContinue,
+                    primaryIcon = Icons.AutoMirrored.Outlined.OpenInNew,
+                    secondaryText = stringResource(R.string.home_apk_helper_download),
+                    onSecondaryClick = onOpenApkDownloadHelper,
+                    secondaryIcon = Icons.Outlined.Download,
+                    layout = DialogButtonLayout.Vertical
+                )
+            } else {
+                AppDialogButton(
+                    text = continueText,
+                    onClick = onContinue,
+                    icon = Icons.AutoMirrored.Outlined.OpenInNew,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    ) {
+        val textColor = LocalDialogTextColor.current
+        val secondaryColor = LocalDialogSecondaryTextColor.current
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.home_download_instructions_steps_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = textColor
+            )
+
+            // The redirect resolves while the dialog is already up, so the steps are swapped
+            // for the site specific ones as soon as the destination is known
+            Crossfade(
+                targetState = source,
+                // Site specific steps are not all the same height, so the dialog grows into them
+                modifier = Modifier.animateContentSize(),
+                animationSpec = tween(Defaults.ANIMATION_DURATION_SHORT),
+                label = "downloadInstructions"
+            ) { currentSource ->
+                val mountInstallRequired = usingMountInstall && !targetAppInstalled
+                val steps = currentSource.instructionSteps(
+                    requestedVersion = requestedVersion,
+                    mountInstallRequired = mountInstallRequired
+                )
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    steps.forEachIndexed { index, step ->
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            InstructionStep(
+                                number = "${index + 1}",
+                                text = step.text,
+                                textColor = textColor,
+                                secondaryColor = secondaryColor
+                            )
+
+                            step.button?.let { button ->
+                                Box(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    SiteDownloadButton(
+                                        button = button,
+                                        downloadColor = downloadColor,
+                                        isApkBundle = isApkBundle
+                                    )
+                                }
+                            }
+
+                            step.note?.let { note ->
+                                Notice(
+                                    text = note,
+                                    tone = SemanticTone.Warning,
+                                    icon = Icons.Outlined.Warning,
+                                    density = NoticeDensity.Compact
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Redraws the button the user has to find on the website.
+ *
+ * Pressing it downloads nothing, so every copy answers with the same nudge back to the website.
+ */
+@Composable
+private fun SiteDownloadButton(
+    button: SiteButton,
+    downloadColor: Color,
+    isApkBundle: Boolean
+) {
+    val context = LocalContext.current
+    val toasts = listOf(
+        stringResource(R.string.home_download_instructions_download_button_toast),
+        stringResource(R.string.home_download_instructions_download_button_toast_2),
+        stringResource(R.string.home_download_instructions_download_button_toast_3),
+        stringResource(R.string.home_download_instructions_download_button_toast_4),
+        stringResource(R.string.home_download_instructions_download_button_toast_5),
+        stringResource(R.string.home_download_instructions_download_button_toast_6),
+    )
+    var clickCount by remember { mutableIntStateOf(0) }
+    val onClick = {
+        clickCount++
+        context.toast(
+            string = toasts.getOrElse(clickCount - 1) { toasts.last() },
+            duration = Toast.LENGTH_LONG
+        )
+    }
+
+    when (button) {
+        // APKMirror tints its download button with the app's own accent color
+        SiteButton.ApkMirror -> {
+            val buttonColor = downloadColor.ensureContrast(MaterialTheme.colorScheme.background)
+            val contentColor = if (buttonColor.requiresLightContent()) Color.White else Color.Black
+
+            Surface(
+                onClick = onClick,
+                shape = RoundedCornerShape(1.dp),
+                color = buttonColor
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Download,
+                            contentDescription = null,
+                            tint = contentColor,
+                            modifier = Modifier.size(Defaults.IconSizeSmall)
+                        )
+                        Text(
+                            text = if (isApkBundle) "DOWNLOAD APK BUNDLE" else "DOWNLOAD APK",
+                            style = MaterialTheme.typography.labelLarge,
+                            color = contentColor
+                        )
+                    }
+
+                    // APKMirror spells out what a bundle holds on a second line, with the file
+                    // size and split count we have no way of knowing left out
+                    if (isApkBundle) {
+                        Text(
+                            text = "Base APK and splits",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = contentColor
+                        )
+                    }
+                }
+            }
+        }
+
+        // Uptodown uses its own brand color for every app, so the accent color plays no part here
+        SiteButton.Uptodown -> Surface(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(8.dp),
+            color = UptodownBrandColor
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 18.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Download",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                    Text(
+                        text = "Free",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Outlined.SaveAlt,
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(Defaults.IconSizeSmall)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InstructionStep(
+    number: String,
+    text: AnnotatedString,
+    textColor: Color,
+    secondaryColor: Color
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            text = number,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = textColor.copy(alpha = 0.6f)
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = secondaryColor,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -6,7 +6,6 @@
 package app.morphe.manager.ui.screen.home
 
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
@@ -19,9 +18,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -158,6 +155,10 @@ fun HomeDialogs(
         val usingMountInstall = homeViewModel.usingMountInstall
         // Remember packageName to prevent color flickering during exit animation
         val packageName = remember { homeViewModel.pendingPackageName }
+        // Settled in dialog 1 and remembered for the same reason, so the steps stay put on the way out
+        val requestedVersion = remember {
+            (homeViewModel.pendingSelectedDownloadVersion ?: homeViewModel.pendingRecommendedVersion)?.version
+        }
 
         // Resolve download button color: bundle declared → default
         val bundleMetadata by homeViewModel.bundleAppMetadataFlow.collectAsStateWithLifecycle()
@@ -172,6 +173,8 @@ fun HomeDialogs(
         }
 
         DownloadInstructionsDialog(
+            downloadUrl = homeViewModel.resolvedDownloadUrl,
+            requestedVersion = requestedVersion,
             usingMountInstall = usingMountInstall,
             targetAppInstalled = homeViewModel.pendingTargetAppInstalled == true,
             downloadColor = downloadColor,
@@ -824,195 +827,6 @@ internal fun ApkAvailabilityDialog(
             }
         }
     }
-}
-
-/**
- * Dialog 2: Download instructions dialog.
- */
-@Composable
-internal fun DownloadInstructionsDialog(
-    usingMountInstall: Boolean,
-    targetAppInstalled: Boolean,
-    downloadColor: Color,
-    isApkBundle: Boolean,
-    onDismiss: () -> Unit,
-    onOpenApkDownloadHelper: (() -> Unit)? = null,
-    onContinue: () -> Unit
-) {
-    val context = LocalContext.current
-    val downloadButtonToasts = listOf(
-        stringResource(R.string.home_download_instructions_download_button_toast),
-        stringResource(R.string.home_download_instructions_download_button_toast_2),
-        stringResource(R.string.home_download_instructions_download_button_toast_3),
-        stringResource(R.string.home_download_instructions_download_button_toast_4),
-        stringResource(R.string.home_download_instructions_download_button_toast_5),
-        stringResource(R.string.home_download_instructions_download_button_toast_6),
-    )
-    var downloadClickCount by remember { mutableIntStateOf(0) }
-
-    AppDialog(
-        onDismissRequest = onDismiss,
-        title = stringResource(R.string.home_download_instructions_title),
-        footer = {
-            if (onOpenApkDownloadHelper != null) {
-                AppDialogButtonRow(
-                    primaryText = stringResource(R.string.home_download_instructions_continue),
-                    onPrimaryClick = onContinue,
-                    primaryIcon = Icons.AutoMirrored.Outlined.OpenInNew,
-                    secondaryText = stringResource(R.string.home_apk_helper_download),
-                    onSecondaryClick = onOpenApkDownloadHelper,
-                    secondaryIcon = Icons.Outlined.Download,
-                    layout = DialogButtonLayout.Vertical
-                )
-            } else {
-                AppDialogButton(
-                    text = stringResource(R.string.home_download_instructions_continue),
-                    onClick = onContinue,
-                    icon = Icons.AutoMirrored.Outlined.OpenInNew,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    ) {
-        val textColor = LocalDialogTextColor.current
-        val secondaryColor = LocalDialogSecondaryTextColor.current
-
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                text = stringResource(R.string.home_download_instructions_steps_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = textColor
-            )
-
-            InstructionStep(
-                number = "1",
-                text = stringResource(
-                    R.string.home_download_instructions_step1,
-                    stringResource(R.string.home_download_instructions_continue)
-                ),
-                textColor = textColor,
-                secondaryColor = secondaryColor
-            )
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                InstructionStep(
-                    number = "2",
-                    text = stringResource(R.string.home_download_instructions_step2_part1),
-                    textColor = textColor,
-                    secondaryColor = secondaryColor
-                )
-
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    val adjustedDownloadColor = downloadColor.ensureContrast(MaterialTheme.colorScheme.background)
-                    val downloadContentColor = if (adjustedDownloadColor.requiresLightContent()) Color.White else Color.Black
-                    Surface(
-                        onClick = {
-                            downloadClickCount++
-                            context.toast(
-                                string = downloadButtonToasts.getOrElse(downloadClickCount - 1) { downloadButtonToasts.last() },
-                                duration = Toast.LENGTH_LONG
-                            )
-                        },
-                        shape = RoundedCornerShape(1.dp),
-                        color = adjustedDownloadColor
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Download,
-                                contentDescription = null,
-                                tint = downloadContentColor,
-                                modifier = Modifier.size(Defaults.IconSizeSmall)
-                            )
-                            Text(
-                                text = if (isApkBundle) "DOWNLOAD APK BUNDLE" else "DOWNLOAD APK",
-                                style = MaterialTheme.typography.labelLarge,
-                                color = downloadContentColor
-                            )
-                        }
-                    }
-                }
-            }
-
-            val mountInstallRequired = usingMountInstall && !targetAppInstalled
-
-            InstructionStep(
-                number = "3",
-                text = htmlAnnotatedString(
-                    stringResource(
-                        if (mountInstallRequired) {
-                            R.string.home_download_instructions_step3_mount
-                        } else {
-                            R.string.home_download_instructions_step3
-                        }
-                    )
-                ),
-                textColor = textColor,
-                secondaryColor = secondaryColor
-            )
-
-            InstructionStep(
-                number = "4",
-                text = stringResource(
-                    if (mountInstallRequired) R.string.home_download_instructions_step4_mount
-                    else R.string.home_download_instructions_step4
-                ),
-                textColor = textColor,
-                secondaryColor = secondaryColor
-            )
-        }
-    }
-}
-
-@Composable
-private fun InstructionStep(
-    number: String,
-    text: AnnotatedString,
-    textColor: Color,
-    secondaryColor: Color
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.Top
-    ) {
-        Text(
-            text = number,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = textColor.copy(alpha = 0.6f)
-        )
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
-            color = secondaryColor,
-            modifier = Modifier.weight(1f)
-        )
-    }
-}
-
-@Composable
-private fun InstructionStep(
-    number: String,
-    text: String,
-    textColor: Color,
-    secondaryColor: Color
-) {
-    InstructionStep(
-        number = number,
-        text = AnnotatedString(text),
-        textColor = textColor,
-        secondaryColor = secondaryColor
-    )
 }
 
 /**

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
@@ -257,7 +257,7 @@ class BatchPatcherViewModel : ViewModel(), KoinComponent {
      * The API redirect takes a moment, so the unresolved search URL is published first and
      * replaced once it resolves. That way the dialog is never waiting on the network.
      */
-    data class ApkSearch(val item: BatchPatchItem, val url: String)
+    data class ApkSearch(val item: BatchPatchItem, val version: String?, val url: String)
 
     var apkSearch: ApkSearch? by mutableStateOf(null)
         private set
@@ -267,6 +267,7 @@ class BatchPatcherViewModel : ViewModel(), KoinComponent {
         apkChoice = null
         apkSearch = ApkSearch(
             item = item,
+            version = version,
             url = downloadUrlResolver.apiSearchUrl(item.packageName, version)
         )
         viewModelScope.launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,12 @@
     <string name="home_download_instructions_steps_title">Instructions:</string>
     <string name="home_download_instructions_step1">Press the \'%s\' button below</string>
     <string name="home_download_instructions_step2_part1">Scroll down the webpage and press</string>
+    <string name="home_download_instructions_step2_generic">Scroll down the webpage and press its download button</string>
+    <string name="home_download_instructions_step2_variant">Scroll down the webpage and press the download button of the top &lt;b&gt;APK variant&lt;/b&gt;</string>
+    <string name="home_download_instructions_step2_search">Open a search result from a website you trust</string>
+    <string name="home_download_instructions_step2_search_note">Morphe cannot vouch for these websites. Skip the ones offering their own app store instead of an APK file</string>
+    <string name="home_download_instructions_step3_search">On that website, download the APK of version &lt;b&gt;%s&lt;/b&gt;, not the newest one</string>
+    <string name="home_download_instructions_step3_search_any">On that website, download the APK of the app. &lt;b&gt;Any version&lt;/b&gt; can be patched</string>
     <string name="home_download_instructions_download_button_toast">Press download on the website, and not here 😊</string>
     <string name="home_download_instructions_download_button_toast_2">Great! Now click continue and go to the website 👆</string>
     <string name="home_download_instructions_download_button_toast_3">Practice makes perfect and you\'re getting there 💪</string>
@@ -220,7 +226,8 @@
     <string name="home_download_instructions_step3_mount">Wait for the download to complete, then &lt;b&gt;install the APK&lt;/b&gt;</string>
     <string name="home_download_instructions_step4">After the download finishes, return to Morphe</string>
     <string name="home_download_instructions_step4_mount">After installing the original APK, return to Morphe</string>
-    <string name="home_download_instructions_continue">Continue to APKMirror.com</string>
+    <string name="home_download_instructions_continue_to">Continue to %s</string>
+    <string name="home_download_instructions_destination">the download page</string>
 
     <!-- Home Screen - Dialog 3: File Picker Prompt -->
     <string name="home_file_picker_prompt_title">Select downloaded APK</string>


### PR DESCRIPTION
### PR description

The download instructions always described `APKMirror`, even when the link opened `Uptodown`, a web search, or the APK file itself. Morphe now reads where the link actually goes and shows the matching steps, with a redrawn copy of the button user need to press on that particular website.

Closes #411
___
![Screenshot_2026-08-11-16-24-09-205_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/f3d26dd2-2396-42c8-8217-3c0a5a2fefe0)

![Screenshot_2026-08-11-15-01-25-403_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/565d639d-1346-4f4a-a0f4-613d558db443)

![Screenshot_2026-08-11-16-25-48-266_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/d46a5cad-df38-4fa8-9278-5225eb36e0ae)

