### PR TITLE
fix: Honor a non default port in remote bundle URLs

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -26,6 +26,7 @@ import app.morphe.manager.ui.viewmodel.BundleSnapshot
 import app.morphe.manager.util.*
 import io.ktor.client.plugins.ResponseException
 import io.ktor.http.Url
+import io.ktor.http.hostWithPortIfSpecified
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentMapOf
@@ -1332,15 +1333,6 @@ class PatchBundleRepository(
         val host = parsed.host
         val pathSegments = parsed.encodedPath.trim('/').split('/').filter { it.isNotBlank() }
 
-        // Host including a non default port, so that bundles served on a custom port
-        // remain reachable. Only used for arbitrary hosts: the GitHub and GitLab
-        // branches below rewrite to fixed hosts where a port is never meaningful.
-        val authority = if (parsed.port == parsed.protocol.defaultPort) {
-            host
-        } else {
-            "$host:${parsed.port}"
-        }
-
         // Handle GitHub repository URLs
         if (host.equals("github.com", ignoreCase = true)) {
             if (pathSegments.size < 2) {
@@ -1474,7 +1466,9 @@ class PatchBundleRepository(
         }
 
         val query = parsed.encodedQuery.takeIf { it.isNotEmpty() }?.let { "?$it" }.orEmpty()
-        return "https://$authority$normalizedPath$query"
+        // Rebuilt from the host and port rather than the host alone, so that a bundle served on a
+        // custom port is not silently requested on the protocol default one
+        return "https://${parsed.hostWithPortIfSpecified}$normalizedPath$query"
     }
 
     /** Returns true if [uid] corresponds to a currently loaded bundle. */

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -1332,6 +1332,15 @@ class PatchBundleRepository(
         val host = parsed.host
         val pathSegments = parsed.encodedPath.trim('/').split('/').filter { it.isNotBlank() }
 
+        // Host including a non default port, so that bundles served on a custom port
+        // remain reachable. Only used for arbitrary hosts: the GitHub and GitLab
+        // branches below rewrite to fixed hosts where a port is never meaningful.
+        val authority = if (parsed.port == parsed.protocol.defaultPort) {
+            host
+        } else {
+            "$host:${parsed.port}"
+        }
+
         // Handle GitHub repository URLs
         if (host.equals("github.com", ignoreCase = true)) {
             if (pathSegments.size < 2) {
@@ -1465,7 +1474,7 @@ class PatchBundleRepository(
         }
 
         val query = parsed.encodedQuery.takeIf { it.isNotEmpty() }?.let { "?$it" }.orEmpty()
-        return "https://$host$normalizedPath$query"
+        return "https://$authority$normalizedPath$query"
     }
 
     /** Returns true if [uid] corresponds to a currently loaded bundle. */


### PR DESCRIPTION
## Problem

A remote patch source whose URL has an explicit port silently loses it.

`PatchBundleRepository.normalizeRemoteBundleUrl` rebuilds the URL for arbitrary hosts as:

```kotlin
return "https://$host$normalizedPath$query"
```

`Url.host` does not include the port, so

```
https://example.com:57158/patches-bundle.json
```

is requested as

```
https://example.com/patches-bundle.json
```

## Why it is awkward to diagnose

Nothing in the UI points at the cause:

- the URL passes validation and the source is added ("2 sources installed");
- the source then sits as **Unnamed** with no error shown;
- the server never receives a request, so it looks like Manager is not fetching at all.

It surfaces only in the log, as a timeout against a URL the user never typed:

```
HttpService.request: Connecting to URL: https://example.com/patches-bundle.json
request failed after 3 attempts: ConnectTimeoutException ...
Caused by: java.net.SocketTimeoutException: failed to connect to example.com/… (port 443)
Failed to update bundle Unnamed (HTTP null)
```

## Change

Append the port when it differs from the protocol default, and use that when
rebuilding the URL for arbitrary hosts.

Deliberately limited in scope:

- only the arbitrary host branch is touched. The GitHub and GitLab branches rewrite to
  fixed hosts (`raw.githubusercontent.com`, `gitlab.com`) where a port is never
  meaningful, so they are left alone;
- URLs on a default port are unaffected, since the port is only appended when it
  differs from `protocol.defaultPort`;
- the scheme is still normalised to https, unchanged from before.

## Verification

Built and installed on a device, against a bundle served over HTTPS on port 57158.

Before, the server receives nothing and the source stays "Unnamed". After, both
requests arrive on the correct port and the bundle loads with its version displayed:

```
"GET /patches-bundle.json HTTP/2.0" 200 244    "Morphe-Manager/…"
"GET /rutube-patches.mpp   HTTP/2.0" 200 657956 "Morphe-Manager/…"
```

I did not add a test: the module has no `src/test` source set, and adding test
infrastructure seemed out of scope for this fix. Happy to add one if you would like it,
`normalizeRemoteBundleUrl` is straightforward to cover.
