### PR TITLE
fix: Preserve tracked state after deleting saved APKs

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -157,18 +157,14 @@ class InstalledAppRepository(
 
     /**
      * Update only the [InstalledApp.version] of an existing record and drop the orphan
-     * patched APK at the old version path. Applied patches and selectionPayload are
-     * left untouched.
+     * patched APKs it owned at the old version path. Applied patches and selectionPayload
+     * are left untouched.
      */
     suspend fun updateInstalledVersion(app: InstalledApp, newVersion: String) =
         withContext(Dispatchers.IO) {
             if (app.version == newVersion) return@withContext
             dao.upsertApp(app.copy(version = newVersion))
-            val orphans = listOf(
-                filesystem.getPatchedAppFile(app.currentPackageName, app.version),
-                filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-            ).distinctBy { it.absolutePath }
-            orphans.forEach { file ->
+            savedPatchedApkFiles(app).forEach { file ->
                 if (file.exists()) {
                     runCatching { file.delete() }.onFailure {
                         Log.w(TAG, "Failed to delete ${file.absolutePath}", it)

--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -11,7 +11,9 @@ import app.morphe.manager.util.PM
 import app.morphe.manager.util.PatchSelection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -30,6 +32,7 @@ class InstalledAppRepository(
     private val bundleDao = db.patchBundleDao()
 
     private val _orphanedInstalls = MutableStateFlow<List<InstalledApp>>(emptyList())
+    private val _savedPatchedApkChanges = MutableSharedFlow<Set<String>>(extraBufferCapacity = 1)
 
     /**
      * Copies that patching left behind on the device under their previous package name.
@@ -37,6 +40,9 @@ class InstalledAppRepository(
      * they turn into installs nothing points at.
      */
     val orphanedInstalls = _orphanedInstalls.asStateFlow()
+
+    /** Package names whose retained patched APK evidence changed without changing its record. */
+    val savedPatchedApkChanges = _savedPatchedApkChanges.asSharedFlow()
 
     fun getAll() = dao.getAll().distinctUntilChanged()
 
@@ -156,27 +162,61 @@ class InstalledAppRepository(
             Log.i(TAG, "Reconciled version for ${app.currentPackageName}: ${app.version} → $newVersion")
         }
 
-    /**
-     * Delete installed app record and its saved patched APK file from storage.
-     * Looks up the file by both currentPackageName and originalPackageName to handle renamed packages.
-     */
-    suspend fun delete(installedApp: InstalledApp) = withContext(Dispatchers.IO) {
-        // Find the saved patched APK file
-        val savedFile = listOf(
+    private fun savedPatchedApkFiles(installedApp: InstalledApp) =
+        listOf(
             filesystem.getPatchedAppFile(installedApp.currentPackageName, installedApp.version),
             filesystem.getPatchedAppFile(installedApp.originalPackageName, installedApp.version)
-        ).distinct().firstOrNull { it.exists() }
+        ).distinctBy { it.absolutePath }
 
-        if (savedFile != null) {
-            val deleted = runCatching { savedFile.delete() }.getOrElse { false }
+    /** Deletes every current or legacy retained copy and reports whether any file changed. */
+    private fun deleteSavedPatchedApkFiles(installedApp: InstalledApp): Boolean {
+        val savedFiles = savedPatchedApkFiles(installedApp).filter { it.exists() }
+        if (savedFiles.isEmpty()) {
+            Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
+            return false
+        }
+
+        var changed = false
+        savedFiles.forEach { savedFile ->
+            val deleted = runCatching { savedFile.delete() }.getOrDefault(false)
             if (deleted) {
+                changed = true
                 Log.d(TAG, "Deleted patched APK: ${savedFile.absolutePath}")
             } else {
                 Log.w(TAG, "Failed to delete patched APK: ${savedFile.absolutePath}")
             }
-        } else {
-            Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
         }
+        return changed
+    }
+
+    /**
+     * Deletes retained patched APK files while preserving their patch records and settings.
+     * Consumers are notified because this changes the evidence used to verify live installs.
+     */
+    suspend fun deleteSavedPatchedApks(installedApps: Collection<InstalledApp>) =
+        withContext(Dispatchers.IO) {
+            val changedPackages = buildSet {
+                installedApps.forEach { installedApp ->
+                    if (deleteSavedPatchedApkFiles(installedApp)) {
+                        add(installedApp.currentPackageName)
+                        add(installedApp.originalPackageName)
+                    }
+                }
+            }
+            if (changedPackages.isNotEmpty()) {
+                _savedPatchedApkChanges.emit(changedPackages)
+            }
+        }
+
+    suspend fun deleteSavedPatchedApk(installedApp: InstalledApp) =
+        deleteSavedPatchedApks(listOf(installedApp))
+
+    /**
+     * Deletes an installed app record together with every retained patched APK copy.
+     * This is the explicit "forget app" operation, not storage-only APK cleanup.
+     */
+    suspend fun delete(installedApp: InstalledApp) = withContext(Dispatchers.IO) {
+        deleteSavedPatchedApkFiles(installedApp)
 
         dao.delete(installedApp)
     }

--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -10,17 +10,33 @@ import app.morphe.manager.data.room.apps.installed.SelectionPayload
 import app.morphe.manager.util.PM
 import app.morphe.manager.util.PatchSelection
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
+import java.io.File
 
 private const val TAG = "Morphe InstalledAppRepository"
+
+/**
+ * Package names a record keeps its retained copies under, given whether a record already occupies
+ * its original name. A rename leaves a copy under the original package name, but that same path is
+ * where a separate, unrenamed record would keep its own APK.
+ */
+internal fun retainedPatchedApkOwners(
+    currentPackageName: String,
+    originalPackageName: String,
+    originalPackageIsTracked: Boolean
+): List<String> = if (originalPackageName == currentPackageName || originalPackageIsTracked) {
+    listOf(currentPackageName)
+} else {
+    listOf(currentPackageName, originalPackageName)
+}
+
+/**
+ * Whether the record still describes something once its retained copies are gone.
+ * A saved-only record is the archive, so nothing is left to track without it.
+ */
+internal fun outlivesRetainedPatchedApk(installType: InstallType) =
+    installType != InstallType.SAVED
 
 class InstalledAppRepository(
     db: AppDatabase,
@@ -162,45 +178,50 @@ class InstalledAppRepository(
             Log.i(TAG, "Reconciled version for ${app.currentPackageName}: ${app.version} → $newVersion")
         }
 
-    private fun savedPatchedApkFiles(installedApp: InstalledApp) =
-        listOf(
-            filesystem.getPatchedAppFile(installedApp.currentPackageName, installedApp.version),
-            filesystem.getPatchedAppFile(installedApp.originalPackageName, installedApp.version)
-        ).distinctBy { it.absolutePath }
+    /** Every storage path this record owns a retained copy at, current and legacy. */
+    suspend fun savedPatchedApkFiles(installedApp: InstalledApp): List<File> =
+        retainedPatchedApkOwners(
+            currentPackageName = installedApp.currentPackageName,
+            originalPackageName = installedApp.originalPackageName,
+            originalPackageIsTracked = dao.get(installedApp.originalPackageName) != null
+        ).map { packageName ->
+            filesystem.getPatchedAppFile(packageName, installedApp.version)
+        }
 
-    /** Deletes every current or legacy retained copy and reports whether any file changed. */
-    private fun deleteSavedPatchedApkFiles(installedApp: InstalledApp): Boolean {
+    /** Deletes every retained copy this record owns and reports whether any of them existed. */
+    private suspend fun deleteSavedPatchedApkFiles(installedApp: InstalledApp): Boolean {
         val savedFiles = savedPatchedApkFiles(installedApp).filter { it.exists() }
         if (savedFiles.isEmpty()) {
             Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
             return false
         }
 
-        var changed = false
         savedFiles.forEach { savedFile ->
-            val deleted = runCatching { savedFile.delete() }.getOrDefault(false)
-            if (deleted) {
-                changed = true
+            if (runCatching { savedFile.delete() }.getOrDefault(false)) {
                 Log.d(TAG, "Deleted patched APK: ${savedFile.absolutePath}")
             } else {
                 Log.w(TAG, "Failed to delete patched APK: ${savedFile.absolutePath}")
             }
         }
-        return changed
+        // Reported even when a delete failed, so the listing rebuilds from what is actually there
+        return true
     }
 
     /**
-     * Deletes retained patched APK files while preserving their patch records and settings.
+     * Deletes retained patched APK files while preserving the records that describe an install.
+     * A saved-only record describes nothing once its archive is gone, so it goes with the file.
      * Consumers are notified because this changes the evidence used to verify live installs.
      */
     suspend fun deleteSavedPatchedApks(installedApps: Collection<InstalledApp>) =
         withContext(Dispatchers.IO) {
             val changedPackages = buildSet {
                 installedApps.forEach { installedApp ->
-                    if (deleteSavedPatchedApkFiles(installedApp)) {
-                        add(installedApp.currentPackageName)
-                        add(installedApp.originalPackageName)
+                    if (!deleteSavedPatchedApkFiles(installedApp)) return@forEach
+                    if (!outlivesRetainedPatchedApk(installedApp.installType)) {
+                        dao.delete(installedApp)
                     }
+                    add(installedApp.currentPackageName)
+                    add(installedApp.originalPackageName)
                 }
             }
             if (changedPackages.isNotEmpty()) {

--- a/app/src/main/java/app/morphe/manager/domain/repository/OriginalApkRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/OriginalApkRepository.kt
@@ -41,6 +41,12 @@ class OriginalApkRepository(
             Log.d(TAG, "Original APK retention disabled, skipping save for $packageName")
             return@withContext null
         }
+        // Create new file path
+        val safePackage = FilenameUtils.sanitize(packageName)
+        val safeVersion = FilenameUtils.sanitize(version.ifBlank { "unspecified" })
+        val targetFile = originalApksDir.resolve("${safePackage}_${safeVersion}_original.apk")
+        val copies = sourceFile != targetFile
+
         try {
             // Delete old version if exists
             val existing = dao.get(packageName)
@@ -52,13 +58,8 @@ class OriginalApkRepository(
                 }
             }
 
-            // Create new file path
-            val safePackage = FilenameUtils.sanitize(packageName)
-            val safeVersion = FilenameUtils.sanitize(version.ifBlank { "unspecified" })
-            val targetFile = originalApksDir.resolve("${safePackage}_${safeVersion}_original.apk")
-
             // Copy file if source is different
-            if (sourceFile != targetFile) {
+            if (copies) {
                 sourceFile.copyTo(targetFile, overwrite = true)
             }
 
@@ -76,6 +77,8 @@ class OriginalApkRepository(
             targetFile
         } catch (e: Exception) {
             Log.e(TAG, "Failed to save original APK for $packageName", e)
+            // Only a copy this call made is safe to drop, and no record points at it
+            if (copies) targetFile.delete()
             null
         }
     }

--- a/app/src/main/java/app/morphe/manager/domain/repository/OriginalApkRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/OriginalApkRepository.kt
@@ -8,6 +8,7 @@ import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.util.FilenameUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -84,6 +85,19 @@ class OriginalApkRepository(
      */
     suspend fun markUsed(packageName: String) {
         dao.updateLastUsed(packageName)
+    }
+
+    /**
+     * Drops records whose retained file is gone.
+     * A record here is only a pointer to its archive, so without the file it has nothing left to
+     * describe and would otherwise keep reporting its old size and offering actions that no-op.
+     */
+    suspend fun pruneMissingApks() = withContext(Dispatchers.IO) {
+        dao.getAll().first().forEach { originalApk ->
+            if (File(originalApk.filePath).exists()) return@forEach
+            dao.delete(originalApk)
+            Log.d(TAG, "Dropped original APK record without a file for ${originalApk.packageName}")
+        }
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
@@ -33,6 +33,15 @@ internal fun <T> TrackedInstallPresentation.displayedPackageInfo(
 }
 
 /**
+ * Lets an Unverified detail view use the live app's icon when no retained icon remains, without
+ * also replacing the tracked label and version with metadata from an unverified package.
+ */
+internal fun <T> trackedDetailIconPackageInfo(
+    displayedPackageInfo: T?,
+    installedPackageInfo: T?
+): T? = displayedPackageInfo ?: installedPackageInfo
+
+/**
  * Keeps the untracked-app resolver fallback out of tracked states. In particular, an Unknown
  * tracked package with no retained APK must stay metadata-free instead of silently revealing the
  * package currently occupying its name.

--- a/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
+++ b/app/src/main/java/app/morphe/manager/ui/model/TrackedInstallPresentation.kt
@@ -33,15 +33,6 @@ internal fun <T> TrackedInstallPresentation.displayedPackageInfo(
 }
 
 /**
- * Lets an Unverified detail view use the live app's icon when no retained icon remains, without
- * also replacing the tracked label and version with metadata from an unverified package.
- */
-internal fun <T> trackedDetailIconPackageInfo(
-    displayedPackageInfo: T?,
-    installedPackageInfo: T?
-): T? = displayedPackageInfo ?: installedPackageInfo
-
-/**
  * Keeps the untracked-app resolver fallback out of tracked states. In particular, an Unknown
  * tracked package with no retained APK must stay metadata-free instead of silently revealing the
  * package currently occupying its name.
@@ -61,8 +52,9 @@ internal fun <T> displayedHomePackageInfo(
  * Keeps a present, confirmed non-patched package distinct from a package that is absent.
  *
  * A confirmed replacement is present, not deleted, but it remains distinct from both the patched
- * build in Morphe's record and an app that has never been patched. [showsInstalledPackage] lets
- * the UI use the replacement's current icon and version only when its identity is confirmed.
+ * build in Morphe's record and an app that has never been patched.
+ * [TrackedInstallPresentation.showsInstalledPackage] lets the UI use the replacement's current
+ * icon and version only when its identity is confirmed.
  */
 internal fun trackedInstallPresentation(
     installType: InstallType,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -49,6 +49,7 @@ import app.morphe.manager.patcher.util.NativeLibStripper
 import app.morphe.manager.ui.screen.settings.system.InstallerSelectionDialog
 import app.morphe.manager.ui.screen.settings.system.InstallerUnavailableDialog
 import app.morphe.manager.ui.screen.shared.*
+import app.morphe.manager.ui.screen.shared.Animations
 import app.morphe.manager.ui.theme.MonochromeThemeDefaults
 import app.morphe.manager.ui.viewmodel.HomeViewModel
 import app.morphe.manager.ui.viewmodel.InstallViewModel
@@ -110,7 +111,6 @@ fun InstalledAppInfoDialog(
     val context = LocalContext.current
     val installedApp = viewModel.installedApp
     val appInfo = viewModel.appInfo
-    val appIconInfo = viewModel.appIconInfo
     val appliedPatches = viewModel.appliedPatches
     val isLoading = viewModel.isLoading
 
@@ -464,7 +464,6 @@ fun InstalledAppInfoDialog(
                         item(contentType = "hero") {
                             AppHeroHeader(
                                 appInfo = appInfo,
-                                appIconInfo = appIconInfo,
                                 packageName = packageName,
                                 installedApp = installedApp,
                                 accentColor = infoAccentColor,
@@ -572,7 +571,6 @@ fun InstalledAppInfoDialog(
                         item(contentType = "hero") {
                             AppHeroHeader(
                                 appInfo = appInfo,
-                                appIconInfo = appIconInfo,
                                 packageName = packageName,
                                 installedApp = installedApp,
                                 accentColor = infoAccentColor,
@@ -844,7 +842,6 @@ private fun WarningBanner(
 @Composable
 private fun AppHeroHeader(
     appInfo: PackageInfo?,
-    appIconInfo: PackageInfo?,
     packageName: String,
     installedApp: InstalledApp,
     accentColor: Color,
@@ -922,9 +919,10 @@ private fun AppHeroHeader(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                // Animated app icon
+                // Animated app icon, resolved by name when the record has no metadata to show
                 AppIcon(
-                    packageInfo = appIconInfo,
+                    packageInfo = appInfo,
+                    packageName = packageName,
                     contentDescription = null,
                     modifier = Modifier
                         .size(iconSize)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/InstalledAppInfoDialog.kt
@@ -110,6 +110,7 @@ fun InstalledAppInfoDialog(
     val context = LocalContext.current
     val installedApp = viewModel.installedApp
     val appInfo = viewModel.appInfo
+    val appIconInfo = viewModel.appIconInfo
     val appliedPatches = viewModel.appliedPatches
     val isLoading = viewModel.isLoading
 
@@ -463,6 +464,7 @@ fun InstalledAppInfoDialog(
                         item(contentType = "hero") {
                             AppHeroHeader(
                                 appInfo = appInfo,
+                                appIconInfo = appIconInfo,
                                 packageName = packageName,
                                 installedApp = installedApp,
                                 accentColor = infoAccentColor,
@@ -570,6 +572,7 @@ fun InstalledAppInfoDialog(
                         item(contentType = "hero") {
                             AppHeroHeader(
                                 appInfo = appInfo,
+                                appIconInfo = appIconInfo,
                                 packageName = packageName,
                                 installedApp = installedApp,
                                 accentColor = infoAccentColor,
@@ -841,6 +844,7 @@ private fun WarningBanner(
 @Composable
 private fun AppHeroHeader(
     appInfo: PackageInfo?,
+    appIconInfo: PackageInfo?,
     packageName: String,
     installedApp: InstalledApp,
     accentColor: Color,
@@ -920,7 +924,7 @@ private fun AppHeroHeader(
             ) {
                 // Animated app icon
                 AppIcon(
-                    packageInfo = appInfo,
+                    packageInfo = appIconInfo,
                     contentDescription = null,
                     modifier = Modifier
                         .size(iconSize)

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
-import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.data.room.apps.installed.supportsMount
@@ -201,7 +200,6 @@ private fun PatchedApksContent(
     val patchedApksDeletedText = stringResource(R.string.settings_system_patched_apks_deleted)
     val apksDeletedAllText = stringResource(R.string.settings_system_apks_deleted_all)
     val repository: InstalledAppRepository = koinInject()
-    val filesystem: Filesystem = koinInject()
     val appDataResolver: AppDataResolver = koinInject()
     val prefs: PreferencesManager = koinInject()
     val pm: PM = koinInject()
@@ -219,10 +217,10 @@ private fun PatchedApksContent(
             state = ApkLoadState.Loaded(
                 withContext(Dispatchers.IO) {
                     apps.mapNotNull { app ->
-                        val storedFile = listOf(
-                            filesystem.getPatchedAppFile(app.currentPackageName, app.version),
-                            filesystem.getPatchedAppFile(app.originalPackageName, app.version)
-                        ).distinct().firstOrNull { it.exists() } ?: return@mapNotNull null
+                        // Only the copies this record owns, so a renamed app never lists the
+                        // archive an unrenamed record keeps under the same original name
+                        val storedFile = repository.savedPatchedApkFiles(app)
+                            .firstOrNull { it.exists() } ?: return@mapNotNull null
                         val snapshot = localApkSources.trackedAppSnapshot(app)
                         val savedFile = snapshot.savedPatchedApk
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -56,6 +56,9 @@ import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.ui.viewmodel.InstallViewModel
 import app.morphe.manager.util.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -209,7 +212,10 @@ private fun PatchedApksContent(
     var state by remember { mutableStateOf<ApkLoadState<ApkItemDataWithApp>>(ApkLoadState.Loading) }
 
     LaunchedEffect(Unit) {
-        repository.getAll().collect { apps ->
+        combine(
+            repository.getAll(),
+            repository.savedPatchedApkChanges.onStart { emit(emptySet()) }
+        ) { apps, _ -> apps }.collectLatest { apps ->
             state = ApkLoadState.Loaded(
                 withContext(Dispatchers.IO) {
                     apps.mapNotNull { app ->
@@ -435,14 +441,14 @@ private fun PatchedApksContent(
             onDeleteSelectedConfirm = { selectedItems ->
                 val appsToDelete = selectedItems.mapNotNull { appByKey[it.selectionKey] }
                 scope.launch {
-                    appsToDelete.forEach { repository.delete(it) }
+                    repository.deleteSavedPatchedApks(appsToDelete)
                     context.toast(apksDeletedAllText)
                 }
             },
             onDeleteAllConfirm = {
                 val appsToDelete = apkItems.map { it.installedApp }
                 scope.launch {
-                    appsToDelete.forEach { repository.delete(it) }
+                    repository.deleteSavedPatchedApks(appsToDelete)
                     context.toast(apksDeletedAllText)
                 }
             }
@@ -459,7 +465,7 @@ private fun PatchedApksContent(
             onDismiss = { itemToDelete.value = null },
             onConfirm = {
                 scope.launch {
-                    repository.delete(itemToDelete.value!!)
+                    repository.deleteSavedPatchedApk(itemToDelete.value!!)
                     context.toast(patchedApksDeletedText)
                     itemToDelete.value = null
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ApkManagementDialog.kt
@@ -492,6 +492,8 @@ private fun OriginalApksContent(
     var state by remember { mutableStateOf<ApkLoadState<OriginalApkEntry>>(ApkLoadState.Loading) }
 
     LaunchedEffect(Unit) {
+        // Records left behind by a file that is already gone would show a stale size and count
+        repository.pruneMissingApks()
         repository.getAll().collect { apks ->
             state = ApkLoadState.Loaded(
                 withContext(Dispatchers.IO) {

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -536,6 +536,15 @@ class HomeViewModel(
             }
     }
 
+    /** Rechecks only tracked evidence when storage management removes a retained patched APK. */
+    private fun observeSavedPatchedApkChanges() = viewModelScope.launch {
+        installedAppRepository.savedPatchedApkChanges.collect { packageNames ->
+            packageNames.forEach(appDataResolver::invalidate)
+            markTrackedPackagesPending(packageNames, invalidateCache = true)
+            _appStateTicker.update { it + 1 }
+        }
+    }
+
     /**
      * Keeps [_trackedSnapshots] in step with the records and with anything that changed a package.
      *
@@ -813,6 +822,7 @@ class HomeViewModel(
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         observePackageChanges()
+        observeSavedPatchedApkChanges()
         observeTrackedApps()
         observeManagerUpdate()
         triggerUpdateCheck()

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -26,11 +26,7 @@ import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.platform.NetworkInfo
 import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
-import app.morphe.manager.domain.apk.InstalledApkInfo
-import app.morphe.manager.domain.apk.InstalledPatchState
-import app.morphe.manager.domain.apk.LocalApkSources
-import app.morphe.manager.domain.apk.SavedApkInfo
-import app.morphe.manager.domain.apk.TrackedAppSnapshot
+import app.morphe.manager.domain.apk.*
 import app.morphe.manager.domain.batch.BatchPatchCoordinator
 import app.morphe.manager.domain.bundles.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.asRemoteOrNull
@@ -531,7 +527,7 @@ class HomeViewModel(
                     appDataResolver.invalidate(it)
                 }
                 markTrackedPackagesPending(pending, invalidateCache = true)
-                _appStateTicker.value = System.currentTimeMillis()
+                _appStateTicker.update { it + 1 }
                 pendingPackageChanges.value = emptySet()
             }
     }
@@ -941,7 +937,7 @@ class HomeViewModel(
                 _isRefreshing.value = false
             }
             appDataResolver.invalidateAll()
-            _appStateTicker.value = System.currentTimeMillis()
+            _appStateTicker.update { it + 1 }
         }
     }
 
@@ -1634,7 +1630,7 @@ class HomeViewModel(
     fun notifyAppStateChanged(packageName: String) {
         appDataResolver.invalidate(packageName)
         markTrackedPackagesPending(setOf(packageName), invalidateCache = true)
-        _appStateTicker.value = System.currentTimeMillis()
+        _appStateTicker.update { it + 1 }
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import app.morphe.manager.R
-import app.morphe.manager.data.platform.Filesystem
 import app.morphe.manager.data.room.apps.installed.InstallType
 import app.morphe.manager.data.room.apps.installed.InstalledApp
 import app.morphe.manager.domain.apk.InstalledPatchState
@@ -17,9 +16,10 @@ import app.morphe.manager.domain.apk.canRemoveTrackedRecord
 import app.morphe.manager.domain.installer.InstallerManager
 import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
-import app.morphe.manager.domain.repository.*
+import app.morphe.manager.domain.repository.InstalledAppRepository
+import app.morphe.manager.domain.repository.OriginalApkRepository
+import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.model.displayedPackageInfo
-import app.morphe.manager.ui.model.trackedDetailIconPackageInfo
 import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.home.AppliedPatchBundleUi
 import app.morphe.manager.ui.screen.home.resolveAppliedBundleAttribution
@@ -44,7 +44,6 @@ class InstalledAppInfoViewModel(
     private val rootInstaller: RootInstaller by inject()
     private val installerManager: InstallerManager by inject()
     private val originalApkRepository: OriginalApkRepository by inject()
-    private val filesystem: Filesystem by inject()
     private val applicationScope: AppCoroutineScope by inject()
     private val localApkSources: LocalApkSources by inject()
 
@@ -54,8 +53,6 @@ class InstalledAppInfoViewModel(
     var installedApp: InstalledApp? by mutableStateOf(null)
         private set
     var appInfo: PackageInfo? by mutableStateOf(null)
-        private set
-    var appIconInfo: PackageInfo? by mutableStateOf(null)
         private set
     private var usableSavedApk: File? = null
 
@@ -218,7 +215,6 @@ class InstalledAppInfoViewModel(
         withContext(Dispatchers.Main) {
             installedApp = null
             appInfo = null
-            appIconInfo = null
             appliedPatches = null
             isInstalledOnDevice = false
             context.toast(context.getString(R.string.saved_app_removed_toast))
@@ -235,32 +231,10 @@ class InstalledAppInfoViewModel(
      * Note: Patch selection and options are NOT deleted - they remain for future patching.
      */
     private suspend fun deleteRecordAndApk(app: InstalledApp) {
-        // Delete database record
+        // Removes the record together with every retained copy it owns
         installedAppRepository.delete(app)
-
-        // Delete patched APK file
-        withContext(Dispatchers.IO) {
-            savedApkCandidates(app).forEach { it.delete() }
-        }
         usableSavedApk = null
         hasSavedCopy = false
-    }
-
-    /**
-     * Both storage paths this app can occupy, minus any that another record owns.
-     * A rename leaves a copy under the original package name, but that same path is where a
-     * separate, unrenamed record would keep its own APK.
-     */
-    private suspend fun savedApkCandidates(app: InstalledApp): List<File> {
-        val paths = mutableListOf(filesystem.getPatchedAppFile(app.currentPackageName, app.version))
-
-        if (app.originalPackageName != app.currentPackageName &&
-            installedAppRepository.get(app.originalPackageName) == null
-        ) {
-            paths.add(filesystem.getPatchedAppFile(app.originalPackageName, app.version))
-        }
-
-        return paths.distinctBy { it.absolutePath }
     }
 
     suspend fun updateInstallType(packageName: String, newInstallType: InstallType) {
@@ -294,12 +268,10 @@ class InstalledAppInfoViewModel(
         // This flag authorizes actions against Morphe's tracked build, so a confirmed stock
         // replacement remains false even though its own metadata is safe to display.
         isInstalledOnDevice = installedInfo != null && trackedPresentation.isPatched
-        val displayedInfo = trackedPresentation.displayedPackageInfo(
+        appInfo = trackedPresentation.displayedPackageInfo(
             installedPackageInfo = installedInfo,
             savedPackageInfo = snapshot.savedPatchedApkInfo
         )
-        appInfo = displayedInfo
-        appIconInfo = trackedDetailIconPackageInfo(displayedInfo, installedInfo)
         isAppDeleted = trackedPresentation.isDeleted
         isInstallStateNotPatched = trackedPresentation.isNotPatched
         isInstallStateUnknown = trackedPresentation.isUnknown

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/InstalledAppInfoViewModel.kt
@@ -19,6 +19,7 @@ import app.morphe.manager.domain.installer.RootInstaller
 import app.morphe.manager.domain.installer.UninstallCancelledException
 import app.morphe.manager.domain.repository.*
 import app.morphe.manager.ui.model.displayedPackageInfo
+import app.morphe.manager.ui.model.trackedDetailIconPackageInfo
 import app.morphe.manager.ui.model.trackedInstallPresentation
 import app.morphe.manager.ui.screen.home.AppliedPatchBundleUi
 import app.morphe.manager.ui.screen.home.resolveAppliedBundleAttribution
@@ -53,6 +54,8 @@ class InstalledAppInfoViewModel(
     var installedApp: InstalledApp? by mutableStateOf(null)
         private set
     var appInfo: PackageInfo? by mutableStateOf(null)
+        private set
+    var appIconInfo: PackageInfo? by mutableStateOf(null)
         private set
     private var usableSavedApk: File? = null
 
@@ -215,6 +218,7 @@ class InstalledAppInfoViewModel(
         withContext(Dispatchers.Main) {
             installedApp = null
             appInfo = null
+            appIconInfo = null
             appliedPatches = null
             isInstalledOnDevice = false
             context.toast(context.getString(R.string.saved_app_removed_toast))
@@ -290,10 +294,12 @@ class InstalledAppInfoViewModel(
         // This flag authorizes actions against Morphe's tracked build, so a confirmed stock
         // replacement remains false even though its own metadata is safe to display.
         isInstalledOnDevice = installedInfo != null && trackedPresentation.isPatched
-        appInfo = trackedPresentation.displayedPackageInfo(
+        val displayedInfo = trackedPresentation.displayedPackageInfo(
             installedPackageInfo = installedInfo,
             savedPackageInfo = snapshot.savedPatchedApkInfo
         )
+        appInfo = displayedInfo
+        appIconInfo = trackedDetailIconPackageInfo(displayedInfo, installedInfo)
         isAppDeleted = trackedPresentation.isDeleted
         isInstallStateNotPatched = trackedPresentation.isNotPatched
         isInstallStateUnknown = trackedPresentation.isUnknown

--- a/app/src/main/java/app/morphe/manager/util/PM.kt
+++ b/app/src/main/java/app/morphe/manager/util/PM.kt
@@ -102,7 +102,7 @@ class PM(
 
     fun PackageInfo.label(): String {
         val raw = this.applicationInfo!!.loadLabel(app.packageManager).toString()
-        return cleanLabel(raw, this.packageName)
+        return cleanPackageLabel(raw, this.packageName)
     }
 
     fun getVersionCode(packageInfo: PackageInfo) = PackageInfoCompat.getLongVersionCode(packageInfo)
@@ -320,18 +320,37 @@ class PM(
             digest.digest(sig.toByteArray()).joinToString("") { b -> "%02x".format(b) }
         }
     }
+}
 
-    private fun cleanLabel(raw: String, packageName: String): String {
-        val trimmed = raw.trim()
-        if (trimmed.isEmpty()) return trimmed
-        // If the label contains the package name or a dotted class, strip to the last segment.
-        val hasDots = trimmed.contains('.')
-        val pkgMatch = packageName.isNotEmpty() && (trimmed.startsWith(packageName) || trimmed.contains(packageName))
-        val base = if (hasDots || pkgMatch) trimmed.substringAfterLast('.') else trimmed
-        val withoutSuffix = base.removeSuffix("Application")
-        val candidate = withoutSuffix.ifBlank { base }
-        return candidate.ifBlank { trimmed }
-    }
+/**
+ * Whether a label is an identifier the app never meant to show, rather than a name it chose.
+ *
+ * Apps without a real label fall back to their package or a launcher class, and only those are
+ * worth reducing to a last segment. A brand that simply contains a dot must survive, so a dotted
+ * label only qualifies with the shape of a package: no spaces, three or more segments, and a
+ * lowercase top-level domain in front.
+ */
+private fun looksLikeIdentifierLabel(label: String, packageName: String): Boolean {
+    if (label.any(Char::isWhitespace)) return false
+    if (packageName.isNotEmpty() && label.contains(packageName)) return true
+    if (label.count { it == '.' } < 2) return false
+    if (!label.all { it.isLetterOrDigit() || it == '.' || it == '_' }) return false
+    return label.substringBefore('.').none(Char::isUpperCase)
+}
+
+/**
+ * Reduces a launcher label to the part worth showing.
+ * Kept free of Android APIs so the identifier rules can be tested directly.
+ */
+internal fun cleanPackageLabel(raw: String, packageName: String): String {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return trimmed
+    if (!looksLikeIdentifierLabel(trimmed, packageName)) return trimmed
+
+    val base = trimmed.substringAfterLast('.')
+    val withoutSuffix = base.removeSuffix("Application")
+    val candidate = withoutSuffix.ifBlank { base }
+    return candidate.ifBlank { trimmed }
 }
 
 /**

--- a/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.repository
+
+import app.morphe.manager.data.room.apps.installed.InstallType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RetainedPatchedApkOwnershipTest {
+    private fun owners(
+        currentPackageName: String = "app.morphe.youtube",
+        originalPackageName: String = "com.google.android.youtube",
+        originalPackageIsTracked: Boolean = false
+    ) = retainedPatchedApkOwners(
+        currentPackageName = currentPackageName,
+        originalPackageName = originalPackageName,
+        originalPackageIsTracked = originalPackageIsTracked
+    )
+
+    @Test
+    fun `renamed record owns its legacy copy while no other record claims that name`() {
+        assertEquals(listOf("app.morphe.youtube", "com.google.android.youtube"), owners())
+    }
+
+    @Test
+    fun `renamed record leaves the original name to the record that occupies it`() {
+        assertEquals(
+            listOf("app.morphe.youtube"),
+            owners(originalPackageIsTracked = true)
+        )
+    }
+
+    @Test
+    fun `unrenamed record owns a single copy`() {
+        assertEquals(
+            listOf("com.google.android.youtube"),
+            owners(
+                currentPackageName = "com.google.android.youtube",
+                originalPackageIsTracked = true
+            )
+        )
+    }
+
+    @Test
+    fun `saved-only record does not outlive its archive`() {
+        assertFalse(outlivesRetainedPatchedApk(InstallType.SAVED))
+    }
+
+    @Test
+    fun `installed record outlives its archive`() {
+        assertTrue(outlivesRetainedPatchedApk(InstallType.DEFAULT))
+        assertTrue(outlivesRetainedPatchedApk(InstallType.MOUNT))
+    }
+}

--- a/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
@@ -86,24 +86,6 @@ class TrackedInstallPresentationTest {
     }
 
     @Test
-    fun `unknown detail falls back to installed icon without replacing tracked metadata`() {
-        val presentation = trackedInstallPresentation(
-            InstallType.DEFAULT,
-            InstalledPatchState.Unknown
-        )
-        val displayedInfo = presentation.displayedPackageInfo(
-            installedPackageInfo = "installed",
-            savedPackageInfo = null
-        )
-
-        assertEquals(null, displayedInfo)
-        assertEquals(
-            "installed",
-            trackedDetailIconPackageInfo(displayedInfo, installedPackageInfo = "installed")
-        )
-    }
-
-    @Test
     fun `untracked app uses normally resolved package information`() {
         assertEquals(
             "resolved-current",

--- a/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/model/TrackedInstallPresentationTest.kt
@@ -86,6 +86,24 @@ class TrackedInstallPresentationTest {
     }
 
     @Test
+    fun `unknown detail falls back to installed icon without replacing tracked metadata`() {
+        val presentation = trackedInstallPresentation(
+            InstallType.DEFAULT,
+            InstalledPatchState.Unknown
+        )
+        val displayedInfo = presentation.displayedPackageInfo(
+            installedPackageInfo = "installed",
+            savedPackageInfo = null
+        )
+
+        assertEquals(null, displayedInfo)
+        assertEquals(
+            "installed",
+            trackedDetailIconPackageInfo(displayedInfo, installedPackageInfo = "installed")
+        )
+    }
+
+    @Test
     fun `untracked app uses normally resolved package information`() {
         assertEquals(
             "resolved-current",

--- a/app/src/test/java/app/morphe/manager/util/PackageLabelTest.kt
+++ b/app/src/test/java/app/morphe/manager/util/PackageLabelTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PackageLabelTest {
+    @Test
+    fun `brand containing a dot is kept whole`() {
+        assertEquals("Mapy.com", cleanPackageLabel("Mapy.com", "cz.seznam.mapy"))
+        assertEquals("Yandex.Music", cleanPackageLabel("Yandex.Music", "ru.yandex.music"))
+    }
+
+    @Test
+    fun `label that is the package name is reduced to its last segment`() {
+        assertEquals("mapy", cleanPackageLabel("cz.seznam.mapy", "cz.seznam.mapy"))
+    }
+
+    @Test
+    fun `launcher class label drops its package and Application suffix`() {
+        assertEquals("Main", cleanPackageLabel("com.example.app.MainApplication", "com.example.app"))
+    }
+
+    @Test
+    fun `package-shaped label is reduced even when the record package differs`() {
+        assertEquals("player", cleanPackageLabel("org.videolan.player", "com.example.other"))
+    }
+
+    @Test
+    fun `plain names are untouched`() {
+        assertEquals("SoundCloud", cleanPackageLabel("SoundCloud", "com.soundcloud.android"))
+        assertEquals("YouTube Morphe", cleanPackageLabel("  YouTube Morphe  ", "app.morphe.android.youtube"))
+    }
+
+    @Test
+    fun `dotted initialisms survive`() {
+        assertEquals("N.O.V.A.", cleanPackageLabel("N.O.V.A.", "com.gameloft.android.nova"))
+    }
+
+    @Test
+    fun `blank label stays blank`() {
+        assertEquals("", cleanPackageLabel("   ", "com.example.app"))
+    }
+}


### PR DESCRIPTION
### Description

Follow-up to #853. Deleting an item from Settings > Storage management > Patched APKs removed both the retained file and its tracking row, even though the action and confirmation described file-only cleanup. An installed app therefore fell back to `Not patched yet` instead of being re-evaluated as a tracked install. If that re-evaluation produced `Unverified` with no retained archive, the detail header also had no package information from which to render an icon.

### Changes

- Separate retained-APK deletion from the explicit operation that forgets an app record.
- Keep single, selected, and bulk patched-APK cleanup file-only and refresh the storage list immediately.
- Notify Home when retained verification evidence changes so the old verdict becomes pending and is recomputed.
- Use the inspected installed package only as the detail icon fallback; the tracked label and version presentation remain unchanged.
- Add a focused regression test for the unverified icon/metadata split.

### Validation

- `./gradlew :app:testDebugUnitTest` — 115 tests passed.
- `./gradlew :app:assembleDebug` — passed.
- Pixel 9, isolated debug app: a tracked installed app initially showed `Installed`; deleting its retained APK through the storage UI removed the file and refreshed the list, Home changed to `Unverified`, the tracking row remained present with database integrity `ok`, and the detail header showed the real app icon with the tracked version.
- The isolated debug app and test fixtures were removed afterward; production Morphe and Ampere were untouched.
