### PR TITLE
fix: Stop re-verifying every tracked APK on each cold start

### DIFF
--- a/app/schemas/app.morphe.manager.data.room.AppDatabase/13.json
+++ b/app/schemas/app.morphe.manager.data.room.AppDatabase/13.json
@@ -1,0 +1,521 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "d8524a5875f279ef0e9e1cd214583b55",
+    "entities": [
+      {
+        "tableName": "patch_bundles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_name` TEXT, `version` TEXT, `source` TEXT NOT NULL, `auto_update` INTEGER NOT NULL, `enabled` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` INTEGER, `updated_at` INTEGER, PRIMARY KEY(`uid`))",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "versionHash",
+            "columnName": "version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoUpdate",
+            "columnName": "auto_update",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uid"
+          ]
+        }
+      },
+      {
+        "tableName": "patch_selections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER NOT NULL, `patch_bundle` INTEGER NOT NULL, `package_name` TEXT NOT NULL, PRIMARY KEY(`uid`), FOREIGN KEY(`patch_bundle`) REFERENCES `patch_bundles`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchBundle",
+            "columnName": "patch_bundle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_patch_selections_patch_bundle_package_name",
+            "unique": true,
+            "columnNames": [
+              "patch_bundle",
+              "package_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_patch_selections_patch_bundle_package_name` ON `${TABLE_NAME}` (`patch_bundle`, `package_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "patch_bundles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "patch_bundle"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "selected_patches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`selection` INTEGER NOT NULL, `patch_name` TEXT NOT NULL, PRIMARY KEY(`selection`, `patch_name`), FOREIGN KEY(`selection`) REFERENCES `patch_selections`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "selection",
+            "columnName": "selection",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchName",
+            "columnName": "patch_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "selection",
+            "patch_name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "patch_selections",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "selection"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seen_patches",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`patch_bundle` INTEGER NOT NULL, `package_name` TEXT NOT NULL, `patch_name` TEXT NOT NULL, PRIMARY KEY(`patch_bundle`, `package_name`, `patch_name`), FOREIGN KEY(`patch_bundle`) REFERENCES `patch_bundles`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "patchBundle",
+            "columnName": "patch_bundle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchName",
+            "columnName": "patch_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "patch_bundle",
+            "package_name",
+            "patch_name"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "patch_bundles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "patch_bundle"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "installed_app",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`current_package_name` TEXT NOT NULL, `original_package_name` TEXT NOT NULL, `version` TEXT NOT NULL, `install_type` TEXT NOT NULL, `selection_payload` TEXT, `patched_at` INTEGER, PRIMARY KEY(`current_package_name`))",
+        "fields": [
+          {
+            "fieldPath": "currentPackageName",
+            "columnName": "current_package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalPackageName",
+            "columnName": "original_package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installType",
+            "columnName": "install_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectionPayload",
+            "columnName": "selection_payload",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "patchedAt",
+            "columnName": "patched_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "current_package_name"
+          ]
+        }
+      },
+      {
+        "tableName": "applied_patch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`package_name` TEXT NOT NULL, `bundle` INTEGER NOT NULL, `patch_name` TEXT NOT NULL, `bundle_version` TEXT, PRIMARY KEY(`package_name`, `bundle`, `patch_name`), FOREIGN KEY(`package_name`) REFERENCES `installed_app`(`current_package_name`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`bundle`) REFERENCES `patch_bundles`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundle",
+            "columnName": "bundle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchName",
+            "columnName": "patch_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleVersion",
+            "columnName": "bundle_version",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "package_name",
+            "bundle",
+            "patch_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_applied_patch_bundle",
+            "unique": false,
+            "columnNames": [
+              "bundle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_applied_patch_bundle` ON `${TABLE_NAME}` (`bundle`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "installed_app",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "package_name"
+            ],
+            "referencedColumns": [
+              "current_package_name"
+            ]
+          },
+          {
+            "table": "patch_bundles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bundle"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "option_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER NOT NULL, `patch_bundle` INTEGER NOT NULL, `package_name` TEXT NOT NULL, PRIMARY KEY(`uid`), FOREIGN KEY(`patch_bundle`) REFERENCES `patch_bundles`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchBundle",
+            "columnName": "patch_bundle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_option_groups_patch_bundle_package_name",
+            "unique": true,
+            "columnNames": [
+              "patch_bundle",
+              "package_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_option_groups_patch_bundle_package_name` ON `${TABLE_NAME}` (`patch_bundle`, `package_name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "patch_bundles",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "patch_bundle"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "options",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`group` INTEGER NOT NULL, `patch_name` TEXT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`group`, `patch_name`, `key`), FOREIGN KEY(`group`) REFERENCES `option_groups`(`uid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "group",
+            "columnName": "group",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patchName",
+            "columnName": "patch_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "group",
+            "patch_name",
+            "key"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "option_groups",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "group"
+            ],
+            "referencedColumns": [
+              "uid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "original_apks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`package_name` TEXT NOT NULL, `version` TEXT NOT NULL, `file_path` TEXT NOT NULL, `last_used` INTEGER NOT NULL, `file_size` INTEGER NOT NULL, PRIMARY KEY(`package_name`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsed",
+            "columnName": "last_used",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "package_name"
+          ]
+        }
+      },
+      {
+        "tableName": "apk_signatures",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `last_modified` INTEGER NOT NULL, `hashes` TEXT NOT NULL, PRIMARY KEY(`file_path`))",
+        "fields": [
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hashes",
+            "columnName": "hashes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "file_path"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd8524a5875f279ef0e9e1cd214583b55')"
+    ]
+  }
+}

