### PR TITLE
fix: Distinguish present non-patched tracked apps

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
@@ -20,6 +20,7 @@ data class HomeAppItem(
     val isPinnedByDefault: Boolean,
     val isInstalledOnDevice: Boolean,
     val isDeleted: Boolean,
+    val isInstallStateNotPatched: Boolean,
     val isInstallStateUnknown: Boolean,
     val savedApkFile: File?,
     val hasUpdate: Boolean,
@@ -31,5 +32,8 @@ data class HomeAppItem(
      * Whether the pending update is worth surfacing in the UI.
      * Uninstalled apps keep their update flag but show the uninstalled state instead.
      */
-    val showsUpdateBadge: Boolean get() = hasUpdate && !isDeleted && !isInstallStateUnknown
+    val showsUpdateBadge: Boolean get() = hasUpdate &&
+            !isDeleted &&
+            !isInstallStateNotPatched &&
+            !isInstallStateUnknown
 }

--- a/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.model
+
+import app.morphe.manager.data.room.apps.installed.InstallType
+import app.morphe.manager.domain.apk.InstalledPatchState
+
+/** User-facing state derived from Morphe's evidence about a tracked install. */
+internal data class TrackedInstallPresentation(
+    val isPatched: Boolean = false,
+    val isDeleted: Boolean = false,
+    val isNotPatched: Boolean = false,
+    val isUnknown: Boolean = false
+)
+
+/**
+ * Keeps a present, confirmed non-patched package distinct from a package that is absent.
+ *
+ * [isDeleted] still accounts for the tracked patched build being gone so existing recovery and
+ * filtering behavior stays unchanged. [isNotPatched] lets the UI describe the package that is
+ * actually present instead of claiming that no app is installed.
+ */
+internal fun trackedInstallPresentation(
+    installType: InstallType,
+    patchState: InstalledPatchState?
+): TrackedInstallPresentation = when (patchState) {
+    InstalledPatchState.Patched -> TrackedInstallPresentation(isPatched = true)
+    InstalledPatchState.NotPatched -> TrackedInstallPresentation(
+        isDeleted = installType != InstallType.SAVED,
+        isNotPatched = true
+    )
+    InstalledPatchState.Unknown -> TrackedInstallPresentation(isUnknown = true)
+    null -> TrackedInstallPresentation(isDeleted = installType != InstallType.SAVED)
+}

--- a/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
@@ -13,24 +13,59 @@ internal data class TrackedInstallPresentation(
     val isPatched: Boolean = false,
     val isDeleted: Boolean = false,
     val isNotPatched: Boolean = false,
-    val isUnknown: Boolean = false
+    val isUnknown: Boolean = false,
+    /** Whether the package currently installed on the device is safe to identify in the UI. */
+    val showsInstalledPackage: Boolean = false
 )
+
+/**
+ * Chooses which APK should supply the visible icon, label, and version for a tracked record.
+ * Unknown packages deliberately keep showing Morphe's retained artifact rather than assigning
+ * that record to a package whose identity could not be established.
+ */
+internal fun <T> TrackedInstallPresentation.displayedPackageInfo(
+    installedPackageInfo: T?,
+    savedPackageInfo: T?
+): T? = if (showsInstalledPackage) {
+    installedPackageInfo ?: savedPackageInfo
+} else {
+    savedPackageInfo
+}
+
+/**
+ * Keeps the untracked-app resolver fallback out of tracked states. In particular, an Unknown
+ * tracked package with no retained APK must stay metadata-free instead of silently revealing the
+ * package currently occupying its name.
+ */
+internal fun <T> displayedHomePackageInfo(
+    trackedPresentation: TrackedInstallPresentation?,
+    installedPackageInfo: T?,
+    savedPackageInfo: T?,
+    untrackedPackageInfo: T?
+): T? = if (trackedPresentation == null) {
+    untrackedPackageInfo
+} else {
+    trackedPresentation.displayedPackageInfo(installedPackageInfo, savedPackageInfo)
+}
 
 /**
  * Keeps a present, confirmed non-patched package distinct from a package that is absent.
  *
- * [isDeleted] still accounts for the tracked patched build being gone so existing recovery and
- * filtering behavior stays unchanged. [isNotPatched] lets the UI describe the package that is
- * actually present instead of claiming that no app is installed.
+ * A confirmed replacement is present, not deleted, but it remains distinct from both the patched
+ * build in Morphe's record and an app that has never been patched. [showsInstalledPackage] lets
+ * the UI use the replacement's current icon and version only when its identity is confirmed.
  */
 internal fun trackedInstallPresentation(
     installType: InstallType,
     patchState: InstalledPatchState?
 ): TrackedInstallPresentation = when (patchState) {
-    InstalledPatchState.Patched -> TrackedInstallPresentation(isPatched = true)
+    InstalledPatchState.Patched -> TrackedInstallPresentation(
+        isPatched = true,
+        showsInstalledPackage = true
+    )
     InstalledPatchState.NotPatched -> TrackedInstallPresentation(
-        isDeleted = installType != InstallType.SAVED,
-        isNotPatched = true
+        isNotPatched = true,
+        showsInstalledPackage = true
     )
     InstalledPatchState.Unknown -> TrackedInstallPresentation(isUnknown = true)
     null -> TrackedInstallPresentation(isDeleted = installType != InstallType.SAVED)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -193,16 +194,21 @@ fun InstalledAppCard(
     modifier: Modifier = Modifier,
     hasUpdate: Boolean = false,
     isAppDeleted: Boolean = false,
+    isInstallStateNotPatched: Boolean = false,
     isInstallStateUnknown: Boolean = false,
     onLongClick: (() -> Unit)? = null
 ) {
     val cardStyle = homeAppCardStyle(subtitleAlpha = 0.85f)
-    val showsUpdateBadge = hasUpdate && !isAppDeleted && !isInstallStateUnknown
+    val showsUpdateBadge = hasUpdate &&
+            !isAppDeleted &&
+            !isInstallStateNotPatched &&
+            !isInstallStateUnknown
 
     val versionLabel = stringResource(R.string.version)
     val installedLabel = stringResource(R.string.installed)
     val updateAvailableLabel = stringResource(R.string.update_available)
     val deletedLabel = stringResource(R.string.uninstalled)
+    val notPatchedLabel = stringResource(R.string.home_not_patched_yet)
     val unverifiedLabel = stringResource(R.string.home_unverified)
 
     val version = remember(packageInfo, installedApp, isAppDeleted) {
@@ -219,6 +225,8 @@ fun InstalledAppCard(
         updateAvailableLabel,
         isAppDeleted,
         deletedLabel,
+        isInstallStateNotPatched,
+        notPatchedLabel,
         isInstallStateUnknown,
         unverifiedLabel
     ) {
@@ -230,6 +238,7 @@ fun InstalledAppCard(
             append(", ")
             append(
                 when {
+                    isInstallStateNotPatched -> notPatchedLabel
                     isAppDeleted -> deletedLabel
                     isInstallStateUnknown -> unverifiedLabel
                     else -> installedLabel
@@ -290,10 +299,19 @@ fun InstalledAppCard(
 
                 // Frosted-glass colors: a white semi-transparent fill reads on any accent
                 // color the card's bundle brings, and on the user's dynamic theme
-                if (isAppDeleted) {
+                if (isAppDeleted && !isInstallStateNotPatched) {
                     StatusBadge(
                         text = stringResource(R.string.uninstalled),
                         icon = Icons.Outlined.DeleteOutline,
+                        containerColor = cardStyle.chipContainerColor,
+                        contentColor = cardStyle.chipContentColor
+                    )
+                }
+
+                if (isInstallStateNotPatched) {
+                    StatusBadge(
+                        text = notPatchedLabel,
+                        icon = Icons.Outlined.AutoFixHigh,
                         containerColor = cardStyle.chipContainerColor,
                         contentColor = cardStyle.chipContentColor
                     )

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
@@ -55,6 +55,7 @@ import app.morphe.manager.ui.theme.LocalMonochromeTheme
 import app.morphe.manager.ui.theme.MonochromeThemeDefaults
 import app.morphe.manager.util.AppCardColorResolver
 import app.morphe.manager.util.AppDataSource
+import app.morphe.manager.util.withVersionPrefix
 
 private data class HomeAppCardStyle(
     val monochrome: Boolean,
@@ -208,12 +209,12 @@ fun InstalledAppCard(
     val installedLabel = stringResource(R.string.installed)
     val updateAvailableLabel = stringResource(R.string.update_available)
     val deletedLabel = stringResource(R.string.uninstalled)
-    val notPatchedLabel = stringResource(R.string.home_not_patched_yet)
+    val replacementLabel = stringResource(R.string.home_unpatched_version_installed)
     val unverifiedLabel = stringResource(R.string.home_unverified)
 
     val version = remember(packageInfo, installedApp, isAppDeleted) {
         val raw = packageInfo?.versionName ?: installedApp.version
-        if (raw.startsWith("v")) raw else "v$raw"
+        raw.withVersionPrefix()
     }
 
     val contentDesc = remember(
@@ -226,7 +227,7 @@ fun InstalledAppCard(
         isAppDeleted,
         deletedLabel,
         isInstallStateNotPatched,
-        notPatchedLabel,
+        replacementLabel,
         isInstallStateUnknown,
         unverifiedLabel
     ) {
@@ -238,7 +239,7 @@ fun InstalledAppCard(
             append(", ")
             append(
                 when {
-                    isInstallStateNotPatched -> notPatchedLabel
+                    isInstallStateNotPatched -> replacementLabel
                     isAppDeleted -> deletedLabel
                     isInstallStateUnknown -> unverifiedLabel
                     else -> installedLabel
@@ -310,7 +311,7 @@ fun InstalledAppCard(
 
                 if (isInstallStateNotPatched) {
                     StatusBadge(
-                        text = notPatchedLabel,
+                        text = replacementLabel,
                         icon = Icons.Outlined.AutoFixHigh,
                         containerColor = cardStyle.chipContainerColor,
                         contentColor = cardStyle.chipContentColor

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
@@ -365,6 +365,7 @@ internal fun DynamicAppCard(
                                 onClick = onAppClick,
                                 hasUpdate = hasUpdate,
                                 isAppDeleted = item.isDeleted,
+                                isInstallStateNotPatched = item.isInstallStateNotPatched,
                                 isInstallStateUnknown = item.isInstallStateUnknown,
                                 onLongClick = {
                                     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
@@ -495,6 +496,7 @@ internal fun HiddenSearchAppCard(
                     onClick = onAppClick,
                     hasUpdate = item.hasUpdate,
                     isAppDeleted = item.isDeleted,
+                    isInstallStateNotPatched = item.isInstallStateNotPatched,
                     isInstallStateUnknown = item.isInstallStateUnknown
                 )
             } else {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -475,7 +475,7 @@ fun InstalledAppInfoDialog(
                                     StaggeredItem(entered = entered.value, index = 2) {
                                         WarningBanner(
                                             icon = Icons.Outlined.AutoFixHigh,
-                                            title = stringResource(R.string.home_not_patched_yet),
+                                            title = stringResource(R.string.home_unpatched_version_installed),
                                             description = stringResource(R.string.home_app_info_not_patched_description),
                                             buttonText = stringResource(R.string.patch),
                                             buttonIcon = Icons.Outlined.AutoFixHigh,
@@ -592,7 +592,7 @@ fun InstalledAppInfoDialog(
                                         StaggeredItem(entered = entered.value, index = 1) {
                                             WarningBanner(
                                                 icon = Icons.Outlined.AutoFixHigh,
-                                                title = stringResource(R.string.home_not_patched_yet),
+                                                title = stringResource(R.string.home_unpatched_version_installed),
                                                 description = stringResource(R.string.home_app_info_not_patched_description),
                                                 buttonText = stringResource(R.string.patch),
                                                 buttonIcon = Icons.Outlined.AutoFixHigh,
@@ -927,7 +927,7 @@ private fun AppHeroHeader(
                     }
                     // Animated version (slightly behind name via sub-range)
                     Text(
-                        text = appInfo?.versionName?.let { "v$it" } ?: installedApp.version,
+                        text = (appInfo?.versionName ?: installedApp.version).withVersionPrefix(),
                         style = MaterialTheme.typography.bodyMedium,
                         color = onHero.copy(alpha = 0.50f),
                         modifier = Modifier.graphicsLayer {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -95,6 +95,7 @@ fun InstalledAppInfoDialog(
     val hasUpdate = appUpdates[packageName] == true
     val showsUpdateBanner = hasUpdate &&
             !viewModel.isAppDeleted &&
+            !viewModel.isInstallStateNotPatched &&
             !viewModel.isInstallStateUnknown
 
     // Accent color resolution order: bundle metadata (appIconColor) -> KnownApps.brandColor -> default.
@@ -449,7 +450,7 @@ fun InstalledAppInfoDialog(
                                 verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)
                             ) {
                                 AnimatedVisibility(
-                                    visible = viewModel.isAppDeleted,
+                                    visible = viewModel.isAppDeleted && !viewModel.isInstallStateNotPatched,
                                     enter = Animations.expandFadeEnter,
                                     exit = Animations.shrinkFadeExit
                                 ) {
@@ -463,6 +464,23 @@ fun InstalledAppInfoDialog(
                                             onClick = { onTriggerPatchFlow(installedApp.originalPackageName) },
                                             accentColor = infoAccentColor,
                                             isError = true
+                                        )
+                                    }
+                                }
+                                AnimatedVisibility(
+                                    visible = viewModel.isInstallStateNotPatched,
+                                    enter = Animations.expandFadeEnter,
+                                    exit = Animations.shrinkFadeExit
+                                ) {
+                                    StaggeredItem(entered = entered.value, index = 2) {
+                                        WarningBanner(
+                                            icon = Icons.Outlined.AutoFixHigh,
+                                            title = stringResource(R.string.home_not_patched_yet),
+                                            description = stringResource(R.string.home_app_info_not_patched_description),
+                                            buttonText = stringResource(R.string.patch),
+                                            buttonIcon = Icons.Outlined.AutoFixHigh,
+                                            onClick = { onTriggerPatchFlow(installedApp.originalPackageName) },
+                                            accentColor = infoAccentColor
                                         )
                                     }
                                 }
@@ -541,7 +559,7 @@ fun InstalledAppInfoDialog(
                         item(key = "banner") {
                             Column {
                                 androidx.compose.animation.AnimatedVisibility(
-                                    visible = viewModel.isAppDeleted,
+                                    visible = viewModel.isAppDeleted && !viewModel.isInstallStateNotPatched,
                                     enter = Animations.expandFadeEnter,
                                     exit = Animations.shrinkFadeExit
                                 ) {
@@ -559,6 +577,29 @@ fun InstalledAppInfoDialog(
                                                 },
                                                 accentColor = infoAccentColor,
                                                 isError = true,
+                                                modifier = Modifier.padding(horizontal = Defaults.ContentPadding)
+                                            )
+                                        }
+                                    }
+                                }
+                                androidx.compose.animation.AnimatedVisibility(
+                                    visible = viewModel.isInstallStateNotPatched,
+                                    enter = Animations.expandFadeEnter,
+                                    exit = Animations.shrinkFadeExit
+                                ) {
+                                    Column {
+                                        Spacer(Modifier.height(Defaults.ItemSpacing))
+                                        StaggeredItem(entered = entered.value, index = 1) {
+                                            WarningBanner(
+                                                icon = Icons.Outlined.AutoFixHigh,
+                                                title = stringResource(R.string.home_not_patched_yet),
+                                                description = stringResource(R.string.home_app_info_not_patched_description),
+                                                buttonText = stringResource(R.string.patch),
+                                                buttonIcon = Icons.Outlined.AutoFixHigh,
+                                                onClick = {
+                                                    onTriggerPatchFlow(installedApp.originalPackageName)
+                                                },
+                                                accentColor = infoAccentColor,
                                                 modifier = Modifier.padding(horizontal = Defaults.ContentPadding)
                                             )
                                         }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -63,6 +63,8 @@ import app.morphe.manager.patcher.split.SplitApkPreparer
 import app.morphe.manager.domain.manager.loadCopySelectionCandidates
 import app.morphe.manager.ui.model.HomeAppItem
 import app.morphe.manager.ui.model.SelectedApp
+import app.morphe.manager.ui.model.TrackedInstallPresentation
+import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
 import app.morphe.manager.util.*
 import app.morphe.manager.util.PatchSelectionUtils.applyAvailability
@@ -1261,11 +1263,10 @@ class HomeViewModel(
             val savedPatchedApk = trackedSnapshot?.savedPatchedApk
             val savedPackageInfo = trackedSnapshot?.savedPatchedApkInfo
             val trackedPatchState = trackedSnapshot?.patchState
-            val isInstalledOnDevice = trackedPatchState == InstalledPatchState.Patched
-            val isDeleted = installedApp != null &&
-                    installedApp.installType != InstallType.SAVED &&
-                    (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
-            val isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
+            val trackedPresentation = installedApp?.let {
+                trackedInstallPresentation(it.installType, trackedPatchState)
+            } ?: TrackedInstallPresentation()
+            val isInstalledOnDevice = trackedPresentation.isPatched
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
             } == true
@@ -1288,8 +1289,9 @@ class HomeViewModel(
                 },
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
                 isInstalledOnDevice = isInstalledOnDevice || resolvedData.source == AppDataSource.INSTALLED,
-                isDeleted = isDeleted,
-                isInstallStateUnknown = isInstallStateUnknown,
+                isDeleted = trackedPresentation.isDeleted,
+                isInstallStateNotPatched = trackedPresentation.isNotPatched,
+                isInstallStateUnknown = trackedPresentation.isUnknown,
                 savedApkFile = savedPatchedApk,
                 hasUpdate = hasUpdate,
                 patchCount = 0

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -63,7 +63,7 @@ import app.morphe.manager.patcher.split.SplitApkPreparer
 import app.morphe.manager.domain.manager.loadCopySelectionCandidates
 import app.morphe.manager.ui.model.HomeAppItem
 import app.morphe.manager.ui.model.SelectedApp
-import app.morphe.manager.ui.model.TrackedInstallPresentation
+import app.morphe.manager.ui.model.displayedHomePackageInfo
 import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.shared.CopySelectionCandidate
 import app.morphe.manager.util.*
@@ -1265,8 +1265,8 @@ class HomeViewModel(
             val trackedPatchState = trackedSnapshot?.patchState
             val trackedPresentation = installedApp?.let {
                 trackedInstallPresentation(it.installType, trackedPatchState)
-            } ?: TrackedInstallPresentation()
-            val isInstalledOnDevice = trackedPresentation.isPatched
+            }
+            val isInstalledOnDevice = trackedPresentation?.isPatched == true
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
             } == true
@@ -1280,18 +1280,21 @@ class HomeViewModel(
                 displayName = displayName,
                 gradientColors = gradientColors,
                 installedApp = installedApp,
-                // A tracked app that cannot be confirmed shows what Morphe kept on disk rather
-                // than describing whatever package took over its name
-                packageInfo = when {
-                    installedApp == null -> resolvedData.packageInfo
-                    isInstalledOnDevice -> resolvedData.packageInfo ?: savedPackageInfo
-                    else -> savedPackageInfo
-                },
+                // Confirmed installs and replacements use the package actually on the device.
+                // Unknown packages keep showing what Morphe retained rather than attributing the
+                // record to whichever package currently owns the name.
+                packageInfo = displayedHomePackageInfo(
+                    trackedPresentation = trackedPresentation,
+                    installedPackageInfo = trackedSnapshot?.installedPackageInfo,
+                    savedPackageInfo = savedPackageInfo,
+                    untrackedPackageInfo = resolvedData.packageInfo
+                ),
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
-                isInstalledOnDevice = isInstalledOnDevice || resolvedData.source == AppDataSource.INSTALLED,
-                isDeleted = trackedPresentation.isDeleted,
-                isInstallStateNotPatched = trackedPresentation.isNotPatched,
-                isInstallStateUnknown = trackedPresentation.isUnknown,
+                isInstalledOnDevice = (trackedPresentation?.showsInstalledPackage == true) ||
+                        (installedApp == null && resolvedData.source == AppDataSource.INSTALLED),
+                isDeleted = trackedPresentation?.isDeleted == true,
+                isInstallStateNotPatched = trackedPresentation?.isNotPatched == true,
+                isInstallStateUnknown = trackedPresentation?.isUnknown == true,
                 savedApkFile = savedPatchedApk,
                 hasUpdate = hasUpdate,
                 patchCount = 0

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -18,6 +18,7 @@ import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
 import app.morphe.manager.domain.repository.*
+import app.morphe.manager.ui.model.displayedPackageInfo
 import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.home.AppliedPatchBundleUi
 import app.morphe.manager.util.*
@@ -285,13 +286,13 @@ class InstalledAppInfoViewModel(
         val trackedPatchState = snapshot.patchState
         val trackedPresentation = trackedInstallPresentation(app.installType, trackedPatchState)
 
-        if (installedInfo != null && trackedPresentation.isPatched) {
-            isInstalledOnDevice = true
-            appInfo = installedInfo
-        } else {
-            isInstalledOnDevice = false
-            appInfo = snapshot.savedPatchedApkInfo
-        }
+        // This flag authorizes actions against Morphe's tracked build, so a confirmed stock
+        // replacement remains false even though its own metadata is safe to display.
+        isInstalledOnDevice = installedInfo != null && trackedPresentation.isPatched
+        appInfo = trackedPresentation.displayedPackageInfo(
+            installedPackageInfo = installedInfo,
+            savedPackageInfo = snapshot.savedPatchedApkInfo
+        )
         isAppDeleted = trackedPresentation.isDeleted
         isInstallStateNotPatched = trackedPresentation.isNotPatched
         isInstallStateUnknown = trackedPresentation.isUnknown

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -18,6 +18,7 @@ import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
 import app.morphe.manager.domain.repository.*
+import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.home.AppliedPatchBundleUi
 import app.morphe.manager.util.*
 import kotlinx.coroutines.Dispatchers
@@ -66,6 +67,8 @@ class InstalledAppInfoViewModel(
     var hasOriginalApk by mutableStateOf(false)
         private set
     var isAppDeleted by mutableStateOf(false)
+        private set
+    var isInstallStateNotPatched by mutableStateOf(false)
         private set
     var isInstallStateUnknown by mutableStateOf(false)
         private set
@@ -280,21 +283,18 @@ class InstalledAppInfoViewModel(
         usableSavedApk = snapshot.savedPatchedApk
         hasSavedCopy = usableSavedApk != null
         val trackedPatchState = snapshot.patchState
+        val trackedPresentation = trackedInstallPresentation(app.installType, trackedPatchState)
 
-        if (installedInfo != null && trackedPatchState == InstalledPatchState.Patched) {
+        if (installedInfo != null && trackedPresentation.isPatched) {
             isInstalledOnDevice = true
-            isAppDeleted = false
-            isInstallStateUnknown = false
             appInfo = installedInfo
         } else {
             isInstalledOnDevice = false
-            // A missing or stock package means the tracked patched build is gone. Unknown is kept
-            // separate so the UI stays honest while still withholding destructive app actions.
-            isAppDeleted = app.installType != InstallType.SAVED &&
-                    (trackedPatchState == null || trackedPatchState == InstalledPatchState.NotPatched)
-            isInstallStateUnknown = trackedPatchState == InstalledPatchState.Unknown
             appInfo = snapshot.savedPatchedApkInfo
         }
+        isAppDeleted = trackedPresentation.isDeleted
+        isInstallStateNotPatched = trackedPresentation.isNotPatched
+        isInstallStateUnknown = trackedPresentation.isUnknown
 
         canRemoveRecord = canRemoveTrackedRecord(app.installType, trackedPatchState, hasSavedCopy)
 

--- a/app/src/main/java/app/morphe/manager/util/VersionUtils.kt
+++ b/app/src/main/java/app/morphe/manager/util/VersionUtils.kt
@@ -21,6 +21,9 @@ fun isPatcherOutdated(required: String, current: String = BuildConfig.PATCHER_VE
  */
 fun String.normalizeVersion(): String = removePrefix("v").trim()
 
+/** Adds the conventional display prefix without duplicating one already supplied by the app. */
+fun String.withVersionPrefix(): String = if (startsWith("v")) this else "v$this"
+
 /**
  * Compare two version strings.
  * Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <!-- Home Screen -->
     <string name="home_other_apps">Other apps</string>
     <string name="home_not_patched_yet">Not patched yet</string>
+    <string name="home_unpatched_version_installed">Unpatched version installed</string>
     <string name="home_no_patches_available">No patches available</string>
     <string name="home_app_hide_title">Hide this app?</string>
     <string name="home_app_hide_message">This app will be hidden from the home screen. You can restore it later from the hidden apps using the button at the bottom of the list</string>
@@ -419,7 +420,7 @@ Outer zone (dashed): may be clipped by the launcher mask - keep important detail
     <string name="home_app_info_patch_update_available_description">A newer version of patches is available. Repatch your app to get the latest improvements and fixes</string>
     <string name="home_app_info_app_deleted_warning">App was uninstalled</string>
     <string name="home_app_info_app_deleted_description">This app was uninstalled outside the Morphe. Repatch it to restore functionality</string>
-    <string name="home_app_info_not_patched_description">The app installed on this device is not the build Morphe patched. Patch it to restore Morphe\'s tracked install</string>
+    <string name="home_app_info_not_patched_description">An unpatched version of this app is installed. Morphe still has its previous patch record</string>
     <string name="home_app_info_apk_size">APK size</string>
     <string name="home_app_info_cpu_arch">CPU architecture</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,6 +419,7 @@ Outer zone (dashed): may be clipped by the launcher mask - keep important detail
     <string name="home_app_info_patch_update_available_description">A newer version of patches is available. Repatch your app to get the latest improvements and fixes</string>
     <string name="home_app_info_app_deleted_warning">App was uninstalled</string>
     <string name="home_app_info_app_deleted_description">This app was uninstalled outside the Morphe. Repatch it to restore functionality</string>
+    <string name="home_app_info_not_patched_description">The app installed on this device is not the build Morphe patched. Patch it to restore Morphe\'s tracked install</string>
     <string name="home_app_info_apk_size">APK size</string>
     <string name="home_app_info_cpu_arch">CPU architecture</string>
 

--- a/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
@@ -14,7 +14,7 @@ class TrackedInstallPresentationTest {
     @Test
     fun `confirmed patched install is presented as installed`() {
         assertEquals(
-            TrackedInstallPresentation(isPatched = true),
+            TrackedInstallPresentation(isPatched = true, showsInstalledPackage = true),
             trackedInstallPresentation(InstallType.DEFAULT, InstalledPatchState.Patched)
         )
     }
@@ -28,10 +28,73 @@ class TrackedInstallPresentationTest {
     }
 
     @Test
-    fun `present non-patched package is distinguished from an absent package`() {
+    fun `confirmed replacement is present and distinct from a never-patched app`() {
         assertEquals(
-            TrackedInstallPresentation(isDeleted = true, isNotPatched = true),
+            TrackedInstallPresentation(isNotPatched = true, showsInstalledPackage = true),
             trackedInstallPresentation(InstallType.DEFAULT, InstalledPatchState.NotPatched)
+        )
+    }
+
+    @Test
+    fun `confirmed replacement displays current package information`() {
+        val presentation = trackedInstallPresentation(
+            InstallType.DEFAULT,
+            InstalledPatchState.NotPatched
+        )
+
+        assertEquals(
+            "current",
+            presentation.displayedPackageInfo(
+                installedPackageInfo = "current",
+                savedPackageInfo = "saved"
+            )
+        )
+    }
+
+    @Test
+    fun `unknown package keeps displaying retained package information`() {
+        val presentation = trackedInstallPresentation(
+            InstallType.DEFAULT,
+            InstalledPatchState.Unknown
+        )
+
+        assertEquals(
+            "saved",
+            presentation.displayedPackageInfo(
+                installedPackageInfo = "current",
+                savedPackageInfo = "saved"
+            )
+        )
+    }
+
+    @Test
+    fun `unknown tracked package never falls back to untracked current information`() {
+        val presentation = trackedInstallPresentation(
+            InstallType.DEFAULT,
+            InstalledPatchState.Unknown
+        )
+
+        assertEquals(
+            null,
+            displayedHomePackageInfo(
+                trackedPresentation = presentation,
+                installedPackageInfo = "current",
+                savedPackageInfo = null,
+                untrackedPackageInfo = "resolved-current"
+            )
+        )
+    }
+
+    @Test
+    fun `untracked app uses normally resolved package information`() {
+        assertEquals(
+            "resolved-current",
+            displayedHomePackageInfo(
+                trackedPresentation = null,
+                installedPackageInfo = "current",
+                savedPackageInfo = null,
+                untrackedPackageInfo = "resolved-current"
+            )
         )
     }
 

--- a/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.model
+
+import app.morphe.manager.data.room.apps.installed.InstallType
+import app.morphe.manager.domain.apk.InstalledPatchState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TrackedInstallPresentationTest {
+    @Test
+    fun `confirmed patched install is presented as installed`() {
+        assertEquals(
+            TrackedInstallPresentation(isPatched = true),
+            trackedInstallPresentation(InstallType.DEFAULT, InstalledPatchState.Patched)
+        )
+    }
+
+    @Test
+    fun `missing tracked install is presented as deleted`() {
+        assertEquals(
+            TrackedInstallPresentation(isDeleted = true),
+            trackedInstallPresentation(InstallType.DEFAULT, null)
+        )
+    }
+
+    @Test
+    fun `present non-patched package is distinguished from an absent package`() {
+        assertEquals(
+            TrackedInstallPresentation(isDeleted = true, isNotPatched = true),
+            trackedInstallPresentation(InstallType.DEFAULT, InstalledPatchState.NotPatched)
+        )
+    }
+
+    @Test
+    fun `unverifiable install is presented as unknown`() {
+        assertEquals(
+            TrackedInstallPresentation(isUnknown = true),
+            trackedInstallPresentation(InstallType.DEFAULT, InstalledPatchState.Unknown)
+        )
+    }
+
+    @Test
+    fun `saved record without an install is not presented as deleted`() {
+        assertEquals(
+            TrackedInstallPresentation(),
+            trackedInstallPresentation(InstallType.SAVED, null)
+        )
+    }
+}

--- a/app/src/test/java/app/morphe/manager/ui/screen/home/HomeAppFilterModeTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/screen/home/HomeAppFilterModeTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.home
+
+import app.morphe.manager.data.room.apps.installed.InstallType
+import app.morphe.manager.data.room.apps.installed.InstalledApp
+import app.morphe.manager.ui.model.HomeAppItem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HomeAppFilterModeTest {
+    @Test
+    fun `confirmed replacement is historically patched and currently installed`() {
+        val item = HomeAppItem(
+            packageName = "app.example",
+            displayName = "Example",
+            gradientColors = emptyList(),
+            installedApp = InstalledApp(
+                currentPackageName = "app.example",
+                originalPackageName = "app.example",
+                version = "1.0",
+                installType = InstallType.DEFAULT
+            ),
+            packageInfo = null,
+            isPinnedByDefault = false,
+            isInstalledOnDevice = true,
+            isDeleted = false,
+            isInstallStateNotPatched = true,
+            isInstallStateUnknown = false,
+            savedApkFile = null,
+            hasUpdate = false,
+            patchCount = 0
+        )
+
+        assertTrue(HomeAppFilterMode.PATCHED.matches(item))
+        assertTrue(HomeAppFilterMode.INSTALLED.matches(item))
+        assertFalse(HomeAppFilterMode.NOT_PATCHED.matches(item))
+        assertFalse(HomeAppFilterMode.UNINSTALLED.matches(item))
+    }
+}

--- a/app/src/test/java/app/morphe/manager/util/VersionUtilsTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/VersionUtilsTest.kt
@@ -41,6 +41,12 @@ class VersionUtilsTest {
     }
 
     @Test
+    fun `display prefix is added exactly once`() {
+        assertEquals("v1.25.0", "1.25.0".withVersionPrefix())
+        assertEquals("v1.25.0", "v1.25.0".withVersionPrefix())
+    }
+
+    @Test
     fun `segments are compared numerically rather than as text`() {
         assertOlder("1.9.0", "1.10.0")
         assertOlder("1.25.9", "1.25.10")


### PR DESCRIPTION
## Summary

- present a confirmed non-patched replacement as **Unpatched version installed**, distinct from an app that Morphe has never patched
- show the replacement's current installed icon and version and classify it as installed, while retaining Morphe's previous patch record and cleanup action
- reserve **Uninstalled** for an absent package and keep `Unknown` conservative as **Unverified**

Fixes #850. Follow-up to #831.

## Root cause

#831 introduced distinct `Patched`, `NotPatched`, and `Unknown` evidence states, but the presentation layer mapped both `NotPatched` and an absent package to `isDeleted`. It also displayed retained patched-APK metadata for both `NotPatched` and `Unknown`. A confirmed Play Store or stock replacement was therefore presented as an uninstalled historical build rather than the different, unpatched package actually on the device.

## Changes

- Centralize the tracked-state presentation mapping used by the home screen and detail dialog.
- Treat `NotPatched` as a present confirmed replacement, use its current PackageManager metadata, and label it **Unpatched version installed**.
- Keep its historical patched record and detail screen, including Patch and Delete, while continuing to withhold Open and Uninstall actions.
- Keep `Unknown` on retained metadata and prevent the normal untracked-app resolver from leaking the current package identity when no retained APK exists.
- Normalize displayed version prefixes so an installed version already beginning with `v` is not rendered with a duplicate prefix.
- Cover the presentation, metadata selection, filter membership, and version formatting contracts with focused unit tests.

## Validation

- `:app:testDebugUnitTest :app:assembleDebug`: **BUILD SUCCESSFUL**
- 74 unit tests passed
- Pixel 9 device test against real Play Store Ampere `v4.36.1`:
  - confirmed replacement showed its current icon/version and **Unpatched version installed**, never **Uninstalled**
  - detail showed the previous-record explanation with Patch and Delete only
  - adjacent `Unknown` case showed retained `v4.36.0` as **Unverified** and did not reveal current package metadata
  - no AndroidRuntime, Room, or SQLite errors
- Debug app and synthetic device artifacts removed afterward; release Morphe and Ampere remained unchanged
- `git diff --check`: clean
