### PR TITLE
fix: Preserve installed saved records after APK deletion

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
+++ b/app/src/main/java/app/morphe/manager/domain/apk/LocalApkSources.kt
@@ -119,6 +119,32 @@ internal fun canRemoveTrackedRecord(
             patchState != InstalledPatchState.Patched
 
 /**
+ * Whether an installer attribution is compatible with how the record was created.
+ * A saved export may later be installed by any tool, so its installer is not evidence that the
+ * package was replaced after patching.
+ */
+internal fun installerAttributionMatchesRecord(
+    installType: InstallType,
+    installer: String?
+): Boolean = when (installType) {
+        InstallType.PLAY_STORE,
+        InstallType.ROOT_PLAY_STORE,
+        InstallType.SHIZUKU_PLAY_STORE -> installer == PLAY_STORE_INSTALLER_PACKAGE
+
+        // A mounted stock app, a user-picked installer and a saved export can carry any attribution
+        InstallType.MOUNT, InstallType.CUSTOM, InstallType.SAVED -> true
+
+        // Handing the APK to the system installer can leave either Morphe or the installer itself
+        // as the attribution, and the Morphe case was already accepted as proof above
+        InstallType.DEFAULT -> installer == null ||
+                installer == AOSP_INSTALLER_PACKAGE ||
+                installer == AOSP_INSTALLER_PACKAGE_LEGACY
+
+        // Shizuku installs leave no attribution behind, so anything else replaced the package
+        InstallType.SHIZUKU -> installer == null
+}
+
+/**
  * The APKs already on the device that an app could be patched from: the original Morphe kept
  * from a previous run, and the app as the system has it installed.
  */
@@ -254,7 +280,7 @@ class LocalApkSources(
             savedPatchedHashes = savedPatchedApk?.let(pm::getApkFileSignatureHashes).orEmpty(),
             originalHashes = referenceSignatureHashes(app.originalPackageName),
             installedByPatchManager = pm.isPatchManagerInstaller(installer),
-            installerAttributionMatches = installerMatchesRecord(app.installType, installer),
+            installerAttributionMatches = installerAttributionMatchesRecord(app.installType, installer),
             installedAfterPatching = installedAfterPatching(app, installedPackageInfo)
         )
 
@@ -319,31 +345,6 @@ class LocalApkSources(
 
     private fun fileStamp(file: File?): String =
         if (file == null) "-" else "${file.length()}:${file.lastModified()}"
-
-    /**
-     * Whether the current installer is the one Morphe itself would have set for this record.
-     *
-     * Play Store-attributed and custom install modes make installer identity inconclusive, so
-     * only the modes that leave a predictable attribution can rule an installation out.
-     */
-    private fun installerMatchesRecord(installType: InstallType, installer: String?): Boolean =
-        when (installType) {
-            InstallType.PLAY_STORE,
-            InstallType.ROOT_PLAY_STORE,
-            InstallType.SHIZUKU_PLAY_STORE -> installer == PLAY_STORE_INSTALLER_PACKAGE
-
-            // A mounted stock app and a user-picked installer can carry any attribution
-            InstallType.MOUNT, InstallType.CUSTOM -> true
-
-            // Handing the APK to the system installer can leave either Morphe or the installer
-            // itself as the attribution, and the Morphe case was already accepted as proof above
-            InstallType.DEFAULT -> installer == null ||
-                    installer == AOSP_INSTALLER_PACKAGE ||
-                    installer == AOSP_INSTALLER_PACKAGE_LEGACY
-
-            // Shizuku installs leave no attribution behind, so anything else replaced the package
-            InstallType.SHIZUKU, InstallType.SAVED -> installer == null
-        }
 
     /**
      * Whether the installation on the device is newer than the patch record tracking it.

--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -32,14 +32,41 @@ internal fun retainedPatchedApkOwners(
 }
 
 /**
+ * How the package occupying a saved record's name relates to its retained patched APK.
+ * Signature failures remain [UNKNOWN] so storage cleanup never destroys tracking evidence merely
+ * because either side could not be inspected.
+ */
+internal enum class InstalledSavedApkIdentity {
+    ABSENT,
+    MATCHES_RETAINED,
+    DIFFERS_FROM_RETAINED,
+    UNKNOWN
+}
+
+internal fun installedSavedApkIdentity(
+    packageIsInstalled: Boolean,
+    installedSignatureHashes: Set<String>,
+    retainedSignatureHashes: Set<String>
+): InstalledSavedApkIdentity = when {
+    !packageIsInstalled -> InstalledSavedApkIdentity.ABSENT
+    installedSignatureHashes.isEmpty() || retainedSignatureHashes.isEmpty() ->
+        InstalledSavedApkIdentity.UNKNOWN
+    installedSignatureHashes.any { it in retainedSignatureHashes } ->
+        InstalledSavedApkIdentity.MATCHES_RETAINED
+    else -> InstalledSavedApkIdentity.DIFFERS_FROM_RETAINED
+}
+
+/**
  * Whether the record still describes something once its retained copies are gone.
- * [InstallType.SAVED] records can also describe APKs installed after they were exported, so the
- * install type alone cannot decide whether deleting the archive should forget the record.
+ * A [InstallType.SAVED] record outlives the archive when the installed package matches it, or when
+ * identity could not be established. A confirmed different package is not the exported build.
  */
 internal fun outlivesRetainedPatchedApk(
     installType: InstallType,
-    packageIsInstalled: Boolean
-) = installType != InstallType.SAVED || packageIsInstalled
+    installedPackageIdentity: InstalledSavedApkIdentity
+) = installType != InstallType.SAVED ||
+        installedPackageIdentity == InstalledSavedApkIdentity.MATCHES_RETAINED ||
+        installedPackageIdentity == InstalledSavedApkIdentity.UNKNOWN
 
 /**
  * Deletes every retained copy in [files] and returns those still on storage afterwards.
@@ -62,6 +89,11 @@ private enum class SavedApkDeletion {
     /** At least one copy survived and still occupies storage. */
     Failed
 }
