### PR TITLE
feat: Add sliders for patch options

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Run unit tests
         env:
+          # Needed to resolve morphe-patcher from GitHub Packages, which rejects
+          # anonymous reads even for public packages
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           _JAVA_OPTIONS: "-Djava.awt.headless=true"
         run: |
           chmod +x ./gradlew

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -7,8 +7,12 @@ import kotlin.reflect.KType
 import app.morphe.patcher.patch.ColorOption as PatchColorOption
 import app.morphe.patcher.patch.FilePathOption as PatchFilePathOption
 import app.morphe.patcher.patch.FilesOption as PatchFilesOption
+import app.morphe.patcher.patch.FloatRangeOption as PatchFloatRangeOption
+import app.morphe.patcher.patch.FloatSliderOption as PatchFloatSliderOption
 import app.morphe.patcher.patch.FolderOption as PatchFolderOption
 import app.morphe.patcher.patch.ImageOption as PatchImageOption
+import app.morphe.patcher.patch.IntRangeOption as PatchIntRangeOption
+import app.morphe.patcher.patch.IntSliderOption as PatchIntSliderOption
 import app.morphe.patcher.patch.Option as PatchOption
 
 data class PatchInfo(
@@ -234,10 +238,19 @@ fun AppTarget.buildCodesOrNull(): Set<Int>? = versionCodes?.values?.toSet()?.ifE
  * (e.g. [PatchFolderOption], [PatchFilePathOption]). Null when the underlying
  * option is a plain untyped [PatchOption].
  */
-enum class ExplicitOptionKind { Folder, FilePath, Files, Image, Color }
+enum class ExplicitOptionKind {
+    Folder, FilePath, Files, Image, Color, IntSlider, FloatSlider, IntRange, FloatRange
+}
 
 /** Recommended pixel dimensions for an [ExplicitOptionKind.Image] option. */
 data class ImageSize(val width: Int, val height: Int)
+
+/**
+ * Bounds declared by a slider option, normalized so one carrier serves the integer and the
+ * floating point kinds alike. [ExplicitOptionKind] says which of the two the value is.
+ * A null [step] means the slider is continuous.
+ */
+data class SliderBounds(val min: Float, val max: Float, val step: Float?)
 
 @Immutable
 data class Option<T>(
@@ -255,6 +268,8 @@ data class Option<T>(
     val allowedExtensions: ImmutableList<String>? = null,
     /** Recommended image dimensions declared by an Image option. */
     val recommendedSize: ImageSize? = null,
+    /** Bounds declared by a slider or range option. Null for every other kind. */
+    val sliderBounds: SliderBounds? = null,
 ) {
     @Suppress("DEPRECATION")
     constructor(option: PatchOption<T>) : this(
@@ -269,15 +284,20 @@ data class Option<T>(
         explicitKind = extractExplicitKind(option),
         allowedExtensions = extractAllowedExtensions(option)?.toImmutableList(),
         recommendedSize = extractRecommendedSize(option),
+        sliderBounds = extractSliderBounds(option),
     )
 }
 
 private fun extractExplicitKind(option: PatchOption<*>): ExplicitOptionKind? = when (option) {
-    is PatchFolderOption   -> ExplicitOptionKind.Folder
-    is PatchFilePathOption -> ExplicitOptionKind.FilePath
-    is PatchFilesOption    -> ExplicitOptionKind.Files
-    is PatchImageOption    -> ExplicitOptionKind.Image
-    is PatchColorOption    -> ExplicitOptionKind.Color
+    is PatchFolderOption      -> ExplicitOptionKind.Folder
+    is PatchFilePathOption    -> ExplicitOptionKind.FilePath
+    is PatchFilesOption       -> ExplicitOptionKind.Files
+    is PatchImageOption       -> ExplicitOptionKind.Image
+    is PatchColorOption       -> ExplicitOptionKind.Color
+    is PatchIntSliderOption   -> ExplicitOptionKind.IntSlider
+    is PatchFloatSliderOption -> ExplicitOptionKind.FloatSlider
+    is PatchIntRangeOption    -> ExplicitOptionKind.IntRange
+    is PatchFloatRangeOption  -> ExplicitOptionKind.FloatRange
     else -> null
 }
 
@@ -290,5 +310,13 @@ private fun extractAllowedExtensions(option: PatchOption<*>): List<String>? = wh
 
 private fun extractRecommendedSize(option: PatchOption<*>): ImageSize? = when (option) {
     is PatchImageOption -> option.recommendedSize?.let { ImageSize(it.width, it.height) }
+    else -> null
+}
+
+private fun extractSliderBounds(option: PatchOption<*>): SliderBounds? = when (option) {
+    is PatchIntSliderOption   -> SliderBounds(option.min.toFloat(), option.max.toFloat(), option.step.toFloat())
+    is PatchFloatSliderOption -> SliderBounds(option.min, option.max, option.step)
+    is PatchIntRangeOption    -> SliderBounds(option.min.toFloat(), option.max.toFloat(), option.step.toFloat())
+    is PatchFloatRangeOption  -> SliderBounds(option.min, option.max, option.step)
     else -> null
 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchOptions.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchOptions.kt
@@ -33,13 +33,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
-import app.morphe.manager.patcher.patch.ExplicitOptionKind
-import app.morphe.manager.patcher.patch.ImageSize
-import app.morphe.manager.patcher.patch.Option
-import app.morphe.manager.patcher.patch.PatchInfo
+import app.morphe.manager.patcher.patch.*
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.*
 import kotlinx.collections.immutable.ImmutableList
+import kotlin.math.roundToInt
 
 /**
  * Represents the resolved UI kind of patch option.
@@ -65,6 +63,14 @@ private sealed interface OptionKind {
     data object IntLong         : OptionKind
     data object FloatDouble     : OptionKind
     data object ArrayDropdown   : OptionKind
+    /** Slider for a typed integer option that declares bounds. */
+    data class IntSlider(val bounds: SliderBounds)        : OptionKind
+    /** Slider for a typed decimal option that declares bounds. */
+    data class FloatSlider(val bounds: SliderBounds)      : OptionKind
+    /** Range slider for a typed integer range option. */
+    data class IntRangeSlider(val bounds: SliderBounds)   : OptionKind
+    /** Range slider for a typed decimal range option. */
+    data class FloatRangeSlider(val bounds: SliderBounds) : OptionKind
 }
 
 /**
@@ -75,13 +81,20 @@ private fun resolveOptionKind(option: Option<*>, value: Any?): OptionKind {
     // Typed options dispatch to their dedicated picker Kind. Untyped string options
     // fall through to the heuristics below and render with the classic text field.
     option.explicitKind?.let { kind ->
-        return when (kind) {
-            ExplicitOptionKind.Folder   -> OptionKind.FolderPicker
-            ExplicitOptionKind.FilePath -> OptionKind.FilePicker
-            ExplicitOptionKind.Files    -> OptionKind.StringList
-            ExplicitOptionKind.Image    -> OptionKind.Image
-            ExplicitOptionKind.Color    -> OptionKind.Color
+        val explicit = when (kind) {
+            ExplicitOptionKind.Folder      -> OptionKind.FolderPicker
+            ExplicitOptionKind.FilePath    -> OptionKind.FilePicker
+            ExplicitOptionKind.Files       -> OptionKind.StringList
+            ExplicitOptionKind.Image       -> OptionKind.Image
+            ExplicitOptionKind.Color       -> OptionKind.Color
+            // A slider cannot be drawn without bounds, so such an option falls back
+            // to the numeric field below instead of rendering as an empty track
+            ExplicitOptionKind.IntSlider   -> option.sliderBounds?.let(OptionKind::IntSlider)
+            ExplicitOptionKind.FloatSlider -> option.sliderBounds?.let(OptionKind::FloatSlider)
+            ExplicitOptionKind.IntRange    -> option.sliderBounds?.let(OptionKind::IntRangeSlider)
+            ExplicitOptionKind.FloatRange  -> option.sliderBounds?.let(OptionKind::FloatRangeSlider)
         }
+        if (explicit != null) return explicit
     }
 
     val t        = option.type.toString()
@@ -149,6 +162,16 @@ private fun resolveOptionKind(option: Option<*>, value: Any?): OptionKind {
         // Safe fallback
         else -> OptionKind.StringText
     }
+}
+
+/**
+ * A stored range option value read back as a range. Range options hold a two element list,
+ * so anything else means the value predates the option or was written by another tool.
+ */
+private fun Any?.asFloatRange(): ClosedFloatingPointRange<Float>? {
+    val pair = (this as? List<*>)?.mapNotNull { (it as? Number)?.toFloat() } ?: return null
+    if (pair.size != 2) return null
+    return minOf(pair[0], pair[1])..maxOf(pair[0], pair[1])
 }
 
 /**
@@ -227,7 +250,7 @@ internal fun PatchOptionsDialog(
                     }
                 }
 
-                when (resolveOptionKind(option, value)) {
+                when (val kind = resolveOptionKind(option, value)) {
                     OptionKind.StringList -> ListStringInputOption(
                         title = option.title,
                         description = option.description,
@@ -376,6 +399,58 @@ internal fun PatchOptionsDialog(
                         value = value?.toString() ?: "",
                         presets = option.presets ?: emptyMap(),
                         onValueChange = { onValueChange(key, it) }
+                    )
+
+                    is OptionKind.IntSlider -> SliderOptionInput(
+                        title = option.title,
+                        description = option.description,
+                        value = (value as? Number)?.toFloat() ?: kind.bounds.min,
+                        min = kind.bounds.min,
+                        max = kind.bounds.max,
+                        step = kind.bounds.step,
+                        isInteger = true,
+                        required = option.required,
+                        onValueChange = { onValueChange(key, it.roundToInt()) }
+                    )
+
+                    is OptionKind.FloatSlider -> SliderOptionInput(
+                        title = option.title,
+                        description = option.description,
+                        value = (value as? Number)?.toFloat() ?: kind.bounds.min,
+                        min = kind.bounds.min,
+                        max = kind.bounds.max,
+                        step = kind.bounds.step,
+                        isInteger = false,
+                        required = option.required,
+                        onValueChange = { onValueChange(key, it) }
+                    )
+
+                    is OptionKind.IntRangeSlider -> RangeSliderOptionInput(
+                        title = option.title,
+                        description = option.description,
+                        value = value.asFloatRange() ?: (kind.bounds.min..kind.bounds.max),
+                        min = kind.bounds.min,
+                        max = kind.bounds.max,
+                        step = kind.bounds.step,
+                        isInteger = true,
+                        required = option.required,
+                        onValueChange = { range ->
+                            onValueChange(key, listOf(range.start.roundToInt(), range.endInclusive.roundToInt()))
+                        }
+                    )
+
+                    is OptionKind.FloatRangeSlider -> RangeSliderOptionInput(
+                        title = option.title,
+                        description = option.description,
+                        value = value.asFloatRange() ?: (kind.bounds.min..kind.bounds.max),
+                        min = kind.bounds.min,
+                        max = kind.bounds.max,
+                        step = kind.bounds.step,
+                        isInteger = false,
+                        required = option.required,
+                        onValueChange = { range ->
+                            onValueChange(key, listOf(range.start, range.endInclusive))
+                        }
                     )
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
@@ -238,21 +238,10 @@ internal fun UpdateCheckIntervalDialog(
                     modifier = Modifier.fillMaxWidth()
                 )
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = stringResource(entries.first().labelResId),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
-                    Text(
-                        text = stringResource(entries.last().labelResId),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = LocalDialogSecondaryTextColor.current
-                    )
-                }
+                SliderScaleLabels(
+                    start = stringResource(entries.first().labelResId),
+                    end = stringResource(entries.last().labelResId)
+                )
             }
 
             // Battery optimization warning

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/system/ProcessRuntimeDialog.kt
@@ -112,21 +112,10 @@ fun ProcessRuntimeDialog(
                         modifier = Modifier.fillMaxWidth()
                     )
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = "$PROCESS_RUNTIME_MEMORY_MINIMUM MB",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = LocalDialogSecondaryTextColor.current
-                        )
-                        Text(
-                            text = "$maxLimit MB",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = LocalDialogSecondaryTextColor.current
-                        )
-                    }
+                    SliderScaleLabels(
+                        start = "$PROCESS_RUNTIME_MEMORY_MINIMUM MB",
+                        end = "$maxLimit MB"
+                    )
                 }
 
                 // Description

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AdaptiveIconCreatorDialog.kt
@@ -373,56 +373,16 @@ fun AdaptiveIconCreatorDialog(
 
                 // Adaptive scale slider
                 if (foregroundBitmap != null) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                    ScaleSliderRow(
+                        value = scale,
+                        onValueChange = { scale = it },
+                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE
                     ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = LocalDialogSecondaryTextColor.current
+                        SliderResetAction(
+                            visible = scale != 1f || offsetX != 0f || offsetY != 0f,
+                            contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                            onReset = { scale = 1f; offsetX = 0f; offsetY = 0f }
                         )
-                        Spacer(Modifier.width(8.dp))
-                        Slider(
-                            value = scale,
-                            onValueChange = {
-                                scale = it.coerceIn(
-                                    AdaptiveIconConfig.MIN_SCALE,
-                                    AdaptiveIconConfig.MAX_SCALE
-                                )
-                            },
-                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_SCALE,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            modifier = Modifier.size(22.dp),
-                            tint = LocalDialogSecondaryTextColor.current
-                        )
-                        // Spacer inside AnimatedVisibility so the gap also animates away
-                        AnimatedVisibility(
-                            visible = scale != 1f || offsetX != 0f || offsetY != 0f
-                        ) {
-                            Row {
-                                Spacer(Modifier.width(8.dp))
-                                IconButton(
-                                    onClick = { scale = 1f; offsetX = 0f; offsetY = 0f },
-                                    modifier = Modifier.size(40.dp)
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.RestartAlt,
-                                        contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                        modifier = Modifier.size(24.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                        }
                     }
                 }
 
@@ -445,56 +405,16 @@ fun AdaptiveIconCreatorDialog(
 
                 // Notification scale slider
                 if (foregroundBitmap != null) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                    ScaleSliderRow(
+                        value = notificationScale,
+                        onValueChange = { notificationScale = it },
+                        valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_NOTIFICATION_SCALE
                     ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = LocalDialogSecondaryTextColor.current
+                        SliderResetAction(
+                            visible = notificationScale != 1f,
+                            contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
+                            onReset = { notificationScale = 1f }
                         )
-                        Spacer(Modifier.width(8.dp))
-                        Slider(
-                            value = notificationScale,
-                            onValueChange = {
-                                notificationScale = it.coerceIn(
-                                    AdaptiveIconConfig.MIN_SCALE,
-                                    AdaptiveIconConfig.MAX_NOTIFICATION_SCALE
-                                )
-                            },
-                            valueRange = AdaptiveIconConfig.MIN_SCALE..AdaptiveIconConfig.MAX_NOTIFICATION_SCALE,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            modifier = Modifier.size(22.dp),
-                            tint = LocalDialogSecondaryTextColor.current
-                        )
-                        // Spacer inside AnimatedVisibility so the gap also animates away
-                        AnimatedVisibility(
-                            visible = notificationScale != 1f
-                        ) {
-                            Row {
-                                Spacer(Modifier.width(8.dp))
-                                IconButton(
-                                    onClick = { notificationScale = 1f },
-                                    modifier = Modifier.size(40.dp)
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.RestartAlt,
-                                        contentDescription = stringResource(R.string.adaptive_icon_reset_transform),
-                                        modifier = Modifier.size(24.dp),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                        }
                     }
                 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/HeaderCreatorDialog.kt
@@ -9,7 +9,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.*
 import android.net.Uri
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -281,47 +280,16 @@ fun HeaderCreatorDialog(
                     )
 
                     if (lightHeaderBitmap != null) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
+                        ScaleSliderRow(
+                            value = lightScale,
+                            onValueChange = { lightScale = it },
+                            valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE
                         ) {
-                            Icon(
-                                imageVector = Icons.Outlined.Image,
+                            SliderResetAction(
+                                visible = lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f,
                                 contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                onReset = { lightScale = 1f; lightOffsetX = 0f; lightOffsetY = 0f }
                             )
-                            Spacer(Modifier.width(8.dp))
-                            Slider(
-                                value = lightScale,
-                                onValueChange = { lightScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
-                                valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
-                                modifier = Modifier.weight(1f)
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            Icon(
-                                imageVector = Icons.Outlined.Image,
-                                contentDescription = null,
-                                modifier = Modifier.size(22.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            AnimatedVisibility(visible = lightScale != 1f || lightOffsetX != 0f || lightOffsetY != 0f) {
-                                Row {
-                                    Spacer(Modifier.width(8.dp))
-                                    IconButton(
-                                        onClick = { lightScale = 1f; lightOffsetX = 0f; lightOffsetY = 0f },
-                                        modifier = Modifier.size(40.dp)
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Outlined.RestartAlt,
-                                            contentDescription = null,
-                                            modifier = Modifier.size(24.dp)
-                                        )
-                                    }
-                                }
-                            }
                         }
                     }
 
@@ -362,47 +330,16 @@ fun HeaderCreatorDialog(
                 )
 
                 if (darkHeaderBitmap != null) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                    ScaleSliderRow(
+                        value = darkScale,
+                        onValueChange = { darkScale = it },
+                        valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE
                     ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
+                        SliderResetAction(
+                            visible = darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f,
                             contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            onReset = { darkScale = 1f; darkOffsetX = 0f; darkOffsetY = 0f }
                         )
-                        Spacer(Modifier.width(8.dp))
-                        Slider(
-                            value = darkScale,
-                            onValueChange = { darkScale = it.coerceIn(HeaderConfig.MIN_SCALE, HeaderConfig.MAX_SCALE) },
-                            valueRange = HeaderConfig.MIN_SCALE..HeaderConfig.MAX_SCALE,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Icon(
-                            imageVector = Icons.Outlined.Image,
-                            contentDescription = null,
-                            modifier = Modifier.size(22.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        AnimatedVisibility(visible = darkScale != 1f || darkOffsetX != 0f || darkOffsetY != 0f) {
-                            Row {
-                                Spacer(Modifier.width(8.dp))
-                                IconButton(
-                                    onClick = { darkScale = 1f; darkOffsetX = 0f; darkOffsetY = 0f },
-                                    modifier = Modifier.size(40.dp)
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Outlined.RestartAlt,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderComponents.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderComponents.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import android.view.HapticFeedbackConstants
+import android.view.View
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+import java.util.Locale
+import kotlin.math.floor
+import kotlin.math.roundToInt
+
+/**
+ * Parts shared by every slider based option editor: the value readout, the header it sits in,
+ * the scale labels and the arithmetic that keeps a value on the scale a patch declared.
+ * [SliderOptionInput] and [RangeSliderOptionInput] are built from these.
+ */
+
+/** Above this many steps the tick marks turn into visual noise, so they are dropped */
+private const val MAX_VISIBLE_TICKS = 20
+
+/**
+ * Absorbs the float error in a step count, so a scale like `0f..1f` in steps of `0.1f` still
+ * reaches its upper bound. Matches the tolerance the patcher applies when validating.
+ */
+private const val STEP_EPSILON = 1e-4f
+
+/**
+ * Snaps [value] onto the scale defined by [step] and clamps it into `[min, max]`.
+ * A null [step] means the slider is continuous, so the value is only clamped.
+ *
+ * Clamping happens in step counts rather than on the result, so an upper bound that is not
+ * itself on the scale can never produce a value the option would reject.
+ */
+fun snapSliderValue(value: Float, min: Float, max: Float, step: Float?): Float {
+    if (step == null || step <= 0f) return value.coerceIn(min, max)
+    val lastStep = floor((max - min) / step + STEP_EPSILON).toInt()
+    val steps = ((value - min) / step).roundToInt().coerceIn(0, lastStep)
+    return (min + steps * step).coerceIn(min, max)
+}
+
+/** Snaps both ends of a range and keeps them ordered. */
+internal fun snapSliderRange(
+    value: ClosedFloatingPointRange<Float>,
+    min: Float,
+    max: Float,
+    step: Float?
+): ClosedFloatingPointRange<Float> {
+    val start = snapSliderValue(value.start, min, max, step)
+    val end = snapSliderValue(value.endInclusive, min, max, step)
+    return if (start <= end) start..end else end..start
+}
+
+/** Number of decimals worth showing for a slider with the given [step]. */
+private fun decimalsFor(step: Float?): Int = when {
+    step == null -> 2
+    step >= 1f -> 0
+    step >= 0.1f -> 1
+    step >= 0.01f -> 2
+    else -> 3
+}
+
+/** Formats a slider value the way it is shown in the readout and in the input field. */
+internal fun formatSliderValue(value: Float, isInteger: Boolean, step: Float?): String =
+    if (isInteger) value.roundToInt().toString()
+    else String.format(Locale.US, "%.${decimalsFor(step)}f", value)
+
+/**
+ * Tick marks to draw, or 0 for a continuous looking track. The slider quantizes the value
+ * itself when this is not 0, which stays consistent with [snapSliderValue].
+ */
+internal fun tickCount(min: Float, max: Float, step: Float?): Int {
+    if (step == null || step <= 0f) return 0
+    val ticks = ((max - min) / step).roundToInt() - 1
+    return if (ticks in 1..MAX_VISIBLE_TICKS) ticks else 0
+}
+
+/** The tick the platform uses for a slider crossing a step */
+internal fun View.performSliderTick() = performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+
+/** Title row with the value readout pinned to the end. */
+@Composable
+fun SliderHeader(
+    title: String,
+    required: Boolean,
+    readout: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            PickerFieldHeader(title = title, required = required, isInvalid = false)
+        }
+        readout()
+    }
+}
+
+/**
+ * The current value as a pill. It grows and takes on the primary container color while the
+ * value is being changed, and opens the exact value input when tapped.
+ *
+ * The number itself is swapped without any transition. A drag walks through every step on the
+ * way to the target, and animating each swap leaves the digits smeared over each other.
+ */
+@Composable
+fun SliderValuePill(
+    label: String,
+    active: Boolean,
+    onClick: () -> Unit
+) {
+    val scale by animateFloatAsState(
+        targetValue = if (active) 1.08f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "pillScale"
+    )
+    val container by animateColorAsState(
+        targetValue = if (active) MaterialTheme.colorScheme.primaryContainer
+        else LocalDialogTextColor.current.copy(alpha = 0.06f),
+        label = "pillContainer"
+    )
+    val content by animateColorAsState(
+        targetValue = if (active) MaterialTheme.colorScheme.onPrimaryContainer
+        else LocalDialogTextColor.current,
+        label = "pillContent"
+    )
+
+    val shape = RoundedCornerShape(percent = 50)
+
+    Surface(
+        shape = shape,
+        color = container,
+        modifier = Modifier
+            .scale(scale)
+            // Clipped before the click, otherwise the ripple is drawn on the square bounds
+            .clip(shape)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = content
+            )
+
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = stringResource(R.string.patch_option_slider_edit),
+                tint = content.copy(alpha = 0.7f),
+                modifier = Modifier.size(14.dp)
+            )
+        }
+    }
+}
+
+/** Joins the two readouts of a range, so the pair reads as one value rather than two */
+@Composable
+fun SliderPairConnector() {
+    Box(
+        modifier = Modifier
+            .width(8.dp)
+            .height(1.5.dp)
+            .background(
+                color = MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(1.dp)
+            )
+    )
+}
+
+/** The two ends of the scale, shown under the track. */
+@Composable
+fun SliderScaleLabels(start: String, end: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = start,
+            style = MaterialTheme.typography.labelSmall,
+            color = LocalDialogSecondaryTextColor.current
+        )
+        Text(
+            text = end,
+            style = MaterialTheme.typography.labelSmall,
+            color = LocalDialogSecondaryTextColor.current
+        )
+    }
+}
+
+/** Option description, shown under the editor. */
+@Composable
+fun SliderDescription(description: String) {
+    if (description.isBlank()) return
+    Text(
+        text = description,
+        style = MaterialTheme.typography.bodySmall,
+        color = LocalDialogSecondaryTextColor.current
+    )
+}

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderComponents.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderComponents.kt
@@ -7,6 +7,7 @@ package app.morphe.manager.ui.screen.shared
 
 import android.view.HapticFeedbackConstants
 import android.view.View
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -17,8 +18,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.RestartAlt
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -199,6 +205,80 @@ fun SliderPairConnector() {
                 shape = RoundedCornerShape(1.dp)
             )
     )
