### PR TITLE
fix: Keep tracked install verification state fresh

### DIFF
--- a/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignatureDao.kt
+++ b/app/src/main/java/app/morphe/manager/data/room/apk/ApkSignatureDao.kt
@@ -14,6 +14,13 @@ interface ApkSignatureDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(signature: ApkSignature)
 
-    @Query("DELETE FROM apk_signatures WHERE file_path IN (:filePaths)")
-    suspend fun deleteByPaths(filePaths: Collection<String>)
+    @Query(
+        """
+        DELETE FROM apk_signatures
+        WHERE file_path = :filePath
+          AND file_size = :fileSize
+          AND last_modified = :lastModified
+        """
+    )
+    suspend fun deleteRevision(filePath: String, fileSize: Long, lastModified: Long)
 }

--- a/app/src/main/java/app/morphe/manager/domain/apk/ApkFileStamp.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/ApkFileStamp.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.apk
+
+import java.io.File
+
+/** The inexpensive disk identity used to bind cached APK metadata to one file revision. */
+internal data class ApkFileStamp(
+    val path: String,
+    val size: Long,
+    val lastModified: Long
+) {
+    val cacheKey: String get() = "$path:$size:$lastModified"
+}
+
+internal fun File.apkFileStampOrNull(): ApkFileStamp? {
+    if (!isFile) return null
+    return ApkFileStamp(
+        path = absolutePath,
+        size = length(),
+        lastModified = lastModified()
+    )
+}

--- a/app/src/main/java/app/morphe/manager/domain/apk/ApkSignatureCache.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/ApkSignatureCache.kt
@@ -12,6 +12,8 @@ import app.morphe.manager.data.room.apk.ApkSignature
 import app.morphe.manager.util.AppCoroutineScope
 import app.morphe.manager.util.tag
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 
 // Enough for every saved, original and installed archive a tracked app can point at
@@ -34,29 +36,42 @@ class ApkSignatureCache(
             size > MEMORY_ENTRIES
     }
     private var restored = false
+    private val persistenceMutex = Mutex()
 