+
+private data class SavedApkDeletionResult(
+    val status: SavedApkDeletion,
+    val installedPackageIdentity: InstalledSavedApkIdentity = InstalledSavedApkIdentity.UNKNOWN
+)
 
 class InstalledAppRepository(
     db: AppDatabase,
@@ -209,29 +241,66 @@ class InstalledAppRepository(
             filesystem.getPatchedAppFile(packageName, installedApp.version)
         }
 
+    /**
+     * Resolves whether the package at a saved record's name is the retained export.
+     * Only archives that still match the record may prove a signature mismatch; a corrupt or stale
+     * file leaves the result unknown and therefore cannot cause the record to be discarded.
+     */
+    private fun resolveInstalledSavedApkIdentity(
+        installedApp: InstalledApp,
+        savedFiles: List<File>
+    ): InstalledSavedApkIdentity {
+        if (installedApp.installType != InstallType.SAVED) {
+            return InstalledSavedApkIdentity.UNKNOWN
+        }
+
+        val packageIsInstalled = pm.getPackageInfo(installedApp.currentPackageName) != null
+        if (!packageIsInstalled) return InstalledSavedApkIdentity.ABSENT
+
+        val installedHashes = pm.getInstalledSignatureHashes(installedApp.currentPackageName)
+        val retainedHashes = savedFiles.asSequence()
+            .filter { file ->
+                pm.readSavedApkInfo(
+                    file,
+                    installedApp.version,
+                    installedApp.currentPackageName
+                ) != null
+            }
+            .flatMap { pm.getApkFileSignatureHashes(it).asSequence() }
+            .toSet()
+
+        return installedSavedApkIdentity(
+            packageIsInstalled = true,
+            installedSignatureHashes = installedHashes,
+            retainedSignatureHashes = retainedHashes
+        )
+    }
+
     /** Deletes every retained copy this record owns and reports what became of them. */
-    private suspend fun deleteSavedPatchedApkFiles(installedApp: InstalledApp): SavedApkDeletion {
+    private suspend fun deleteSavedPatchedApkFiles(installedApp: InstalledApp): SavedApkDeletionResult {
         val savedFiles = savedPatchedApkFiles(installedApp).filter { it.exists() }
         if (savedFiles.isEmpty()) {
             Log.d(TAG, "No saved APK found for ${installedApp.currentPackageName} v${installedApp.version}")
-            return SavedApkDeletion.Nothing
+            return SavedApkDeletionResult(SavedApkDeletion.Nothing)
         }
 
+        val installedPackageIdentity = resolveInstalledSavedApkIdentity(installedApp, savedFiles)
         val survivors = deleteRetainedCopies(savedFiles)
         if (survivors.isNotEmpty()) {
             Log.w(TAG, "Patched APKs left behind: ${survivors.map { it.absolutePath }}")
-            return SavedApkDeletion.Failed
+            return SavedApkDeletionResult(SavedApkDeletion.Failed)
         }
 
         Log.d(TAG, "Deleted patched APKs for ${installedApp.currentPackageName} v${installedApp.version}")
-        return SavedApkDeletion.Deleted
+        return SavedApkDeletionResult(SavedApkDeletion.Deleted, installedPackageIdentity)
     }
 
     /**
      * Deletes retained patched APK files while preserving the records that describe an install.
-     * A saved-only record goes with its archive only when its package is not installed. Exporting
-     * records an app as [InstallType.SAVED], and installing that export later does not change the
-     * record, so an installed package must keep its tracking evidence for verification.
+     * Exporting records an app as [InstallType.SAVED], and installing that export later does not
+     * change the record. A matching installed package therefore keeps the row, while a confirmed
+     * different package does not make the saved-only record outlive its archive. An unreadable
+     * identity is preserved so a transient inspection failure cannot destroy tracking evidence.
      * A copy that survives the attempt keeps its record: the listing is built from records, so
      * dropping one would leave the file occupying storage with nothing left to remove it with.
      * Consumers are notified because this changes the evidence used to verify live installs.
@@ -243,16 +312,14 @@ class InstalledAppRepository(
             var deletedEverything = true
             val changedPackages = buildSet {
                 installedApps.forEach { installedApp ->
-                    when (deleteSavedPatchedApkFiles(installedApp)) {
+                    val deletion = deleteSavedPatchedApkFiles(installedApp)
+                    when (deletion.status) {
                         SavedApkDeletion.Nothing -> return@forEach
                         SavedApkDeletion.Failed -> deletedEverything = false
                         SavedApkDeletion.Deleted -> {
-                            val savedPackageIsInstalled =
-                                installedApp.installType == InstallType.SAVED &&
-                                        pm.getPackageInfo(installedApp.currentPackageName) != null
                             if (!outlivesRetainedPatchedApk(
                                     installedApp.installType,
-                                    savedPackageIsInstalled
+                                    deletion.installedPackageIdentity
                                 )
                             ) {
                                 dao.delete(installedApp)

--- a/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/InstalledAppRepository.kt
@@ -33,10 +33,13 @@ internal fun retainedPatchedApkOwners(
 
 /**
  * Whether the record still describes something once its retained copies are gone.
- * A saved-only record is the archive, so nothing is left to track without it.
+ * [InstallType.SAVED] records can also describe APKs installed after they were exported, so the
+ * install type alone cannot decide whether deleting the archive should forget the record.
  */
-internal fun outlivesRetainedPatchedApk(installType: InstallType) =
-    installType != InstallType.SAVED
+internal fun outlivesRetainedPatchedApk(
+    installType: InstallType,
+    packageIsInstalled: Boolean
+) = installType != InstallType.SAVED || packageIsInstalled
 
 /**
  * Deletes every retained copy in [files] and returns those still on storage afterwards.
@@ -226,7 +229,9 @@ class InstalledAppRepository(
 
     /**
      * Deletes retained patched APK files while preserving the records that describe an install.
-     * A saved-only record describes nothing once its archive is gone, so it goes with the file.
+     * A saved-only record goes with its archive only when its package is not installed. Exporting
+     * records an app as [InstallType.SAVED], and installing that export later does not change the
+     * record, so an installed package must keep its tracking evidence for verification.
      * A copy that survives the attempt keeps its record: the listing is built from records, so
      * dropping one would leave the file occupying storage with nothing left to remove it with.
      * Consumers are notified because this changes the evidence used to verify live installs.
@@ -241,10 +246,18 @@ class InstalledAppRepository(
                     when (deleteSavedPatchedApkFiles(installedApp)) {
                         SavedApkDeletion.Nothing -> return@forEach
                         SavedApkDeletion.Failed -> deletedEverything = false
-                        SavedApkDeletion.Deleted ->
-                            if (!outlivesRetainedPatchedApk(installedApp.installType)) {
+                        SavedApkDeletion.Deleted -> {
+                            val savedPackageIsInstalled =
+                                installedApp.installType == InstallType.SAVED &&
+                                        pm.getPackageInfo(installedApp.currentPackageName) != null
+                            if (!outlivesRetainedPatchedApk(
+                                    installedApp.installType,
+                                    savedPackageIsInstalled
+                                )
+                            ) {
                                 dao.delete(installedApp)
                             }
+                        }
                     }
                     add(installedApp.currentPackageName)
                     add(installedApp.originalPackageName)

--- a/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/apk/TrackedPatchStateResolverTest.kt
@@ -5,6 +5,8 @@
 
 package app.morphe.manager.domain.apk
 
+import app.morphe.manager.data.room.apps.installed.InstallType
+import app.morphe.manager.util.AOSP_INSTALLER_PACKAGE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -150,6 +152,20 @@ class TrackedPatchStateResolverTest {
             resolve(
                 installedHashes = setOf("unrecognized"),
                 installerAttributionMatches = true,
+                installedAfterPatching = true
+            )
+        )
+    }
+
+    @Test
+    fun `saved export installed through system installer remains unknown without signatures`() {
+        assertEquals(
+            InstalledPatchState.Unknown,
+            resolve(
+                installerAttributionMatches = installerAttributionMatchesRecord(
+                    InstallType.SAVED,
+                    AOSP_INSTALLER_PACKAGE
+                ),
                 installedAfterPatching = true
             )
         )

--- a/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
@@ -47,13 +47,38 @@ class RetainedPatchedApkOwnershipTest {
     }
 
     @Test
-    fun `saved-only record does not outlive its archive`() {
-        assertFalse(outlivesRetainedPatchedApk(InstallType.SAVED))
+    fun `installed saved record outlives its archive`() {
+        assertTrue(
+            outlivesRetainedPatchedApk(
+                InstallType.SAVED,
+                packageIsInstalled = true
+            )
+        )
     }
 
     @Test
-    fun `installed record outlives its archive`() {
-        assertTrue(outlivesRetainedPatchedApk(InstallType.DEFAULT))
-        assertTrue(outlivesRetainedPatchedApk(InstallType.MOUNT))
+    fun `saved-only record does not outlive its archive`() {
+        assertFalse(
+            outlivesRetainedPatchedApk(
+                InstallType.SAVED,
+                packageIsInstalled = false
+            )
+        )
+    }
+
+    @Test
+    fun `installed record types outlive their archives even while absent`() {
+        assertTrue(
+            outlivesRetainedPatchedApk(
+                InstallType.DEFAULT,
+                packageIsInstalled = false
+            )
+        )
+        assertTrue(
+            outlivesRetainedPatchedApk(
+                InstallType.MOUNT,
+                packageIsInstalled = false
+            )
+        )
     }
 }

--- a/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/repository/RetainedPatchedApkOwnershipTest.kt
@@ -22,6 +22,20 @@ class RetainedPatchedApkOwnershipTest {
         originalPackageIsTracked = originalPackageIsTracked
     )
 
+    private fun outlives(
+        installType: InstallType,
+        packageIsInstalled: Boolean,
+        installedSignatureHashes: Set<String> = setOf("patched"),
+        retainedSignatureHashes: Set<String> = setOf("patched")
+    ) = outlivesRetainedPatchedApk(
+        installType,
+        installedSavedApkIdentity(
+            packageIsInstalled,
+            installedSignatureHashes,
+            retainedSignatureHashes
+        )
+    )
+
     @Test
     fun `renamed record owns its legacy copy while no other record claims that name`() {
         assertEquals(listOf("app.morphe.youtube", "com.google.android.youtube"), owners())
@@ -47,38 +61,52 @@ class RetainedPatchedApkOwnershipTest {
     }
 
     @Test
-    fun `installed saved record outlives its archive`() {
+    fun `saved record outlives its archive when the installed package matches`() {
+        assertTrue(outlives(InstallType.SAVED, packageIsInstalled = true))
+    }
+
+    @Test
+    fun `saved record survives when installed identity cannot be read`() {
         assertTrue(
-            outlivesRetainedPatchedApk(
+            outlives(
                 InstallType.SAVED,
-                packageIsInstalled = true
+                packageIsInstalled = true,
+                installedSignatureHashes = emptySet()
+            )
+        )
+        assertTrue(
+            outlives(
+                InstallType.SAVED,
+                packageIsInstalled = true,
+                retainedSignatureHashes = emptySet()
+            )
+        )
+    }
+
+    @Test
+    fun `saved record does not outlive archive when a different package occupies its name`() {
+        assertFalse(
+            outlives(
+                InstallType.SAVED,
+                packageIsInstalled = true,
+                installedSignatureHashes = setOf("stock"),
+                retainedSignatureHashes = setOf("patched")
             )
         )
     }
 
     @Test
     fun `saved-only record does not outlive its archive`() {
-        assertFalse(
-            outlivesRetainedPatchedApk(
-                InstallType.SAVED,
-                packageIsInstalled = false
-            )
-        )
+        assertFalse(outlives(InstallType.SAVED, packageIsInstalled = false))
     }
 
     @Test
     fun `installed record types outlive their archives even while absent`() {
         assertTrue(
-            outlivesRetainedPatchedApk(
-                InstallType.DEFAULT,
-                packageIsInstalled = false
-            )
+            outlives(InstallType.DEFAULT, packageIsInstalled = false)
         )
         assertTrue(
-            outlivesRetainedPatchedApk(
-                InstallType.MOUNT,
-                packageIsInstalled = false
-            )
+            outlives(InstallType.MOUNT, packageIsInstalled = false)
         )
     }
 }


### PR DESCRIPTION
### Problem

PR #859 started deleting SAVED tracking rows when their retained APK was removed. That assumes a SAVED row can only describe an archive, but an exported APK can be installed later while its row remains SAVED. Storage cleanup then deletes the row for a live install, so Home loses the evidence needed to re-verify it and presents it as Not patched yet—or removes a universal-only card—instead of Unverified.

The rule was introduced in commit 5e58502d and landed through squash commit 3dd233a6.

### Changes

- Check whether the tracked package is installed before pruning a SAVED row.
- Preserve installed exported-app records so archive removal triggers verification and resolves to Unverified when no evidence remains.
- Continue removing SAVED rows that only described the deleted archive.
- Cover installed and archive-only SAVED records with focused regression tests.

### Validation

- ./gradlew :app:testDebugUnitTest
- git diff --check