+}
+
+/**
+ * A scale slider flanked by the same icon twice, small on the left and large on the right,
+ * which is how every "resize this image" control in the dialogs reads its range. The value is
+ * clamped into [valueRange] before it is reported.
+ *
+ * @param trailing Extra actions after the track, typically a [SliderResetAction].
+ */
+@Composable
+fun ScaleSliderRow(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    modifier: Modifier = Modifier,
+    icon: ImageVector = Icons.Outlined.Image,
+    trailing: @Composable RowScope.() -> Unit = {}
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp),
+            tint = LocalDialogSecondaryTextColor.current
+        )
+        Spacer(Modifier.width(8.dp))
+        Slider(
+            value = value,
+            onValueChange = { onValueChange(it.coerceIn(valueRange.start, valueRange.endInclusive)) },
+            valueRange = valueRange,
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(Modifier.width(8.dp))
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(22.dp),
+            tint = LocalDialogSecondaryTextColor.current
+        )
+        trailing()
+    }
+}
+
+/**
+ * Reset button that appears next to a [ScaleSliderRow] once the transform moved away from its
+ * default. The spacer sits inside the animation so the gap collapses with the button.
+ */
+@Composable
+fun RowScope.SliderResetAction(
+    visible: Boolean,
+    contentDescription: String?,
+    onReset: () -> Unit
+) {
+    AnimatedVisibility(visible = visible) {
+        Row {
+            Spacer(Modifier.width(8.dp))
+            IconButton(
+                onClick = onReset,
+                modifier = Modifier.size(40.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.RestartAlt,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(24.dp),
+                    tint = LocalDialogTextColor.current
+                )
+            }
+        }
+    }
 }
 
 /** The two ends of the scale, shown under the track. */

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderOptionInput.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SliderOptionInput.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import app.morphe.manager.R
+
+/**
+ * A single value slider for a patch option declared with bounds, for example
+ * `intSliderOption` or `floatSliderOption` in the patcher.
+ *
+ * The readout doubles as the button that reveals a text field, because a slider alone
+ * cannot comfortably hit an exact value on a wide range.
+ *
+ * @param value The current value, already clamped into `[min, max]` by the caller.
+ * @param isInteger Whether the value is shown and reported without decimals.
+ * @param onValueChange Called once the user lets go of the thumb or leaves the input field,
+ *   never on every pixel of a drag.
+ */
+@Composable
+fun SliderOptionInput(
+    title: String,
+    description: String,
+    value: Float,
+    min: Float,
+    max: Float,
+    step: Float?,
+    isInteger: Boolean,
+    required: Boolean = false,
+    onValueChange: (Float) -> Unit
+) {
+    val view = LocalView.current
+    var dragging by remember { mutableStateOf(false) }
+    var editing by rememberSaveable { mutableStateOf(false) }
+    var position by remember { mutableFloatStateOf(snapSliderValue(value, min, max, step)) }
+
+    // Follow the value when something else changes it, such as the reset action
+    LaunchedEffect(value) {
+        if (!dragging) position = snapSliderValue(value, min, max, step)
+    }
+
+    // A drag stays glued to the finger, only changes from elsewhere glide into place
+    val glidingPosition by animateFloatAsState(
+        targetValue = position,
+        animationSpec = if (dragging) snap() else spring(
+            dampingRatio = Spring.DampingRatioNoBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "sliderPosition"
+    )
+
+    SliderOptionFrame(
+        title = title,
+        description = description,
+        required = required,
+        min = min,
+        max = max,
+        step = step,
+        isInteger = isInteger,
+        editing = editing,
+        readout = {
+            SliderValuePill(
+                label = formatSliderValue(position, isInteger, step),
+                active = dragging || editing,
+                onClick = { editing = !editing }
+            )
+        },
+        input = {
+            SliderTextInput(
+                value = position,
+                min = min,
+                max = max,
+                step = step,
+                isInteger = isInteger,
+                onCommit = {
+                    position = it
+                    onValueChange(it)
+                }
+            )
+        }
+    ) {
+        Slider(
+            value = if (dragging) position else glidingPosition,
+            onValueChange = { raw ->
+                dragging = true
+                val snapped = snapSliderValue(raw, min, max, step)
+                if (snapped != position) {
+                    position = snapped
+                    if (step != null) view.performSliderTick()
+                }
+            },
+            onValueChangeFinished = {
+                dragging = false
+                onValueChange(position)
+            },
+            valueRange = min..max,
+            steps = tickCount(min, max, step),
+            colors = SliderDefaults.colors(),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+/**
+ * A two thumb slider for a patch option declared as a range, for example `intRangeOption`
+ * or `floatRangeOption` in the patcher.
+ *
+ * @param value The current range, already clamped into `[min, max]` by the caller.
+ * @param onValueChange Called with the ordered pair once the user lets go of a thumb or
+ *   leaves one of the input fields.
+ */
+@Composable
+fun RangeSliderOptionInput(
+    title: String,
+    description: String,
+    value: ClosedFloatingPointRange<Float>,
+    min: Float,
+    max: Float,
+    step: Float?,
+    isInteger: Boolean,
+    required: Boolean = false,
+    onValueChange: (ClosedFloatingPointRange<Float>) -> Unit
+) {
+    val view = LocalView.current
+    var dragging by remember { mutableStateOf(false) }
+    var editing by rememberSaveable { mutableStateOf(false) }
+    var position by remember { mutableStateOf(snapSliderRange(value, min, max, step)) }
+
+    LaunchedEffect(value) {
+        if (!dragging) position = snapSliderRange(value, min, max, step)
+    }
+
+    SliderOptionFrame(
+        title = title,
+        description = description,
+        required = required,
+        min = min,
+        max = max,
+        step = step,
+        isInteger = isInteger,
+        editing = editing,
+        readout = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SliderValuePill(
+                    label = formatSliderValue(position.start, isInteger, step),
+                    active = dragging || editing,
+                    onClick = { editing = !editing }
+                )
+                SliderPairConnector()
+                SliderValuePill(
+                    label = formatSliderValue(position.endInclusive, isInteger, step),
+                    active = dragging || editing,
+                    onClick = { editing = !editing }
+                )
+            }
+        },
+        input = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall)
+            ) {
+                SliderTextInput(
+                    value = position.start,
+                    min = min,
+                    max = position.endInclusive,
+                    step = step,
+                    isInteger = isInteger,
+                    label = stringResource(R.string.patch_option_slider_range_start),
+                    modifier = Modifier.weight(1f),
+                    onCommit = {
+                        position = it..position.endInclusive
+                        onValueChange(position)
+                    }
+                )
+                SliderTextInput(
+                    value = position.endInclusive,
+                    min = position.start,
+                    max = max,
+                    step = step,
+                    isInteger = isInteger,
+                    label = stringResource(R.string.patch_option_slider_range_end),
+                    modifier = Modifier.weight(1f),
+                    onCommit = {
+                        position = position.start..it
+                        onValueChange(position)
+                    }
+                )
+            }
+        }
+    ) {
+        RangeSlider(
+            value = position,
+            onValueChange = { raw ->
+                dragging = true
+                val snapped = snapSliderRange(raw, min, max, step)
+                if (snapped != position) {
+                    position = snapped
+                    if (step != null) view.performSliderTick()
+                }
+            },
+            onValueChangeFinished = {
+                dragging = false
+                onValueChange(position)
+            },
+            valueRange = min..max,
+            steps = tickCount(min, max, step),
+            colors = SliderDefaults.colors(),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+/**
+ * Everything around the track, which is the same whether the option holds one value or two:
+ * the title with its readout, the scale labels, the exact value input and the description.
+ */
+@Composable
+private fun SliderOptionFrame(
+    title: String,
+    description: String,
+    required: Boolean,
+    min: Float,
+    max: Float,
+    step: Float?,
+    isInteger: Boolean,
+    editing: Boolean,
+    readout: @Composable () -> Unit,
+    input: @Composable () -> Unit,
+    slider: @Composable () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall)
+    ) {
+        SliderHeader(title = title, required = required, readout = readout)
+
+        slider()
+
+        SliderScaleLabels(
+            start = formatSliderValue(min, isInteger, step),
+            end = formatSliderValue(max, isInteger, step)
+        )
+
+        AnimatedVisibility(
+            visible = editing,
+            enter = Animations.expandFadeEnter,
+            exit = Animations.shrinkFadeExit
+        ) {
+            input()
+        }
+
+        SliderDescription(description)
+    }
+}
+
+/**
+ * Exact value input for a slider. What is typed is only reported once the field is left or
+ * the keyboard action is confirmed, so a half typed number is never clamped away mid keystroke.
+ * While the field is not focused it keeps following the thumb.
+ */
+@Composable
+private fun SliderTextInput(
+    value: Float,
+    min: Float,
+    max: Float,
+    step: Float?,
+    isInteger: Boolean,
+    modifier: Modifier = Modifier,
+    label: String? = null,
+    onCommit: (Float) -> Unit
+) {
+    var text by remember { mutableStateOf(formatSliderValue(value, isInteger, step)) }
+    var focused by remember { mutableStateOf(false) }
+    val parsed = text.toFloatOrNull()
+    val isInvalid = parsed == null || parsed < min || parsed > max
+
+    LaunchedEffect(value) {
+        if (!focused) text = formatSliderValue(value, isInteger, step)
+    }
+
+    fun commit() {
+        val snapped = snapSliderValue(parsed ?: value, min, max, step)
+        text = formatSliderValue(snapped, isInteger, step)
+        onCommit(snapped)
+    }
+
+    AppDialogTextField(
+        modifier = modifier.onFocusChanged { state ->
+            val wasFocused = focused
+            focused = state.isFocused
+            if (wasFocused && !state.isFocused) commit()
+        },
+        value = text,
+        onValueChange = { text = it },
+        label = label?.let { { Text(it) } },
+        placeholder = {
+            Text(
+                stringResource(
+                    if (isInteger) R.string.patch_option_enter_number
+                    else R.string.patch_option_enter_decimal
+                )
+            )
+        },
+        isError = isInvalid,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = if (isInteger) KeyboardType.Number else KeyboardType.Decimal,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(onDone = { commit() })
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -319,6 +319,9 @@ For the best results, this app recommends patching a &lt;b&gt;full APK&lt;/b&gt;
     <string name="patch_option_enter_value">Enter value</string>
     <string name="patch_option_enter_number">Enter number</string>
     <string name="patch_option_enter_decimal">Enter decimal</string>
+    <string name="patch_option_slider_edit">Enter an exact value</string>
+    <string name="patch_option_slider_range_start">From</string>
+    <string name="patch_option_slider_range_end">To</string>
     <string name="patch_option_list_duplicate">This value already exists</string>
     <string name="patch_option_list_empty">Value cannot be empty</string>
     <string name="patch_option_list_empty_state">No values added yet</string>

--- a/app/src/test/java/app/morphe/manager/ui/screen/shared/SliderOptionInputTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/screen/shared/SliderOptionInputTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.shared
+
+import kotlin.math.abs
+import kotlin.math.round
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The snapping the slider applies before a value is written back. It has to agree with the
+ * bound check the patcher runs, otherwise a value the user just picked is rejected on patching.
+ */
+class SliderOptionInputTest {
+    @Test
+    fun `values are clamped into the bounds`() {
+        assertEquals(0f, snapSliderValue(-10f, min = 0f, max = 100f, step = 1f))
+        assertEquals(100f, snapSliderValue(140f, min = 0f, max = 100f, step = 1f))
+    }
+
+    @Test
+    fun `values are snapped onto the step scale`() {
+        assertEquals(35f, snapSliderValue(33.4f, min = 0f, max = 100f, step = 5f))
+        assertEquals(30f, snapSliderValue(32.4f, min = 0f, max = 100f, step = 5f))
+    }
+
+    @Test
+    fun `the scale starts at the lower bound, not at zero`() {
+        // min 3 with a step of 5 accepts 3, 8, 13 and so on
+        assertEquals(8f, snapSliderValue(9f, min = 3f, max = 23f, step = 5f))
+        assertEquals(13f, snapSliderValue(11f, min = 3f, max = 23f, step = 5f))
+    }
+
+    @Test
+    fun `snapping stays on the scale when the upper bound is not on it`() {
+        // 10 is not reachable from 0 in steps of 3, so the last reachable value wins
+        assertEquals(9f, snapSliderValue(11f, min = 0f, max = 10f, step = 3f))
+        assertEquals(9f, snapSliderValue(10f, min = 0f, max = 10f, step = 3f))
+    }
+
+    @Test
+    fun `the upper bound stays reachable on a decimal scale`() {
+        assertEquals(1f, snapSliderValue(1f, min = 0f, max = 1f, step = 0.1f))
+    }
+
+    @Test
+    fun `a continuous slider only clamps`() {
+        assertEquals(1.234f, snapSliderValue(1.234f, min = 0f, max = 2f, step = null))
+        assertEquals(2f, snapSliderValue(9f, min = 0f, max = 2f, step = null))
+    }
+
+    @Test
+    fun `a decimal step lands close enough for the patcher to accept it`() {
+        val value = snapSliderValue(0.71f, min = 0f, max = 1f, step = 0.1f)
+        val stepsFromMin = value / 0.1f
+        // The patcher accepts a deviation of up to one ten thousandth of a step
+        assertTrue(
+            abs(stepsFromMin - round(stepsFromMin)) <= 1e-4f,
+            "snapped value $value is off the 0.1 scale"
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ markdown-renderer = "0.43.0"
 # Remove when released stable 1.5.0 in Compose BOM. Fix for https://github.com/MorpheApp/morphe-manager/issues/74
 material3 = "1.5.0-alpha25" # 1.5.0-alpha09 API Changes: Remove deprecated experimental ModalBottomSheet
 morphe-library = "1.4.0"
-morphe-patcher = "1.8.0"
+morphe-patcher = "1.9.0-dev.1" # Change to stable
 navigation = "2.9.8"
 placeholder = "2.0.0"
 play-services-base = "18.10.0"


### PR DESCRIPTION
## Summary

Adds slider and range editing for numeric patch options, so patch authors can declare bounds users cannot leave, and users get an exact value instead of a free-form number field.

Four typed options are introduced in the patcher: `intSliderOption`, `floatSliderOption`, `intRangeOption` and `floatRangeOption`. They follow the existing typed option pattern (`FolderOption`, `ImageOption`, `ColorOption`): the subclass carries a UI hint, while the stored value stays a plain `Int`, `Float` or a two element list. Nothing in the storage, import/export or CLI paths needed changing.

The bounds are enforced by the option itself rather than by the editor, so a value coming from the CLI or an options file is rejected the same way as one picked in the manager. Impossible declarations (min above max, non-positive step, unreachable max, out of range default) fail while the bundle is loading.

## Compatibility

Backward compatible: bundles that use plain `intOption` keep rendering as a numeric field. Bundles built against the new patcher declare the required patcher version, so an older manager reports "update the manager" instead of a linkage error.

Closes #823
Depends on https://github.com/MorpheApp/morphe-patcher/pull/172
___
![Screenshot_2026-08-16-01-14-32-681_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/116c09b0-f42e-4827-8adf-8e0a51d5e730)
![Screenshot_2026-08-16-01-14-51-072_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/671a8083-d512-4558-81f4-ba32bd431d0b)
![Screenshot_2026-08-16-01-15-03-211_app.morphe.manager.debug-edit.jpg](https://github.com/user-attachments/assets/415b6a3f-6c00-4837-a57d-1cae3713d63a)