--- a/app/src/main/java/app/morphe/manager/data/room/AppDatabase.kt
+++ b/app/src/main/java/app/morphe/manager/data/room/AppDatabase.kt
@@ -3,6 +3,8 @@ package app.morphe.manager.data.room
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import app.morphe.manager.data.room.apk.ApkSignature
+import app.morphe.manager.data.room.apk.ApkSignatureDao
 import app.morphe.manager.data.room.apps.installed.AppliedPatch
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.data.room.apps.installed.InstalledAppDao
@@ -29,9 +31,10 @@ import kotlin.random.Random
         AppliedPatch::class,
         OptionGroup::class,
         Option::class,
-        OriginalApk::class
+        OriginalApk::class,
+        ApkSignature::class
     ],
-    version = 12
+    version = 13
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
@@ -40,6 +43,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun installedAppDao(): InstalledAppDao
     abstract fun optionDao(): OptionDao
     abstract fun originalApkDao(): OriginalApkDao
+    abstract fun apkSignatureDao(): ApkSignatureDao
 
     companion object {
         fun generateUid() = Random.nextInt()

--- a/app/src/main/java/app/morphe/manager/data/room/Migrations.kt
+++ b/app/src/main/java/app/morphe/manager/data/room/Migrations.kt
@@ -81,3 +81,19 @@ val MIGRATION_11_12 = object : Migration(11, 12) {
         )
     }
 }
+
+val MIGRATION_12_13 = object : Migration(12, 13) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS apk_signatures (
+                file_path TEXT NOT NULL,
+                file_size INTEGER NOT NULL,
+                last_modified INTEGER NOT NULL,
+                hashes TEXT NOT NULL,
+                PRIMARY KEY(file_path)
+            )
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignature.kt
+++ b/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignature.kt
@@ -1,0 +1,25 @@
+package app.morphe.manager.data.room.apk
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Certificate fingerprints extracted from an APK on disk.
+ *
+ * [fileSize] and [lastModified] identify the archive they were taken from, so a file rewritten
+ * at the same path no longer matches.
+ */
+@Entity(tableName = "apk_signatures")
+data class ApkSignature(
+    @PrimaryKey
+    @ColumnInfo(name = "file_path") val filePath: String,
+    @ColumnInfo(name = "file_size") val fileSize: Long,
+    @ColumnInfo(name = "last_modified") val lastModified: Long,
+    /** SHA-256 fingerprints joined by [SEPARATOR]. Empty when the archive carries no signature. */
+    @ColumnInfo(name = "hashes") val hashes: String
+) {
+    companion object {
+        const val SEPARATOR = ","
+    }
+}

--- a/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignatureDao.kt
+++ b/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignatureDao.kt
@@ -1,0 +1,19 @@
+package app.morphe.manager.data.room.apk
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ApkSignatureDao {
+    /** Blocking on purpose: the callers are archive reads, which never run on the main thread. */
+    @Query("SELECT * FROM apk_signatures")
+    fun getAllBlocking(): List<ApkSignature>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(signature: ApkSignature)
+
+    @Query("DELETE FROM apk_signatures WHERE file_path IN (:filePaths)")
+    suspend fun deleteByPaths(filePaths: Collection<String>)
+}

