### PR TITLE
fix: Dialog status bar stays all white in light theme

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
@@ -132,16 +132,7 @@ fun AppDialog(
             decorFitsSystemWindows = false
         )
     ) {
-        // Remove standard system backgrounds/window shadows
-        val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
-        SideEffect {
-            dialogWindow?.let {
-                it.setDimAmount(0f)
-                it.setBackgroundDrawableResource(android.R.color.transparent)
-                WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightStatusBars = !isDarkTheme
-                WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightNavigationBars = !isDarkTheme
-            }
-        }
+        DialogWindowEffect(isDarkTheme)
 
         Box(
             modifier = Modifier
@@ -179,6 +170,30 @@ fun AppDialog(
 }
 
 /**
+ * Strips a dialog window down to its content and points the system bars at [isDarkTheme].
+ *
+ * A dialog gets a window of its own, with an insets controller of its own, so what the activity
+ * set in its theme never reaches it. Left alone, the bar icons keep the platform default and go
+ * invisible against a light dialog.
+ */
+@Composable
+private fun DialogWindowEffect(isDarkTheme: Boolean) {
+    val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
+
+    SideEffect {
+        dialogWindow?.let {
+            // Remove standard system backgrounds/window shadows
+            it.setDimAmount(0f)
+            it.setBackgroundDrawableResource(android.R.color.transparent)
+
+            val insets = WindowCompat.getInsetsController(it, it.decorView)
+            insets.isAppearanceLightStatusBars = !isDarkTheme
+            insets.isAppearanceLightNavigationBars = !isDarkTheme
+        }
+    }
+}
+
+/**
  * Fullscreen semi-transparent overlay dialog. Blocks all interaction behind it.
  * Handles its own fade enter/exit animation via [Animations].
  */
@@ -188,6 +203,10 @@ fun Overlay(
     backgroundAlpha: Float = 0.75f,
     content: @Composable BoxScope.() -> Unit
 ) {
+    // Drawn over the theme background, so the bars read against the same thing an AppDialog gives
+    // them even though this one lets some of the screen behind show through
+    val isDarkTheme = MaterialTheme.colorScheme.background.isDarkBackground()
+
     AnimatedVisibility(
         visible = visible,
         enter = Animations.overlayEnter,
@@ -202,13 +221,8 @@ fun Overlay(
                 decorFitsSystemWindows = false
             )
         ) {
-            val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
-            SideEffect {
-                dialogWindow?.let {
-                    it.setDimAmount(0f)
-                    it.setBackgroundDrawableResource(android.R.color.transparent)
-                }
-            }
+            DialogWindowEffect(isDarkTheme)
+
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/AppDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
 import app.morphe.manager.util.isDarkBackground
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -137,6 +138,8 @@ fun AppDialog(
             dialogWindow?.let {
                 it.setDimAmount(0f)
                 it.setBackgroundDrawableResource(android.R.color.transparent)
+                WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightStatusBars = !isDarkTheme
+                WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightNavigationBars = !isDarkTheme
             }
         }
 


### PR DESCRIPTION
## Problem

**Before**

<div>
  <img src="https://github.com/user-attachments/assets/246ed584-2cb0-4ff2-ad6b-8ba60ac23a77" alt="Dialog status bar stays all white in light theme" width="300">
  <img src="https://github.com/user-attachments/assets/0cb96647-b98c-4776-83d1-6b3692ef01a9" alt="Dialog status bar stays all white in light theme (2)" width="300">
</div>

**After**

<img src="https://github.com/user-attachments/assets/7fa85072-96b5-4af2-a7cf-d44eb6bcdc67" alt="Dialog status bar after the fix" width="300">

`AppDialog` (app details, confirmations, pickers) runs in its own dialog window. That window's status/navigation bar icon appearance was never set, so the icons kept following the app theme's default and stayed **white even in light theme**, where the dialog background is light — making them nearly invisible.

## Fix

Mirror the activity-level behavior in `Theme.kt:156-157` for the dialog window:

```kotlin
WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightStatusBars = !isDarkTheme
WindowCompat.getInsetsController(it, it.decorView).isAppearanceLightNavigationBars = !isDarkTheme
```

Added inside the existing `SideEffect` in `AppDialog.kt` where the dialog window is already configured (dim, transparent background). Icons are now black in light theme and white in dark theme, matching the activity.

## Test plan

- Light theme: open a dialog (e.g. app details) → status/nav bar icons are black
- Dark theme: same dialogs → icons stay white