-    /** Fingerprints previously taken from [file], or null when it has to be read. */
-    fun get(file: File): Set<String>? {
-        val key = key(file) ?: return null
+    /** Captures the exact file revision that an archive read is about to inspect. */
+    internal fun stamp(file: File): ApkFileStamp? = file.apkFileStampOrNull()
+
+    /** Fingerprints previously taken from [stamp], or null when it has to be read. */
+    internal fun get(stamp: ApkFileStamp): Set<String>? {
         return synchronized(entries) {
             restoreOnce()
-            entries[key]
+            entries[stamp.cacheKey]
         }
     }
 
-    fun put(file: File, hashes: Set<String>) {
-        val key = key(file) ?: return
-        synchronized(entries) { entries[key] = hashes }
+    /**
+     * Stores [hashes] only if [file] is still the revision that was inspected.
+     *
+     * Retained APKs are overwritten in place. Rechecking the stamp prevents hashes read from the
+     * old archive from being assigned to the new revision, while the mutex prevents an older
+     * asynchronous database write from winning after a newer one.
+     */
+    internal fun putIfUnchanged(file: File, stamp: ApkFileStamp, hashes: Set<String>) {
+        if (file.apkFileStampOrNull() != stamp) return
+        synchronized(entries) { entries[stamp.cacheKey] = hashes }
 
         val record = ApkSignature(
-            filePath = file.absolutePath,
-            fileSize = file.length(),
-            lastModified = file.lastModified(),
+            filePath = stamp.path,
+            fileSize = stamp.size,
+            lastModified = stamp.lastModified,
             hashes = hashes.joinToString(ApkSignature.SEPARATOR)
         )
         scope.launch {
-            runCatching { dao.upsert(record) }
-                .onFailure { Log.e(tag, "Failed to persist signatures for ${file.absolutePath}", it) }
+            persistenceMutex.withLock {
+                if (file.apkFileStampOrNull() != stamp) return@withLock
+                runCatching { dao.upsert(record) }
+                    .onFailure { Log.e(tag, "Failed to persist signatures for ${file.absolutePath}", it) }
+            }
         }
     }
 
@@ -68,36 +83,34 @@ class ApkSignatureCache(
      */
     private fun restoreOnce() {
         if (restored) return
-        restored = true
         if (Looper.myLooper() == Looper.getMainLooper()) return
+        restored = true
 
         val persisted = runCatching { dao.getAllBlocking() }
             .onFailure { Log.e(tag, "Failed to read persisted APK signatures", it) }
             .getOrNull()
             ?: return
 
-        val stale = mutableListOf<String>()
+        val stale = mutableListOf<ApkSignature>()
         persisted.forEach { record ->
             val file = File(record.filePath)
             if (file.length() != record.fileSize || file.lastModified() != record.lastModified) {
-                stale += record.filePath
+                stale += record
                 return@forEach
             }
-            entries[cacheKey(record.filePath, record.fileSize, record.lastModified)] =
+            entries[ApkFileStamp(record.filePath, record.fileSize, record.lastModified).cacheKey] =
                 record.hashes.split(ApkSignature.SEPARATOR).filterTo(mutableSetOf()) { it.isNotEmpty() }
         }
 
         if (stale.isEmpty()) return
         scope.launch {
-            runCatching { dao.deleteByPaths(stale) }
-                .onFailure { Log.e(tag, "Failed to drop stale APK signatures", it) }
+            persistenceMutex.withLock {
+                runCatching {
+                    stale.forEach { record ->
+                        dao.deleteRevision(record.filePath, record.fileSize, record.lastModified)
+                    }
+                }.onFailure { Log.e(tag, "Failed to drop stale APK signatures", it) }
+            }
         }
     }
-
-    private fun key(file: File): String? {
-        if (!file.isFile) return null
-        return cacheKey(file.absolutePath, file.length(), file.lastModified())
-    }
-
-    private fun cacheKey(path: String, size: Long, lastModified: Long) = "$path:$size:$lastModified"
 }

--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -220,10 +220,13 @@ class LocalApkSources(
      */
     suspend fun trackedAppSnapshot(app: InstalledApp): TrackedAppSnapshot = withContext(Dispatchers.IO) {
         val installedPackageInfo = pm.getPackageInfo(app.currentPackageName)
-        val fingerprint = trackedAppFingerprint(app, installedPackageInfo)
+        val installer = installedPackageInfo?.let {
+            pm.getInstallerPackageName(app.currentPackageName)
+        }
+        val fingerprint = trackedAppFingerprint(app, installedPackageInfo, installer)
         cachedSnapshot(app.currentPackageName, fingerprint)?.let { return@withContext it }
 
-        val snapshot = resolveTrackedAppSnapshot(app, installedPackageInfo)
+        val snapshot = resolveTrackedAppSnapshot(app, installedPackageInfo, installer)
         cacheSnapshot(app.currentPackageName, fingerprint, snapshot)
         snapshot
     }
@@ -235,7 +238,8 @@ class LocalApkSources(
 
     private suspend fun resolveTrackedAppSnapshot(
         app: InstalledApp,
-        installedPackageInfo: PackageInfo?
+        installedPackageInfo: PackageInfo?,
+        installer: String?
     ): TrackedAppSnapshot {
         val savedPatched = validatedPatchedApk(app)
         val savedPatchedApk: File? = savedPatched?.first
@@ -245,7 +249,6 @@ class LocalApkSources(
             return TrackedAppSnapshot(null, savedPatchedApk, savedPatchedInfo, null)
         }
 
-        val installer = pm.getInstallerPackageName(app.currentPackageName)
         val patchState = resolveTrackedPatchState(
             installedHashes = pm.getInstalledSignatureHashes(app.currentPackageName),
             savedPatchedHashes = savedPatchedApk?.let(pm::getApkFileSignatureHashes).orEmpty(),
@@ -285,15 +288,32 @@ class LocalApkSources(
      * A mount swaps the file behind `sourceDir` and a repatch rewrites the saved APK in place.
      * Both archives are therefore described by their own size and timestamp, not by the record.
      */
-    private fun trackedAppFingerprint(app: InstalledApp, installedPackageInfo: PackageInfo?): String {
+    private suspend fun trackedAppFingerprint(
+        app: InstalledApp,
+        installedPackageInfo: PackageInfo?,
+        installer: String?
+    ): String {
         val installedApk = installedPackageInfo?.applicationInfo?.sourceDir?.let(::File)
+        val originalApk = originalApkRepository.get(app.originalPackageName)
+        val originalFile = originalApk?.let { File(it.filePath) }
+        val bundleSignatures = patchBundleRepository.appMetadata.value[app.originalPackageName]
+            ?.signatures
+            .orEmpty()
         return buildString {
+            append(app.currentPackageName).append('|')
+            append(app.originalPackageName).append('|')
             append(app.version).append('|')
             append(app.installType).append('|')
             append(app.patchedAt).append('|')
+            append(installedPackageInfo?.versionName).append('|')
+            append(installedPackageInfo?.firstInstallTime).append('|')
             append(installedPackageInfo?.lastUpdateTime).append('|')
+            append(installer).append('|')
             append(fileStamp(installedApk)).append('|')
             savedPatchedApkCandidates(app).joinTo(this, ";") { fileStamp(it) }
+            append('|').append(originalApk?.version).append('|')
+            append(originalFile?.absolutePath).append(':').append(fileStamp(originalFile)).append('|')
+            bundleSignatures.sorted().joinTo(this, ",")
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/HomeAppItem.kt
@@ -22,6 +22,7 @@ data class HomeAppItem(
     val isDeleted: Boolean,
     val isInstallStateNotPatched: Boolean,
     val isInstallStateUnknown: Boolean,
+    val isInstallStatePending: Boolean,
     val savedApkFile: File?,
     val hasUpdate: Boolean,
     val patchCount: Int
@@ -35,5 +36,6 @@ data class HomeAppItem(
     val showsUpdateBadge: Boolean get() = hasUpdate &&
             !isDeleted &&
             !isInstallStateNotPatched &&
-            !isInstallStateUnknown
+            !isInstallStateUnknown &&
+            !isInstallStatePending
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
@@ -24,7 +24,9 @@ import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +59,10 @@ import app.morphe.manager.ui.theme.MonochromeThemeDefaults
 import app.morphe.manager.util.AppCardColorResolver
 import app.morphe.manager.util.AppDataSource
 import app.morphe.manager.util.withVersionPrefix
+import kotlinx.coroutines.delay
+
+// A verdict answered from cache lands within a frame, so the badge waits rather than flashing
+private const val INSTALL_VERIFICATION_BADGE_DELAY_MS = 400L
 
 private data class HomeAppCardStyle(
     val monochrome: Boolean,
@@ -216,6 +222,16 @@ fun InstalledAppCard(
     val unverifiedLabel = stringResource(R.string.home_unverified)
     val pendingLabel = stringResource(R.string.home_install_verification_pending)
 
+    val showsPendingBadge = remember { mutableStateOf(false) }
+    LaunchedEffect(isInstallStatePending) {
+        if (!isInstallStatePending) {
+            showsPendingBadge.value = false
+            return@LaunchedEffect
+        }
+        delay(INSTALL_VERIFICATION_BADGE_DELAY_MS)
+        showsPendingBadge.value = true
+    }
+
     val version = remember(packageInfo, installedApp, isAppDeleted) {
         val raw = packageInfo?.versionName ?: installedApp.version
         raw.withVersionPrefix()
@@ -234,7 +250,7 @@ fun InstalledAppCard(
         replacementLabel,
         isInstallStateUnknown,
         unverifiedLabel,
-        isInstallStatePending,
+        showsPendingBadge.value,
         pendingLabel
     ) {
         buildString {
@@ -245,7 +261,7 @@ fun InstalledAppCard(
             append(", ")
             append(
                 when {
-                    isInstallStatePending -> pendingLabel
+                    showsPendingBadge.value -> pendingLabel
                     isInstallStateNotPatched -> replacementLabel
                     isAppDeleted -> deletedLabel
                     isInstallStateUnknown -> unverifiedLabel
@@ -334,7 +350,7 @@ fun InstalledAppCard(
                     )
                 }
 
-                if (isInstallStatePending) {
+                if (showsPendingBadge.value) {
                     StatusBadge(
                         text = pendingLabel,
                         icon = Icons.Outlined.HourglassEmpty,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppCards.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.DeleteOutline
+import androidx.compose.material.icons.outlined.HourglassEmpty
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -197,13 +198,15 @@ fun InstalledAppCard(
     isAppDeleted: Boolean = false,
     isInstallStateNotPatched: Boolean = false,
     isInstallStateUnknown: Boolean = false,
+    isInstallStatePending: Boolean = false,
     onLongClick: (() -> Unit)? = null
 ) {
     val cardStyle = homeAppCardStyle(subtitleAlpha = 0.85f)
     val showsUpdateBadge = hasUpdate &&
             !isAppDeleted &&
             !isInstallStateNotPatched &&
-            !isInstallStateUnknown
+            !isInstallStateUnknown &&
+            !isInstallStatePending
 
     val versionLabel = stringResource(R.string.version)
     val installedLabel = stringResource(R.string.installed)
@@ -211,6 +214,7 @@ fun InstalledAppCard(
     val deletedLabel = stringResource(R.string.uninstalled)
     val replacementLabel = stringResource(R.string.home_unpatched_version_installed)
     val unverifiedLabel = stringResource(R.string.home_unverified)
+    val pendingLabel = stringResource(R.string.home_install_verification_pending)
 
     val version = remember(packageInfo, installedApp, isAppDeleted) {
         val raw = packageInfo?.versionName ?: installedApp.version
@@ -229,7 +233,9 @@ fun InstalledAppCard(
         isInstallStateNotPatched,
         replacementLabel,
         isInstallStateUnknown,
-        unverifiedLabel
+        unverifiedLabel,
+        isInstallStatePending,
+        pendingLabel
     ) {
         buildString {
             append(displayName)
@@ -239,6 +245,7 @@ fun InstalledAppCard(
             append(", ")
             append(
                 when {
+                    isInstallStatePending -> pendingLabel
                     isInstallStateNotPatched -> replacementLabel
                     isAppDeleted -> deletedLabel
                     isInstallStateUnknown -> unverifiedLabel
@@ -322,6 +329,15 @@ fun InstalledAppCard(
                     StatusBadge(
                         text = unverifiedLabel,
                         icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                        containerColor = cardStyle.chipContainerColor,
+                        contentColor = cardStyle.chipContentColor
+                    )
+                }
+
+                if (isInstallStatePending) {
+                    StatusBadge(
+                        text = pendingLabel,
+                        icon = Icons.Outlined.HourglassEmpty,
                         containerColor = cardStyle.chipContainerColor,
                         contentColor = cardStyle.chipContentColor
                     )

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppSwipe.kt
@@ -367,6 +367,7 @@ internal fun DynamicAppCard(
                                 isAppDeleted = item.isDeleted,
                                 isInstallStateNotPatched = item.isInstallStateNotPatched,
                                 isInstallStateUnknown = item.isInstallStateUnknown,
+                                isInstallStatePending = item.isInstallStatePending,
                                 onLongClick = {
                                     view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
                                     onLongPress()
@@ -497,7 +498,8 @@ internal fun HiddenSearchAppCard(
                     hasUpdate = item.hasUpdate,
                     isAppDeleted = item.isDeleted,
                     isInstallStateNotPatched = item.isInstallStateNotPatched,
-                    isInstallStateUnknown = item.isInstallStateUnknown
+                    isInstallStateUnknown = item.isInstallStateUnknown,
+                    isInstallStatePending = item.isInstallStatePending
                 )
             } else {
                 AppButton(

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -494,6 +494,7 @@ class HomeViewModel(
                         it.originalPackageName in observedPackages
             }
             .mapTo(mutableSetOf()) { it.currentPackageName }
+        // The records may not be loaded yet, so an unmatched package is treated as its own key
         if (matches.isEmpty()) matches += observedPackages
         return matches
     }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -73,7 +73,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -461,7 +461,10 @@ class HomeViewModel(
     // Verified tracked installs, keyed by the package the record currently occupies.
     // Resolved away from the home state so inspecting archives never holds the cards back.
     private val _trackedSnapshots = MutableStateFlow<Map<String, TrackedSnapshotEntry>>(emptyMap())
-    private val trackedInspectionGeneration = AtomicLong()
+
+    // Counted per package, so invalidating one app never discards results already produced for
+    // the others in the same pass
+    private val trackedInspectionGenerations = ConcurrentHashMap<String, Long>()
 
     @Volatile
     private var activeTrackedApps: Map<String, InstalledApp> = emptyMap()
@@ -505,10 +508,14 @@ class HomeViewModel(
     ) {
         if (observedPackages.isEmpty()) return
         val currentPackages = trackedCurrentPackages(observedPackages)
-        trackedInspectionGeneration.incrementAndGet()
+        currentPackages.forEach(::bumpTrackedInspection)
         if (invalidateCache) currentPackages.forEach(localApkSources::invalidate)
         _trackedSnapshots.update { snapshots -> snapshots - currentPackages }
     }
+
+    /** Claims the next inspection for [packageName], so any result in flight for it is dropped. */
+    private fun bumpTrackedInspection(packageName: String): Long =
+        trackedInspectionGenerations.merge(packageName, 1L, Long::plus)!!
 
     /**
      * Coalesces package broadcasts before rebuilding the home state.
@@ -591,15 +598,17 @@ class HomeViewModel(
                 }
             }
 
-            val generation = trackedInspectionGeneration.incrementAndGet()
+            trackedInspectionGenerations.keys.retainAll(appsByPackage.keys)
+
             withContext(Dispatchers.IO) {
                 coroutineScope {
                     inputs.apps.map { installed ->
+                        val generation = bumpTrackedInspection(installed.currentPackageName)
                         launch {
                             val snapshot = trackedAppInspectionSemaphore.withPermit {
                                 localApkSources.trackedAppSnapshot(installed)
                             }
-                            if (trackedInspectionGeneration.get() != generation ||
+                            if (trackedInspectionGenerations[installed.currentPackageName] != generation ||
                                 activeTrackedApps[installed.currentPackageName] != installed
                             ) return@launch
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -73,6 +73,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.InputStream
+import java.util.concurrent.atomic.AtomicLong
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -86,6 +87,10 @@ enum class BundleUpdateStatus {
     Warning,  // Patches may be outdated (on metered network, updates disabled)
     Error     // Error occurred (including no internet)
 }
+
+/** Keys whose evidence was added, removed, or replaced between two snapshots. */
+internal fun <K, V> changedMapKeys(previous: Map<K, V>, current: Map<K, V>): Set<K> =
+    (previous.keys + current.keys).filterTo(mutableSetOf()) { previous[it] != current[it] }
 
 /** * Dialog state for unsupported version warning. */
 data class UnsupportedVersionDialogState(
@@ -442,9 +447,24 @@ class HomeViewModel(
     private val _appStateTicker = MutableStateFlow(0L)
     private val trackedAppInspectionSemaphore = Semaphore(4)
 
+    private data class TrackedSnapshotEntry(
+        val app: InstalledApp,
+        val snapshot: TrackedAppSnapshot
+    )
+
+    private data class TrackedInspectionInputs(
+        val apps: List<InstalledApp>,
+        val originalEvidence: Map<String, String>,
+        val bundleSignatures: Map<String, Set<String>>
+    )
+
     // Verified tracked installs, keyed by the package the record currently occupies.
     // Resolved away from the home state so inspecting archives never holds the cards back.
-    private val _trackedSnapshots = MutableStateFlow<Map<String, TrackedAppSnapshot>>(emptyMap())
+    private val _trackedSnapshots = MutableStateFlow<Map<String, TrackedSnapshotEntry>>(emptyMap())
+    private val trackedInspectionGeneration = AtomicLong()
+
+    @Volatile
+    private var activeTrackedApps: Map<String, InstalledApp> = emptyMap()
 
     // Both signals rebuild the same cards, so they reach the home state as one source
     private val appStateSignal = combine(_appStateTicker, _trackedSnapshots) { ticker, snapshots ->
@@ -460,8 +480,33 @@ class HomeViewModel(
         override fun onReceive(context: Context?, intent: Intent?) {
             val packageName = intent?.data?.schemeSpecificPart ?: return
             if (packageName !in trackedPackageNames) return
+            // Stop presenting the previous verdict immediately, but keep the expensive refresh
+            // debounced until the package manager finishes its add/remove/replace broadcast burst.
+            markTrackedPackagesPending(setOf(packageName), invalidateCache = false)
             pendingPackageChanges.update { it + packageName }
         }
+    }
+
+    private fun trackedCurrentPackages(observedPackages: Set<String>): Set<String> {
+        val matches = activeTrackedApps.values.asSequence()
+            .filter {
+                it.currentPackageName in observedPackages ||
+                        it.originalPackageName in observedPackages
+            }
+            .mapTo(mutableSetOf()) { it.currentPackageName }
+        if (matches.isEmpty()) matches += observedPackages
+        return matches
+    }
+
+    private fun markTrackedPackagesPending(
+        observedPackages: Set<String>,
+        invalidateCache: Boolean
+    ) {
+        if (observedPackages.isEmpty()) return
+        val currentPackages = trackedCurrentPackages(observedPackages)
+        trackedInspectionGeneration.incrementAndGet()
+        if (invalidateCache) currentPackages.forEach(localApkSources::invalidate)
+        _trackedSnapshots.update { snapshots -> snapshots - currentPackages }
     }
 
     /**
@@ -476,8 +521,8 @@ class HomeViewModel(
                 delay(PACKAGE_CHANGE_DEBOUNCE_MS.milliseconds)
                 pending.forEach {
                     appDataResolver.invalidate(it)
-                    localApkSources.invalidate(it)
                 }
+                markTrackedPackagesPending(pending, invalidateCache = true)
                 _appStateTicker.value = System.currentTimeMillis()
                 pendingPackageChanges.value = emptySet()
             }
@@ -490,21 +535,84 @@ class HomeViewModel(
      * state. Cards appear as soon as the bundles are known and adopt the verdict as it lands.
      */
     private fun observeTrackedApps() = viewModelScope.launch {
-        combine(installedAppRepository.getAll(), _appStateTicker) { apps, _ -> apps }
-            .collectLatest { apps ->
-                val snapshots = withContext(Dispatchers.IO) {
-                    coroutineScope {
-                        apps.map { installed ->
-                            async {
-                                installed.currentPackageName to trackedAppInspectionSemaphore.withPermit {
-                                    localApkSources.trackedAppSnapshot(installed)
-                                }
-                            }
-                        }.awaitAll().toMap()
+        val originalEvidence = originalApkRepository.getAll()
+            .map { originals ->
+                originals.associate { original ->
+                    val file = File(original.filePath)
+                    original.packageName to buildString {
+                        append(original.version).append('|')
+                        append(original.filePath).append('|')
+                        append(file.length()).append(':').append(file.lastModified())
                     }
                 }
-                _trackedSnapshots.value = snapshots
             }
+            .distinctUntilChanged()
+        val bundleSignatures = patchBundleRepository.appMetadata
+            .map { metadata ->
+                metadata.mapValues { (_, appMetadata) -> appMetadata.signatures.orEmpty().toSet() }
+            }
+            .distinctUntilChanged()
+
+        var previousOriginalEvidence: Map<String, String>? = null
+        var previousBundleSignatures: Map<String, Set<String>>? = null
+
+        combine(
+            installedAppRepository.getAll(),
+            _appStateTicker,
+            originalEvidence,
+            bundleSignatures
+        ) { apps, _, originals, signatures ->
+            TrackedInspectionInputs(apps, originals, signatures)
+        }.collectLatest { inputs ->
+            val appsByPackage = inputs.apps.associateBy { it.currentPackageName }
+            activeTrackedApps = appsByPackage
+            trackedPackageNames = inputs.apps.flatMapTo(mutableSetOf()) {
+                listOf(it.currentPackageName, it.originalPackageName)
+            }
+
+            val changedEvidence = buildSet {
+                previousOriginalEvidence?.let {
+                    addAll(changedMapKeys(it, inputs.originalEvidence))
+                }
+                previousBundleSignatures?.let {
+                    addAll(changedMapKeys(it, inputs.bundleSignatures))
+                }
+            }
+            previousOriginalEvidence = inputs.originalEvidence
+            previousBundleSignatures = inputs.bundleSignatures
+            markTrackedPackagesPending(changedEvidence, invalidateCache = true)
+
+            // A changed or removed database record is pending until its matching result arrives;
+            // never keep presenting a snapshot produced for the previous record.
+            _trackedSnapshots.update { snapshots ->
+                snapshots.filter { (packageName, entry) ->
+                    appsByPackage[packageName] == entry.app
+                }
+            }
+
+            val generation = trackedInspectionGeneration.incrementAndGet()
+            withContext(Dispatchers.IO) {
+                coroutineScope {
+                    inputs.apps.map { installed ->
+                        launch {
+                            val snapshot = trackedAppInspectionSemaphore.withPermit {
+                                localApkSources.trackedAppSnapshot(installed)
+                            }
+                            if (trackedInspectionGeneration.get() != generation ||
+                                activeTrackedApps[installed.currentPackageName] != installed
+                            ) return@launch
+
+                            _trackedSnapshots.update { snapshots ->
+                                snapshots + (installed.currentPackageName to TrackedSnapshotEntry(
+                                    app = installed,
+                                    snapshot = snapshot
+                                ))
+                            }
+                        }
+                    }.joinAll()
+                }
+            }
+        }
     }
 
     // Track when at least one third-party source is enabled
@@ -1276,7 +1384,10 @@ class HomeViewModel(
             val displayName = resolvedData.displayName.takeIf {
                 resolvedData.source == AppDataSource.INSTALLED || resolvedData.source == AppDataSource.PATCHED_APK
             } ?: bundleMeta?.displayName ?: KnownApps.getAppName(packageName)
-            val trackedSnapshot = installedApp?.let { trackedSnapshots[it.currentPackageName] }
+            val trackedEntry = installedApp?.let { tracked ->
+                trackedSnapshots[tracked.currentPackageName]?.takeIf { it.app == tracked }
+            }
+            val trackedSnapshot = trackedEntry?.snapshot
             val savedPatchedApk = trackedSnapshot?.savedPatchedApk
             val savedPackageInfo = trackedSnapshot?.savedPatchedApkInfo
             // Inspection resolves on its own, so a record without a snapshot has not been judged
@@ -1290,6 +1401,7 @@ class HomeViewModel(
             val isUninspectedInstall = installedApp != null &&
                     trackedSnapshot == null &&
                     pm.getPackageInfo(installedApp.currentPackageName) != null
+            val isInstallStatePending = installedApp != null && trackedSnapshot == null
             val isInstalledOnDevice = trackedPresentation?.isPatched == true
             val hasUpdate = installedApp?.let {
                 updatesMap[it.currentPackageName] == true
@@ -1320,6 +1432,7 @@ class HomeViewModel(
                 isDeleted = trackedPresentation?.isDeleted == true,
                 isInstallStateNotPatched = trackedPresentation?.isNotPatched == true,
                 isInstallStateUnknown = trackedPresentation?.isUnknown == true,
+                isInstallStatePending = isInstallStatePending,
                 savedApkFile = savedPatchedApk,
                 hasUpdate = hasUpdate,
                 patchCount = 0
@@ -1500,7 +1613,7 @@ class HomeViewModel(
      */
     fun notifyAppStateChanged(packageName: String) {
         appDataResolver.invalidate(packageName)
-        localApkSources.invalidate(packageName)
+        markTrackedPackagesPending(setOf(packageName), invalidateCache = true)
         _appStateTicker.value = System.currentTimeMillis()
     }
 

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -239,7 +239,8 @@ class PM(
      * Uses full signing history to handle apps with certificate rotation.
      */
     fun getApkFileSignatureHashes(file: File): Set<String> {
-        signatureCache.get(file)?.let { return it }
+        val stamp = signatureCache.stamp(file) ?: return emptySet()
+        signatureCache.get(stamp)?.let { return it }
 
         return try {
             val info = app.packageManager.getPackageArchiveInfo(file.absolutePath, signingFlags())
@@ -248,7 +249,7 @@ class PM(
                 sourceDir = file.absolutePath
                 publicSourceDir = file.absolutePath
             }
-            signatureHashes(info).also { signatureCache.put(file, it) }
+            signatureHashes(info).also { signatureCache.putIfUnchanged(file, stamp, it) }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read APK file signatures", e)
             emptySet()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,7 @@
     <string name="home_apk_use_installed">Use installed APK</string>
     <string name="home_apk_use_installed_unverified">Could not verify the signature of the installed app, so it may already be patched</string>
     <string name="home_unverified">Unverified</string>
+    <string name="home_install_verification_pending">Checking install…</string>
     <string name="home_app_info_install_unverified">Morphe cannot confirm that the installed app is the build it patched. Reinstall it from the saved APK to restore its actions</string>
     <string name="home_app_info_no_saved_apk">No saved APK. Patching will require selecting the APK file again</string>
     <string name="home_version_requires_android">Requires Android %s+</string>

--- a/app/src/test/java/app/morphe/manager/domain/apk/ApkFileStampTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/ApkFileStampTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.apk
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class ApkFileStampTest {
+    @Test
+    fun `rewriting an APK invalidates the stamp captured before verification`() {
+        val file = Files.createTempFile("morphe-apk-stamp", ".apk").toFile()
+        try {
+            file.writeText("old")
+            val before = file.apkFileStampOrNull()
+
+            file.writeText("new archive contents")
+            val after = file.apkFileStampOrNull()
+
+            assertNotEquals(before, after)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun `missing files cannot identify a cache entry`() {
+        val missing = Files.createTempDirectory("morphe-apk-stamp").resolve("missing.apk").toFile()
+        try {
+            assertNull(missing.apkFileStampOrNull())
+        } finally {
+            missing.parentFile?.delete()
+        }
+    }
+}

--- a/app/src/test/java/app/morphe/manager/ui/screen/home/HomeAppFilterModeTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/screen/home/HomeAppFilterModeTest.kt
@@ -31,6 +31,7 @@ class HomeAppFilterModeTest {
             isDeleted = false,
             isInstallStateNotPatched = true,
             isInstallStateUnknown = false,
+            isInstallStatePending = false,
             savedApkFile = null,
             hasUpdate = false,
             patchCount = 0
@@ -40,5 +41,34 @@ class HomeAppFilterModeTest {
         assertTrue(HomeAppFilterMode.INSTALLED.matches(item))
         assertFalse(HomeAppFilterMode.NOT_PATCHED.matches(item))
         assertFalse(HomeAppFilterMode.UNINSTALLED.matches(item))
+    }
+
+    @Test
+    fun `pending verification stays physically installed without showing an update verdict`() {
+        val item = HomeAppItem(
+            packageName = "app.example",
+            displayName = "Example",
+            gradientColors = emptyList(),
+            installedApp = InstalledApp(
+                currentPackageName = "app.example",
+                originalPackageName = "app.example",
+                version = "1.0",
+                installType = InstallType.DEFAULT
+            ),
+            packageInfo = null,
+            isPinnedByDefault = false,
+            isInstalledOnDevice = true,
+            isDeleted = false,
+            isInstallStateNotPatched = false,
+            isInstallStateUnknown = false,
+            isInstallStatePending = true,
+            savedApkFile = null,
+            hasUpdate = true,
+            patchCount = 0
+        )
+
+        assertTrue(HomeAppFilterMode.INSTALLED.matches(item))
+        assertFalse(HomeAppFilterMode.UNINSTALLED.matches(item))
+        assertFalse(item.showsUpdateBadge)
     }
 }

--- a/app/src/test/java/app/morphe/manager/ui/viewmodel/TrackedEvidenceInvalidationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/viewmodel/TrackedEvidenceInvalidationTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.viewmodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TrackedEvidenceInvalidationTest {
+    @Test
+    fun `added removed and replaced evidence keys are invalidated`() {
+        assertEquals(
+            setOf("added", "removed", "replaced"),
+            changedMapKeys(
+                previous = mapOf(
+                    "unchanged" to "same",
+                    "removed" to "old",
+                    "replaced" to "old"
+                ),
+                current = mapOf(
+                    "unchanged" to "same",
+                    "added" to "new",
+                    "replaced" to "new"
+                )
+            )
+        )
+    }
+}


### PR DESCRIPTION
### Description

Follow-up to #852. Snapshot verification no longer blocks the initial app list, but unresolved records could briefly reuse an old verdict or appear as installed before their result arrived. The snapshot fingerprint also omitted saved-original APKs and bundle certificate changes.

### Changes

- Publish tracked snapshots per app and show `Checking install…` until each verdict arrives.
- Remove an affected verdict as soon as a package change is reported, while keeping archive work debounced.
- Re-evaluate snapshots when saved-original APKs or bundle signatures change, and include all verdict inputs in the snapshot fingerprint.
- Bind signature-cache writes to the file revision inspected and prevent stale cleanup or delayed writes from replacing a newer cache row.
- Add focused tests for pending presentation, evidence invalidation, and APK revision stamps.

### Validation

- `./gradlew :app:testDebugUnitTest` — 79 tests passed.
- `./gradlew :app:assembleDebug` — passed.
- Pixel 9: tested five real tracked APKs totaling 1,067.9 MiB with an empty cache; all five resolved correctly, five cache rows were persisted, the database remained valid, and no crash/ANR/cache errors were logged.