--- a/app/src/main/java/app/morphe/manager/di/DatabaseModule.kt
+++ b/app/src/main/java/app/morphe/manager/di/DatabaseModule.kt
@@ -15,7 +15,8 @@ val databaseModule = module {
                 MIGRATION_8_9,
                 MIGRATION_9_10,
                 MIGRATION_10_11,
-                MIGRATION_11_12
+                MIGRATION_11_12,
+                MIGRATION_12_13
             )
             .build()
 

--- a/app/src/main/java/app/morphe/manager/di/ManagerModule.kt
+++ b/app/src/main/java/app/morphe/manager/di/ManagerModule.kt
@@ -1,5 +1,6 @@
 package app.morphe.manager.di
 
+import app.morphe.manager.domain.apk.ApkSignatureCache
 import app.morphe.manager.domain.apk.LocalApkSources
 import app.morphe.manager.domain.batch.BatchPatchCoordinator
 import app.morphe.manager.domain.batch.BatchPlanResolver
@@ -16,6 +17,7 @@ import org.koin.dsl.module
 
 val managerModule = module {
     singleOf(::KeystoreManager)
+    singleOf(::ApkSignatureCache)
     singleOf(::PM)
     singleOf(::RootInstaller)
     singleOf(::SessionInstaller)

--- a/app/src/main/java/app/morphe/manager/domain/apk/ApkSignatureCache.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/ApkSignatureCache.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.apk
+
+import android.os.Looper
+import android.util.Log
+import app.morphe.manager.data.room.AppDatabase
+import app.morphe.manager.data.room.apk.ApkSignature
+import app.morphe.manager.util.AppCoroutineScope
+import app.morphe.manager.util.tag
+import kotlinx.coroutines.launch
+import java.io.File
+
+// Enough for every saved, original and installed archive a tracked app can point at
+private const val MEMORY_ENTRIES = 256
+
+/**
+ * Certificate fingerprints of APKs on disk, remembered across process restarts.
+ *
+ * Extracting them verifies the whole archive, so a cold start must not repeat the work. An entry
+ * describes one exact archive: a file rewritten at the same path is keyed apart and read again.
+ */
+class ApkSignatureCache(
+    db: AppDatabase,
+    private val scope: AppCoroutineScope
+) {
+    private val dao = db.apkSignatureDao()
+
+    private val entries = object : LinkedHashMap<String, Set<String>>(0, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Set<String>>) =
+            size > MEMORY_ENTRIES
+    }
+    private var restored = false
+
+    /** Fingerprints previously taken from [file], or null when it has to be read. */
+    fun get(file: File): Set<String>? {
+        val key = key(file) ?: return null
+        return synchronized(entries) {
+            restoreOnce()
+            entries[key]
+        }
+    }
+
+    fun put(file: File, hashes: Set<String>) {
+        val key = key(file) ?: return
+        synchronized(entries) { entries[key] = hashes }
+
+        val record = ApkSignature(
+            filePath = file.absolutePath,
+            fileSize = file.length(),
+            lastModified = file.lastModified(),
+            hashes = hashes.joinToString(ApkSignature.SEPARATOR)
+        )
+        scope.launch {
+            runCatching { dao.upsert(record) }
+                .onFailure { Log.e(tag, "Failed to persist signatures for ${file.absolutePath}", it) }
+        }
+    }
+
+    /**
+     * Loads the persisted entries on first use.
+     *
+     * A single query on the caller's thread, because a suspending hand-off would race with the
+     * very archive read this exists to spare. A main-thread caller keeps the memory layer only.
+     */
+    private fun restoreOnce() {
+        if (restored) return
+        restored = true
+        if (Looper.myLooper() == Looper.getMainLooper()) return
+
+        val persisted = runCatching { dao.getAllBlocking() }
+            .onFailure { Log.e(tag, "Failed to read persisted APK signatures", it) }
+            .getOrNull()
+            ?: return
+
+        val stale = mutableListOf<String>()
+        persisted.forEach { record ->
+            val file = File(record.filePath)
+            if (file.length() != record.fileSize || file.lastModified() != record.lastModified) {
+                stale += record.filePath
+                return@forEach
+            }
+            entries[cacheKey(record.filePath, record.fileSize, record.lastModified)] =
+                record.hashes.split(ApkSignature.SEPARATOR).filterTo(mutableSetOf()) { it.isNotEmpty() }
+        }
+
+        if (stale.isEmpty()) return
+        scope.launch {
+            runCatching { dao.deleteByPaths(stale) }
+                .onFailure { Log.e(tag, "Failed to drop stale APK signatures", it) }
+        }
+    }
+
+    private fun key(file: File): String? {
+        if (!file.isFile) return null
+        return cacheKey(file.absolutePath, file.length(), file.lastModified())
+    }
+
+    private fun cacheKey(path: String, size: Long, lastModified: Long) = "$path:$size:$lastModified"
+}

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -130,6 +130,11 @@ class LocalApkSources(
     private val filesystem: Filesystem,
     private val pm: PM
 ) {
+    // Keyed by the tracked package, kept only while the evidence behind it is unchanged
+    private val snapshotCache = mutableMapOf<String, CachedSnapshot>()
+
+    private data class CachedSnapshot(val fingerprint: String, val snapshot: TrackedAppSnapshot)
+
     /** The original APK kept after a previous patch, or null when there is none on disk. */
     suspend fun saved(packageName: String): SavedApkInfo? = try {
         val originalApk = originalApkRepository.get(packageName)
@@ -210,44 +215,90 @@ class LocalApkSources(
     /**
      * Resolves the saved APK and installed identity together for UI action gating.
      *
-     * Certificate reads go through [PM]'s archive cache, so repeated calls for an unchanged app
-     * cost a package manager query rather than a full archive verification.
+     * Repeated calls for an unchanged app are answered from the previous result, so a refresh can
+     * ask about every tracked app without paying for the inspection again.
      */
     suspend fun trackedAppSnapshot(app: InstalledApp): TrackedAppSnapshot = withContext(Dispatchers.IO) {
+        val installedPackageInfo = pm.getPackageInfo(app.currentPackageName)
+        val fingerprint = trackedAppFingerprint(app, installedPackageInfo)
+        cachedSnapshot(app.currentPackageName, fingerprint)?.let { return@withContext it }
+
+        val snapshot = resolveTrackedAppSnapshot(app, installedPackageInfo)
+        cacheSnapshot(app.currentPackageName, fingerprint, snapshot)
+        snapshot
+    }
+
+    /** Drops the remembered snapshot of [packageName] so the next read inspects the disk again. */
+    fun invalidate(packageName: String) {
+        synchronized(snapshotCache) { snapshotCache.remove(packageName) }
+    }
+
+    private suspend fun resolveTrackedAppSnapshot(
+        app: InstalledApp,
+        installedPackageInfo: PackageInfo?
+    ): TrackedAppSnapshot {
         val savedPatched = validatedPatchedApk(app)
         val savedPatchedApk: File? = savedPatched?.first
         val savedPatchedInfo: PackageInfo? = savedPatched?.second
 
-        val installedPackageInfo = pm.getPackageInfo(app.currentPackageName)
-            ?: return@withContext TrackedAppSnapshot(null, savedPatchedApk, savedPatchedInfo, null)
-
-        // A mounted install keeps the stock certificate in PackageManager while sourceDir points
-        // at the patched APK, so this signal must win over all certificate comparisons below.
-        if (pm.hasSourceApkSignatureMismatch(app.currentPackageName)) {
-            return@withContext TrackedAppSnapshot(
-                installedPackageInfo,
-                savedPatchedApk,
-                savedPatchedInfo,
-                InstalledPatchState.Patched
-            )
+        if (installedPackageInfo == null) {
+            return TrackedAppSnapshot(null, savedPatchedApk, savedPatchedInfo, null)
         }
 
         val installer = pm.getInstallerPackageName(app.currentPackageName)
+        val patchState = resolveTrackedPatchState(
+            installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName),
+            savedPatchedHashes = savedPatchedApk?.let(pm::getApkFileSignatureHashes).orEmpty(),
+            originalHashes = referenceSignatureHashes(app.originalPackageName),
+            installedByPatchManager = pm.isPatchManagerInstaller(installer),
+            installerAttributionMatches = installerMatchesRecord(app.installType, installer),
+            installedAfterPatching = installedAfterPatching(app, installedPackageInfo)
+        )
 
-        TrackedAppSnapshot(
+        // A mounted install reports the stock certificate while sourceDir points at the patched
+        // APK, so it overrides the verdict, and is only read while that verdict is still open
+        val mounted = patchState != InstalledPatchState.Patched &&
+                pm.hasSourceApkSignatureMismatch(app.currentPackageName)
+
+        return TrackedAppSnapshot(
             installedPackageInfo = installedPackageInfo,
             savedPatchedApk = savedPatchedApk,
             savedPatchedApkInfo = savedPatchedInfo,
-            patchState = resolveTrackedPatchState(
-                installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName),
-                savedPatchedHashes = savedPatchedInfo?.let(pm::signatureHashes).orEmpty(),
-                originalHashes = referenceSignatureHashes(app.originalPackageName),
-                installedByPatchManager = pm.isPatchManagerInstaller(installer),
-                installerAttributionMatches = installerMatchesRecord(app.installType, installer),
-                installedAfterPatching = installedAfterPatching(app, installedPackageInfo)
-            )
+            patchState = if (mounted) InstalledPatchState.Patched else patchState
         )
     }
+
+    private fun cachedSnapshot(packageName: String, fingerprint: String): TrackedAppSnapshot? =
+        synchronized(snapshotCache) {
+            snapshotCache[packageName]?.takeIf { it.fingerprint == fingerprint }?.snapshot
+        }
+
+    private fun cacheSnapshot(packageName: String, fingerprint: String, snapshot: TrackedAppSnapshot) {
+        synchronized(snapshotCache) {
+            snapshotCache[packageName] = CachedSnapshot(fingerprint, snapshot)
+        }
+    }
+
+    /**
+     * Everything that can change what the snapshot resolves to, read with stat calls alone.
+     *
+     * A mount swaps the file behind `sourceDir` and a repatch rewrites the saved APK in place.
+     * Both archives are therefore described by their own size and timestamp, not by the record.
+     */
+    private fun trackedAppFingerprint(app: InstalledApp, installedPackageInfo: PackageInfo?): String {
+        val installedApk = installedPackageInfo?.applicationInfo?.sourceDir?.let(::File)
+        return buildString {
+            append(app.version).append('|')
+            append(app.installType).append('|')
+            append(app.patchedAt).append('|')
+            append(installedPackageInfo?.lastUpdateTime).append('|')
+            append(fileStamp(installedApk)).append('|')
+            savedPatchedApkCandidates(app).joinTo(this, ";") { fileStamp(it) }
+        }
+    }
+
+    private fun fileStamp(file: File?): String =
+        if (file == null) "-" else "${file.length()}:${file.lastModified()}"
 
     /**
      * Whether the current installer is the one Morphe itself would have set for this record.
@@ -284,16 +335,20 @@ class LocalApkSources(
         return installedPackageInfo.firstInstallTime > patchedAt + INSTALL_TIME_TOLERANCE_MS
     }
 
-    /**
-     * Searches both current and legacy storage paths, but only accepts the artifact the record
-     * describes. A renamed app must never fall back to an APK whose embedded id is the original
-     * package, and the expected file name is not on its own proof of what the file contains.
-     */
-    private fun validatedPatchedApk(app: InstalledApp): Pair<File, PackageInfo>? =
+    /** Current and legacy storage paths a patched build could have been retained at. */
+    private fun savedPatchedApkCandidates(app: InstalledApp): List<File> =
         listOf(
             filesystem.getPatchedAppFile(app.currentPackageName, app.version),
             filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-        ).distinctBy { it.absolutePath }.firstNotNullOfOrNull { file ->
+        ).distinctBy { it.absolutePath }
+
+    /**
+     * Searches both storage paths, but only accepts the artifact the record describes. A renamed
+     * app must never fall back to an APK whose embedded id is the original package. The expected
+     * file name is not on its own proof of what the file contains.
+     */
+    private fun validatedPatchedApk(app: InstalledApp): Pair<File, PackageInfo>? =
+        savedPatchedApkCandidates(app).firstNotNullOfOrNull { file ->
             pm.readSavedApkInfo(file, app.version, app.currentPackageName)?.let { file to it }
         }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -30,6 +30,7 @@ import app.morphe.manager.domain.apk.InstalledApkInfo
 import app.morphe.manager.domain.apk.InstalledPatchState
 import app.morphe.manager.domain.apk.LocalApkSources
 import app.morphe.manager.domain.apk.SavedApkInfo
+import app.morphe.manager.domain.apk.TrackedAppSnapshot
 import app.morphe.manager.domain.batch.BatchPatchCoordinator
 import app.morphe.manager.domain.bundles.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.asRemoteOrNull
@@ -441,6 +442,15 @@ class HomeViewModel(
     private val _appStateTicker = MutableStateFlow(0L)
     private val trackedAppInspectionSemaphore = Semaphore(4)
 
+    // Verified tracked installs, keyed by the package the record currently occupies.
+    // Resolved away from the home state so inspecting archives never holds the cards back.
+    private val _trackedSnapshots = MutableStateFlow<Map<String, TrackedAppSnapshot>>(emptyMap())
+
+    // Both signals rebuild the same cards, so they reach the home state as one source
+    private val appStateSignal = combine(_appStateTicker, _trackedSnapshots) { ticker, snapshots ->
+        ticker to snapshots
+    }
+
     // Package names worth reacting to, refreshed from the same flow that feeds the home cards
     @Volatile
     private var trackedPackageNames: Set<String> = emptySet()
@@ -464,9 +474,36 @@ class HomeViewModel(
             .filter { it.isNotEmpty() }
             .collectLatest { pending ->
                 delay(PACKAGE_CHANGE_DEBOUNCE_MS.milliseconds)
-                pending.forEach { appDataResolver.invalidate(it) }
+                pending.forEach {
+                    appDataResolver.invalidate(it)
+                    localApkSources.invalidate(it)
+                }
                 _appStateTicker.value = System.currentTimeMillis()
                 pendingPackageChanges.value = emptySet()
+            }
+    }
+
+    /**
+     * Keeps [_trackedSnapshots] in step with the records and with anything that changed a package.
+     *
+     * Inspecting a record reads its archives, so it happens here rather than inside the home
+     * state. Cards appear as soon as the bundles are known and adopt the verdict as it lands.
+     */
+    private fun observeTrackedApps() = viewModelScope.launch {
+        combine(installedAppRepository.getAll(), _appStateTicker) { apps, _ -> apps }
+            .collectLatest { apps ->
+                val snapshots = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        apps.map { installed ->
+                            async {
+                                installed.currentPackageName to trackedAppInspectionSemaphore.withPermit {
+                                    localApkSources.trackedAppSnapshot(installed)
+                                }
+                            }
+                        }.awaitAll().toMap()
+                    }
+                }
+                _trackedSnapshots.value = snapshots
             }
     }
 
@@ -658,6 +695,7 @@ class HomeViewModel(
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         observePackageChanges()
+        observeTrackedApps()
         observeManagerUpdate()
         triggerUpdateCheck()
         observeLoadingState()
@@ -1208,8 +1246,8 @@ class HomeViewModel(
             }
         },
         _appUpdatesAvailable,
-        _appStateTicker,
-    ) { bundleState, homePrefs, installedApps, updatesMap, _ ->
+        appStateSignal,
+    ) { bundleState, homePrefs, installedApps, updatesMap, (_, trackedSnapshots) ->
         val ready = bundleState as? PatchBundleRepository.BundleState.Ready
             ?: return@combine null
 
@@ -1238,17 +1276,20 @@ class HomeViewModel(
             val displayName = resolvedData.displayName.takeIf {
                 resolvedData.source == AppDataSource.INSTALLED || resolvedData.source == AppDataSource.PATCHED_APK
             } ?: bundleMeta?.displayName ?: KnownApps.getAppName(packageName)
-            val trackedSnapshot = installedApp?.let {
-                trackedAppInspectionSemaphore.withPermit {
-                    localApkSources.trackedAppSnapshot(it)
-                }
-            }
+            val trackedSnapshot = installedApp?.let { trackedSnapshots[it.currentPackageName] }
             val savedPatchedApk = trackedSnapshot?.savedPatchedApk
             val savedPackageInfo = trackedSnapshot?.savedPatchedApkInfo
-            val trackedPatchState = trackedSnapshot?.patchState
-            val trackedPresentation = installedApp?.let {
-                trackedInstallPresentation(it.installType, trackedPatchState)
+            // Inspection resolves on its own, so a record without a snapshot has not been judged
+            // yet and must not be presented as any of the resolved states
+            val trackedPresentation = if (installedApp != null && trackedSnapshot != null) {
+                trackedInstallPresentation(installedApp.installType, trackedSnapshot.patchState)
+            } else {
+                null
             }
+            // An unjudged record is described the way the package manager sees it
+            val isUninspectedInstall = installedApp != null &&
+                    trackedSnapshot == null &&
+                    pm.getPackageInfo(installedApp.currentPackageName) != null
             val isInstalledOnDevice = trackedPresentation?.isPatched == true
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
@@ -1274,6 +1315,7 @@ class HomeViewModel(
                 ),
                 isPinnedByDefault = knownApp?.isPinnedByDefault == true,
                 isInstalledOnDevice = (trackedPresentation?.showsInstalledPackage == true) ||
+                        isUninspectedInstall ||
                         (installedApp == null && resolvedData.source == AppDataSource.INSTALLED),
                 isDeleted = trackedPresentation?.isDeleted == true,
                 isInstallStateNotPatched = trackedPresentation?.isNotPatched == true,
@@ -1458,6 +1500,7 @@ class HomeViewModel(
      */
     fun notifyAppStateChanged(packageName: String) {
         appDataResolver.invalidate(packageName)
+        localApkSources.invalidate(packageName)
         _appStateTicker.value = System.currentTimeMillis()
     }
 

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -19,6 +19,7 @@ import android.util.Log
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.compose.runtime.Immutable
 import androidx.core.content.pm.PackageInfoCompat
+import app.morphe.manager.domain.apk.ApkSignatureCache
 import kotlinx.parcelize.Parcelize
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -35,14 +36,13 @@ data class AppInfo(
 
 @SuppressLint("QueryPermissionsNeeded")
 class PM(
-    private val app: Application
+    private val app: Application,
+    // Certificate extraction verifies the whole archive, so repeating it for every home refresh
+    // is the single most expensive thing this class can do
+    private val signatureCache: ApkSignatureCache
 ) {
     private companion object {
         const val TAG = "Morphe PM"
-
-        // Certificate extraction verifies the whole archive, so repeating it for every home
-        // refresh is the single most expensive thing this class can do.
-        const val SIGNATURE_CACHE_ENTRIES = 64
 
         // Other managers whose installs are always patched.
         // Morphe's own id comes from the application at runtime so debug builds are covered too.
@@ -54,13 +54,6 @@ class PM(
             "app.universal.revanced.manager"
         )
     }
-
-    // Keyed by size and timestamp as well as path, so a rewritten APK never returns a stale answer
-    private val archiveSignatureCache =
-        object : LinkedHashMap<String, Set<String>>(0, 0.75f, true) {
-            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Set<String>>) =
-                size > SIGNATURE_CACHE_ENTRIES
-        }
 
     val application: Application get() = app
 
@@ -246,8 +239,7 @@ class PM(
      * Uses full signing history to handle apps with certificate rotation.
      */
     fun getApkFileSignatureHashes(file: File): Set<String> {
-        val key = signatureCacheKey(file) ?: return emptySet()
-        cachedSignatureHashes(key)?.let { return it }
+        signatureCache.get(file)?.let { return it }
 
         return try {
             val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
@@ -256,7 +248,7 @@ class PM(
                 sourceDir = file.absolutePath
                 publicSourceDir = file.absolutePath
             }
-            signatureHashes(info).also { cacheSignatureHashes(key, it) }
+            signatureHashes(info).also { signatureCache.put(file, it) }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read APK file signatures", e)
             emptySet()
@@ -270,26 +262,23 @@ class PM(
      * left behind by another package or version must not enable install, export or mount actions,
      * and must never stand in as the certificate that proves an install is the patched build.
      *
-     * The parse is shared with [getApkFileSignatureHashes] so callers that need both the identity
-     * and the certificates pay for the archive only once.
+     * The identity is read from the manifest alone, so an archive that is not the recorded
+     * artifact is rejected before its certificate is ever extracted.
      */
     fun readSavedApkInfo(file: File, version: String, vararg packageNames: String): PackageInfo? {
         if (!file.isFile) return null
         return try {
-            val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
-                ?: return null
+            val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, 0) ?: return null
 
-            val hashes = signatureHashes(info)
             val matches = matchesSavedApkRecord(
                 archivePackageName = info.packageName,
                 archiveVersionName = info.versionName,
-                isSigned = hashes.isNotEmpty(),
                 trackedPackageNames = packageNames.asList(),
-                trackedVersion = version
+                trackedVersion = version,
+                isSigned = { getApkFileSignatureHashes(file).isNotEmpty() }
             )
             if (!matches) return null
 
-            signatureCacheKey(file)?.let { cacheSignatureHashes(it, hashes) }
             // Needed by callers that read the label or icon straight off the archive
             info.applicationInfo?.apply {
                 sourceDir = file.absolutePath
@@ -303,20 +292,8 @@ class PM(
     }
 
     /** SHA-256 certificate fingerprints of an already parsed [packageInfo]. */
-    fun signatureHashes(packageInfo: PackageInfo): Set<String> =
+    private fun signatureHashes(packageInfo: PackageInfo): Set<String> =
         packageInfo.extractSignatures()?.toSha256Hashes().orEmpty()
-
-    private fun signatureCacheKey(file: File): String? {
-        if (!file.isFile) return null
-        return "${file.absolutePath}:${file.length()}:${file.lastModified()}"
-    }
-
-    private fun cachedSignatureHashes(key: String): Set<String>? =
-        synchronized(archiveSignatureCache) { archiveSignatureCache[key] }
-
-    private fun cacheSignatureHashes(key: String, hashes: Set<String>) {
-        synchronized(archiveSignatureCache) { archiveSignatureCache[key] = hashes }
-    }
 
     @Suppress("DEPRECATION")
     private fun signingFlags() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
@@ -363,17 +340,20 @@ class PM(
  * version it produced both as the record's version and in the retained file name, so an archive
  * that reports a different one is not the build the record was written for. Accepting it would
  * hand its certificate to the tracked-install check as proof that an install is patched.
+ *
+ * [isSigned] is evaluated last and only when the identity already matches, because reading a
+ * certificate means verifying the entire archive.
  */
 internal fun matchesSavedApkRecord(
     archivePackageName: String?,
     archiveVersionName: String?,
-    isSigned: Boolean,
     trackedPackageNames: Collection<String>,
-    trackedVersion: String
+    trackedVersion: String,
+    isSigned: () -> Boolean
 ): Boolean =
-    isSigned &&
-            archivePackageName in trackedPackageNames &&
-            archiveVersionName == trackedVersion
+    archivePackageName in trackedPackageNames &&
+            archiveVersionName == trackedVersion &&
+            isSigned()
 
 fun File.sha256OrNull(): String? = runCatching {
     if (!isFile) return@runCatching null

--- a/app/src/test/java/app/morphe/manager/util/SavedApkRecordTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/SavedApkRecordTest.kt
@@ -11,8 +11,8 @@ import kotlin.test.assertTrue
 
 /**
  * The accepted archive becomes the certificate that decides whether an installed package is the
- * tracked patched build, so anything reaching this predicate has to be the artifact the record
- * was written for and not merely a file sitting at the expected path.
+ * tracked patched build. Anything reaching this predicate has to be the artifact the record was
+ * written for, not merely a file sitting at the expected path.
  */
 class SavedApkRecordTest {
     private fun matches(
@@ -24,9 +24,9 @@ class SavedApkRecordTest {
     ) = matchesSavedApkRecord(
         archivePackageName = archivePackageName,
         archiveVersionName = archiveVersionName,
-        isSigned = isSigned,
         trackedPackageNames = trackedPackageNames,
-        trackedVersion = trackedVersion
+        trackedVersion = trackedVersion,
+        isSigned = { isSigned }
     )
 
     @Test
@@ -67,5 +67,23 @@ class SavedApkRecordTest {
         assertFalse(matches(isSigned = false))
         assertFalse(matches(archivePackageName = null))
         assertFalse(matches(archiveVersionName = null))
+    }
+
+    @Test
+    fun `an archive that is not the recorded artifact is rejected without reading its certificate`() {
+        var certificateRead = false
+        val matched = matchesSavedApkRecord(
+            archivePackageName = "app.morphe.other",
+            archiveVersionName = "1.2.3",
+            trackedPackageNames = listOf("app.morphe.target"),
+            trackedVersion = "1.2.3",
+            isSigned = {
+                certificateRead = true
+                true
+            }
+        )
+
+        assertFalse(matched)
+        assertFalse(certificateRead)
     }
 }


### PR DESCRIPTION
### Description

Since #831 the home screen resolved a `TrackedAppSnapshot` for every tracked app on each refresh, and each snapshot ran up to three full archive verifications: the saved patched APK, the installed `base.apk`, and the saved original APK. `getPackageArchiveInfo` with `GET_SIGNING_CERTIFICATES` hashes the entire file, so a library of large apps meant hashing around a gigabyte on every cold start, with the home state blocked until it finished. Users with many tracked apps reported 40+ seconds before any card appeared.

A simpleperf trace of the first 30 seconds after a cold start put `sha512_block_data_order` at 7.7% of all cycles, 155.9 billion cycles total.

### Changes

- Certificate fingerprints are persisted in a new `apk_signatures` table (schema 12 → 13), keyed by path, size and mtime, so a rewritten file is never answered from a stale entry.
- `readSavedApkInfo` decides identity from the manifest alone and asks for certificates only once it matches, so an archive that is not the recorded artifact is rejected without hashing.
- The mount check (`hasSourceApkSignatureMismatch`) is read only when it could still change the verdict, rather than ahead of every other signal. The resulting state table is unchanged.
- `TrackedAppSnapshot` is cached per package behind a fingerprint built from stat calls, and invalidated by the package-change receiver and by `notifyAppStateChanged`.
- Snapshots resolve in their own flow instead of inside the home state. Cards render from PackageManager and adopt the verified state as it lands, so verification never holds them back.