### PR TITLE
feat: Add per-bundle issue reporting, pre-release warnings, and home screen improvements

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/bundles/PatchBundleSource.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/PatchBundleSource.kt
@@ -130,6 +130,14 @@ sealed class PatchBundleSource(
         val PatchBundleSource.isDefault inline get() = uid == 0
         val PatchBundleSource.asRemoteOrNull inline get() = this as? RemotePatchBundle
 
+        /**
+         * True while the source is set to fetch pre-release builds. Only the two remote kinds
+         * carry the flag, so anything else can never be on a pre-release branch.
+         */
+        val PatchBundleSource.usesPrerelease: Boolean
+            get() = (this as? JsonPatchBundle)?.usePrerelease == true ||
+                    (this as? APIPatchBundle)?.usePrerelease == true
+
         /** Classifies a [PatchBundleSource] into its user-visible type. */
         val PatchBundleSource.sourceType: BundleSourceType get() = when {
             isDefault -> BundleSourceType.PreInstalled

--- a/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
@@ -155,6 +155,15 @@ sealed class RemotePatchBundle(
         get() = inferPageUrlFromEndpoint(endpoint) ?: manifestPageUrl ?: endpoint
 
     /**
+     * Where the "report an issue" action takes the user: the repository's issues page.
+     *
+     * Derived from [browsePageUrl] (GitHub: /issues, GitLab: /-/issues). Hosts other than
+     * GitHub and GitLab have no known issues layout, so those fall back to [browsePageUrl].
+     */
+    open val issuesPageUrl: String
+        get() = inferIssuesUrlFromEndpoint(endpoint) ?: browsePageUrl
+
+    /**
      * Shared cache logic for [fetchChangelogEntries] and its overrides.
      */
     protected suspend fun fetchAndCacheEntries(
@@ -252,6 +261,19 @@ sealed class RemotePatchBundle(
                 }
             } catch (_: Exception) {
                 null
+            }
+        }
+
+        /**
+         * Infer the issues page URL from various endpoint formats.
+         * Returns null for hosts other than GitHub and GitLab, whose issues layout is unknown.
+         */
+        fun inferIssuesUrlFromEndpoint(endpoint: String): String? {
+            val repoUrl = inferPageUrlFromEndpoint(endpoint) ?: return null
+            return when {
+                repoUrl.startsWith("https://github.com/") -> "$repoUrl/issues"
+                repoUrl.startsWith("https://gitlab.com/") -> "$repoUrl/-/issues"
+                else -> null
             }
         }
     }
@@ -501,6 +523,8 @@ class APIPatchBundle(
 
     // The endpoint is the API identifier rather than a browsable URL
     override val browsePageUrl: String get() = SOURCE_REPO_URL
+
+    override val issuesPageUrl: String get() = "$SOURCE_REPO_URL/issues"
 
     override suspend fun fetchChangelogEntries(sinceVersion: String?): List<ChangelogEntry> {
         val branch = if (usePrerelease) BRANCH_DEV else BRANCH_STABLE

--- a/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/RemotePatchBundle.kt
@@ -157,11 +157,14 @@ sealed class RemotePatchBundle(
     /**
      * Where the "report an issue" action takes the user: the repository's issues page.
      *
-     * Derived from [browsePageUrl] (GitHub: /issues, GitLab: /-/issues). Hosts other than
-     * GitHub and GitLab have no known issues layout, so those fall back to [browsePageUrl].
+     * Follows the same order as [browsePageUrl] and appends the host's issues path
+     * (GitHub: /issues, GitLab: /-/issues). Hosts other than GitHub and GitLab have no known
+     * issues layout, so those land on the browse page instead of a guessed path.
      */
     open val issuesPageUrl: String
-        get() = inferIssuesUrlFromEndpoint(endpoint) ?: browsePageUrl
+        get() = inferIssuesUrlFromEndpoint(endpoint)
+            ?: manifestPageUrl?.let { issuesUrlForRepoUrl(it) }
+            ?: browsePageUrl
 
     /**
      * Shared cache logic for [fetchChangelogEntries] and its overrides.
@@ -268,13 +271,14 @@ sealed class RemotePatchBundle(
          * Infer the issues page URL from various endpoint formats.
          * Returns null for hosts other than GitHub and GitLab, whose issues layout is unknown.
          */
-        fun inferIssuesUrlFromEndpoint(endpoint: String): String? {
-            val repoUrl = inferPageUrlFromEndpoint(endpoint) ?: return null
-            return when {
-                repoUrl.startsWith("https://github.com/") -> "$repoUrl/issues"
-                repoUrl.startsWith("https://gitlab.com/") -> "$repoUrl/-/issues"
-                else -> null
-            }
+        fun inferIssuesUrlFromEndpoint(endpoint: String): String? =
+            inferPageUrlFromEndpoint(endpoint)?.let { issuesUrlForRepoUrl(it) }
+
+        /** Appends the host's issues path to an already resolved repository URL. */
+        fun issuesUrlForRepoUrl(repoUrl: String): String? = when {
+            repoUrl.startsWith("https://github.com/") -> "$repoUrl/issues"
+            repoUrl.startsWith("https://gitlab.com/") -> "$repoUrl/-/issues"
+            else -> null
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/HomeAppSortMode.kt
@@ -16,7 +16,8 @@ enum class HomeAppSortMode(
     RECOMMENDED(R.string.home_app_sort_recommended, R.string.home_app_sort_recommended_description),
     NAME_ASC(R.string.file_picker_sort_name_asc, R.string.home_app_sort_name_asc_description),
     NAME_DESC(R.string.file_picker_sort_name_desc, R.string.home_app_sort_name_desc_description),
-    UPDATES_FIRST(R.string.home_app_sort_updates_first, R.string.home_app_sort_updates_first_description);
+    UPDATES_FIRST(R.string.home_app_sort_updates_first, R.string.home_app_sort_updates_first_description),
+    RECENTLY_PATCHED(R.string.home_app_sort_recently_patched, R.string.home_app_sort_recently_patched_description);
 
     companion object {
         fun fromPreference(value: String?): HomeAppSortMode =

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -35,7 +35,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.batch.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.usesPrerelease
-import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.screen.home.*
@@ -189,10 +188,6 @@ fun BatchPatcherScreen(
             savedPatches = edit.savedSelection,
             lockStateOf = edit::lockStateOf,
             holdsUniversalPatches = edit::selectAllHoldsUniversal,
-            bundleIssueUrls = allPatchesInfo.mapNotNull { (bundle, _) ->
-                (sourcesByUid[bundle.uid] as? RemotePatchBundle)?.issuesPageUrl
-                    ?.let { bundle.uid to it }
-            }.toMap(),
             prereleaseBundleUids = allPatchesInfo.mapNotNull { (bundle, _) ->
                 bundle.uid.takeIf { sourcesByUid[it]?.usesPrerelease == true }
             }.toSet(),

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.batch.*
+import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.ui.screen.home.*
@@ -183,6 +184,12 @@ fun BatchPatcherScreen(
             savedPatches = edit.savedSelection,
             lockStateOf = edit::lockStateOf,
             holdsUniversalPatches = edit::selectAllHoldsUniversal,
+            bundleIssueUrls = remember(edit.allPatchesInfo) {
+                val sources = patchBundleRepository.sources.value.associateBy { it.uid }
+                edit.allPatchesInfo.mapNotNull { (bundle, _) ->
+                    (sources[bundle.uid] as? RemotePatchBundle)?.issuesPageUrl?.let { bundle.uid to it }
+                }.toMap()
+            },
             proceedText = stringResource(R.string.save),
             // The queue combines sources by design, and the tabs make it plain enough
             warnOnMultipleBundles = false,

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -34,8 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.batch.*
-import app.morphe.manager.domain.bundles.APIPatchBundle
-import app.morphe.manager.domain.bundles.JsonPatchBundle
+import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.usesPrerelease
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
@@ -164,12 +163,16 @@ fun BatchPatcherScreen(
     // The same dialog the single-app flow uses, pointed at one queued app instead of the
     // patcher, so the queue never has to grow a second patch list
     viewModel.edit?.let { edit ->
+        // Reading the property re-walks and re-sorts every bundle's patches, so it is taken once
+        val allPatchesInfo = edit.allPatchesInfo
+        val sources by patchBundleRepository.sources.collectAsStateWithLifecycle()
+        val sourcesByUid = remember(sources) { sources.associateBy { it.uid } }
         ExpertModeDialog(
             newPatches = edit.newPatches,
             options = edit.options,
-            allPatchesInfo = edit.allPatchesInfo,
+            allPatchesInfo = allPatchesInfo,
             totalSelectedCount = edit.totalSelectedCount,
-            totalPatchesCount = edit.totalPatchesCount,
+            totalPatchesCount = allPatchesInfo.sumOf { (_, patches) -> patches.size },
             hasMultipleBundles = edit.hasMultipleBundles,
             patchActions = ExpertPatchActions(
                 onPatchToggle = edit::togglePatch,
@@ -186,21 +189,13 @@ fun BatchPatcherScreen(
             savedPatches = edit.savedSelection,
             lockStateOf = edit::lockStateOf,
             holdsUniversalPatches = edit::selectAllHoldsUniversal,
-            bundleIssueUrls = remember(edit.allPatchesInfo) {
-                val sources = patchBundleRepository.sources.value.associateBy { it.uid }
-                edit.allPatchesInfo.mapNotNull { (bundle, _) ->
-                    (sources[bundle.uid] as? RemotePatchBundle)?.issuesPageUrl?.let { bundle.uid to it }
-                }.toMap()
-            },
-            prereleaseBundleUids = remember(edit.allPatchesInfo) {
-                val sources = patchBundleRepository.sources.value.associateBy { it.uid }
-                edit.allPatchesInfo.mapNotNull { (bundle, _) ->
-                    val source = sources[bundle.uid]
-                    val isPrerelease = (source as? APIPatchBundle)?.usePrerelease == true ||
-                            (source as? JsonPatchBundle)?.usePrerelease == true
-                    if (isPrerelease) bundle.uid else null
-                }.toSet()
-            },
+            bundleIssueUrls = allPatchesInfo.mapNotNull { (bundle, _) ->
+                (sourcesByUid[bundle.uid] as? RemotePatchBundle)?.issuesPageUrl
+                    ?.let { bundle.uid to it }
+            }.toMap(),
+            prereleaseBundleUids = allPatchesInfo.mapNotNull { (bundle, _) ->
+                bundle.uid.takeIf { sourcesByUid[it]?.usesPrerelease == true }
+            }.toSet(),
             proceedText = stringResource(R.string.save),
             // The queue combines sources by design, and the tabs make it plain enough
             warnOnMultipleBundles = false,

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -734,7 +734,7 @@ private fun BatchItemCard(
                         }
                     }
 
-                    // The install's own package, which is what tells clones of one app apart
+                    // This entry's own package, which is what tells clones of one app apart
                     Text(
                         text = item.id,
                         style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/BatchPatcherScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.batch.*
+import app.morphe.manager.domain.bundles.APIPatchBundle
+import app.morphe.manager.domain.bundles.JsonPatchBundle
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.repository.PatchBundleRepository
@@ -189,6 +191,15 @@ fun BatchPatcherScreen(
                 edit.allPatchesInfo.mapNotNull { (bundle, _) ->
                     (sources[bundle.uid] as? RemotePatchBundle)?.issuesPageUrl?.let { bundle.uid to it }
                 }.toMap()
+            },
+            prereleaseBundleUids = remember(edit.allPatchesInfo) {
+                val sources = patchBundleRepository.sources.value.associateBy { it.uid }
+                edit.allPatchesInfo.mapNotNull { (bundle, _) ->
+                    val source = sources[bundle.uid]
+                    val isPrerelease = (source as? APIPatchBundle)?.usePrerelease == true ||
+                            (source as? JsonPatchBundle)?.usePrerelease == true
+                    if (isPrerelease) bundle.uid else null
+                }.toSet()
             },
             proceedText = stringResource(R.string.save),
             // The queue combines sources by design, and the tabs make it plain enough

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.SearchOff
 import androidx.compose.material.icons.outlined.Source
+import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.listSaver
@@ -77,6 +78,8 @@ fun ExpertModeDialog(
     warnOnMultipleBundles: Boolean = true,
     /** Issues page URLs keyed by bundle uid, for the per-bundle "report an issue" action. */
     bundleIssueUrls: Map<Int, String> = emptyMap(),
+    /** Bundle uids currently receiving pre-release patch versions, shown as a warning header. */
+    prereleaseBundleUids: Set<Int> = emptySet(),
     onDismiss: () -> Unit,
     onProceed: () -> Unit
 ) {
@@ -233,6 +236,15 @@ fun ExpertModeDialog(
                         color = LocalDialogTextColor.current,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                if (bundle.uid in prereleaseBundleUids) {
+                    Notice(
+                        text = stringResource(R.string.expert_mode_prerelease_notice),
+                        icon = Icons.Outlined.WarningAmber,
+                        tone = SemanticTone.Warning,
+                        density = NoticeDensity.Compact
                     )
                 }
 
@@ -407,6 +419,16 @@ fun ExpertModeDialog(
                     } else {
                         // Reserve space so pager height stays stable when a tab has no results
                         Spacer(modifier = Modifier.height(52.dp))
+                    }
+
+                    if (currentBundle.uid in prereleaseBundleUids) {
+                        Notice(
+                            text = stringResource(R.string.expert_mode_prerelease_notice),
+                            icon = Icons.Outlined.WarningAmber,
+                            tone = SemanticTone.Warning,
+                            density = NoticeDensity.Compact,
+                            modifier = Modifier.padding(bottom = Defaults.ContentPaddingSmall)
+                        )
                     }
 
                     // Pager

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -74,6 +75,8 @@ fun ExpertModeDialog(
     proceedText: String = stringResource(R.string.expert_mode_proceed),
     /** Off where mixing sources is the norm rather than something the user just did. */
     warnOnMultipleBundles: Boolean = true,
+    /** Issues page URLs keyed by bundle uid, for the per-bundle "report an issue" action. */
+    bundleIssueUrls: Map<Int, String> = emptyMap(),
     onDismiss: () -> Unit,
     onProceed: () -> Unit
 ) {
@@ -81,6 +84,17 @@ fun ExpertModeDialog(
     val search = rememberSearchFieldState()
     val showMultipleSourcesWarning = remember { mutableStateOf(false) }
     val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val failedToOpenUrlText = stringResource(R.string.sources_management_failed_to_open_url)
+    val reportIssueLabel = stringResource(R.string.sources_management_report_issue)
+    fun openIssueUrl(url: String?) {
+        if (url == null) return
+        try {
+            uriHandler.openUri(url)
+        } catch (_: Exception) {
+            context.toast(failedToOpenUrlText)
+        }
+    }
 
     // Compute set of enabled patch names that have at least one required option
     // with no default (default == null) and no user-provided non-blank value.
@@ -236,7 +250,9 @@ fun ExpertModeDialog(
                     onResetToDefault = { patchActions.onResetToDefault(bundle.uid) },
                     onRestoreSaved = { patchActions.onRestoreSaved(bundle.uid) },
                     onCopyFromBundle = { patchActions.onCopyFromBundle(bundle.uid) },
-                    hasSavedSelection = savedPatches[bundle.uid]?.isNotEmpty() == true
+                    hasSavedSelection = savedPatches[bundle.uid]?.isNotEmpty() == true,
+                    onReportIssue = bundleIssueUrls[bundle.uid]?.let { url -> { openIssueUrl(url) } },
+                    reportIssueLabel = reportIssueLabel
                 )
 
                 if (filteredPatches == null) {
@@ -384,6 +400,8 @@ fun ExpertModeDialog(
                             onRestoreSaved = { patchActions.onRestoreSaved(currentBundle.uid) },
                             onCopyFromBundle = { patchActions.onCopyFromBundle(currentBundle.uid) },
                             hasSavedSelection = savedPatches[currentBundle.uid]?.isNotEmpty() == true,
+                            onReportIssue = bundleIssueUrls[currentBundle.uid]?.let { url -> { openIssueUrl(url) } },
+                            reportIssueLabel = reportIssueLabel,
                             modifier = Modifier.padding(vertical = Defaults.ContentPaddingSmall)
                         )
                     } else {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -77,8 +76,6 @@ fun ExpertModeDialog(
     proceedText: String = stringResource(R.string.expert_mode_proceed),
     /** Off where mixing sources is the norm rather than something the user just did. */
     warnOnMultipleBundles: Boolean = true,
-    /** Issues page URLs keyed by bundle uid, for the per-bundle "report an issue" action. */
-    bundleIssueUrls: Map<Int, String> = emptyMap(),
     /** Bundle uids currently receiving pre-release patch versions, shown as a warning header. */
     prereleaseBundleUids: Set<Int> = emptySet(),
     onDismiss: () -> Unit,
@@ -88,17 +85,6 @@ fun ExpertModeDialog(
     val search = rememberSearchFieldState()
     val showMultipleSourcesWarning = remember { mutableStateOf(false) }
     val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
-    val failedToOpenUrlText = stringResource(R.string.sources_management_failed_to_open_url)
-    val reportIssueLabel = stringResource(R.string.sources_management_report_issue)
-    fun openIssueUrl(url: String?) {
-        if (url == null) return
-        try {
-            uriHandler.openUri(url)
-        } catch (_: Exception) {
-            context.toast(failedToOpenUrlText)
-        }
-    }
 
     // Compute set of enabled patch names that have at least one required option
     // with no default (default == null) and no user-provided non-blank value.
@@ -240,15 +226,6 @@ fun ExpertModeDialog(
                     )
                 }
 
-                if (bundle.uid in prereleaseBundleUids) {
-                    Notice(
-                        text = stringResource(R.string.expert_mode_prerelease_notice),
-                        icon = Icons.Outlined.WarningAmber,
-                        tone = SemanticTone.Warning,
-                        density = NoticeDensity.Compact
-                    )
-                }
-
                 val holdsUniversal = holdsUniversalPatches(bundle.uid, displayPatches)
                 // The second "Enable all" tap applies every universal patch at once; warn first
                 val warnsOnUniversalAll = !holdsUniversal &&
@@ -267,9 +244,7 @@ fun ExpertModeDialog(
                     onResetToDefault = { patchActions.onResetToDefault(bundle.uid) },
                     onRestoreSaved = { patchActions.onRestoreSaved(bundle.uid) },
                     onCopyFromBundle = { patchActions.onCopyFromBundle(bundle.uid) },
-                    hasSavedSelection = savedPatches[bundle.uid]?.isNotEmpty() == true,
-                    onReportIssue = bundleIssueUrls[bundle.uid]?.let { url -> { openIssueUrl(url) } },
-                    reportIssueLabel = reportIssueLabel
+                    hasSavedSelection = savedPatches[bundle.uid]?.isNotEmpty() == true
                 )
 
                 if (filteredPatches == null) {
@@ -295,6 +270,9 @@ fun ExpertModeDialog(
                             modifier = Modifier.fillMaxSize(),
                             verticalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall)
                         ) {
+                            if (bundle.uid in prereleaseBundleUids) {
+                                prereleaseNotice()
+                            }
                             patchSections(
                                 bundleUid = bundle.uid,
                                 sections = sections,
@@ -420,23 +398,11 @@ fun ExpertModeDialog(
                             onRestoreSaved = { patchActions.onRestoreSaved(currentBundle.uid) },
                             onCopyFromBundle = { patchActions.onCopyFromBundle(currentBundle.uid) },
                             hasSavedSelection = savedPatches[currentBundle.uid]?.isNotEmpty() == true,
-                            onReportIssue = bundleIssueUrls[currentBundle.uid]?.let { url -> { openIssueUrl(url) } },
-                            reportIssueLabel = reportIssueLabel,
                             modifier = Modifier.padding(vertical = Defaults.ContentPaddingSmall)
                         )
                     } else {
                         // Reserve space so pager height stays stable when a tab has no results
                         Spacer(modifier = Modifier.height(52.dp))
-                    }
-
-                    if (currentBundle.uid in prereleaseBundleUids) {
-                        Notice(
-                            text = stringResource(R.string.expert_mode_prerelease_notice),
-                            icon = Icons.Outlined.WarningAmber,
-                            tone = SemanticTone.Warning,
-                            density = NoticeDensity.Compact,
-                            modifier = Modifier.padding(bottom = Defaults.ContentPaddingSmall)
-                        )
                     }
 
                     // Pager
@@ -469,6 +435,9 @@ fun ExpertModeDialog(
                                     modifier = Modifier.fillMaxSize(),
                                     verticalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall)
                                 ) {
+                                    if (bundle.uid in prereleaseBundleUids) {
+                                        prereleaseNotice()
+                                    }
                                     patchSections(
                                         bundleUid = bundle.uid,
                                         sections = sections,
@@ -598,6 +567,19 @@ private fun rememberPatchSections(
  * Availability is resolved per patch, so a universal patch the installer requires or rules out
  * carries the same lock as an app-specific one.
  */
+/**
+ * Warning header for a source on the dev branch. It scrolls with the patches it belongs to
+ * rather than holding a fixed strip, which also keeps the tabs from shifting as pages change.
+ */
+private fun LazyListScope.prereleaseNotice() = item(key = "prerelease-notice") {
+    Notice(
+        text = stringResource(R.string.expert_mode_prerelease_notice),
+        icon = Icons.Outlined.WarningAmber,
+        tone = SemanticTone.Warning,
+        density = NoticeDensity.Compact
+    )
+}
+
 private fun LazyListScope.patchSections(
     bundleUid: Int,
     sections: PatchSections,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -40,6 +40,7 @@ import app.morphe.manager.ui.model.renamesByDefault
 import app.morphe.manager.ui.screen.shared.*
 import app.morphe.manager.util.Options
 import app.morphe.manager.util.PatchSelection
+import app.morphe.manager.util.PatchSelectionUtils.hasEnablableUniversal
 import app.morphe.manager.util.toast
 import kotlinx.coroutines.launch
 
@@ -251,7 +252,7 @@ fun ExpertModeDialog(
                 val holdsUniversal = holdsUniversalPatches(bundle.uid, displayPatches)
                 // The second "Enable all" tap applies every universal patch at once; warn first
                 val warnsOnUniversalAll = !holdsUniversal &&
-                        displayPatches.any { (patch, isEnabled) -> patch.isUniversal && !isEnabled }
+                        displayPatches.hasEnablableUniversal(lockStateOf)
                 BundlePatchControls(
                     enabledCount = enabledCount,
                     totalCount = totalCount,
@@ -403,7 +404,7 @@ fun ExpertModeDialog(
                     if (currentFiltered != null) {
                         val holdsUniversal = holdsUniversalPatches(currentBundle.uid, currentFiltered)
                         val warnsOnUniversalAll = !holdsUniversal &&
-                                currentFiltered.any { (patch, isEnabled) -> patch.isUniversal && !isEnabled }
+                                currentFiltered.hasEnablableUniversal(lockStateOf)
                         BundlePatchControls(
                             enabledCount = currentFiltered.count { it.second },
                             totalCount = currentFiltered.size,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -249,10 +249,14 @@ fun ExpertModeDialog(
                 }
 
                 val holdsUniversal = holdsUniversalPatches(bundle.uid, displayPatches)
+                // The second "Enable all" tap applies every universal patch at once; warn first
+                val warnsOnUniversalAll = !holdsUniversal &&
+                        displayPatches.any { (patch, isEnabled) -> patch.isUniversal && !isEnabled }
                 BundlePatchControls(
                     enabledCount = enabledCount,
                     totalCount = totalCount,
                     holdsUniversalPatches = holdsUniversal,
+                    warnOnUniversalAll = warnsOnUniversalAll,
                     onSelectAll = {
                         // This tap enables the universal patches, so it has to show what it turned on
                         if (!holdsUniversal) setUniversalExpanded(bundle.uid, true)
@@ -398,10 +402,13 @@ fun ExpertModeDialog(
 
                     if (currentFiltered != null) {
                         val holdsUniversal = holdsUniversalPatches(currentBundle.uid, currentFiltered)
+                        val warnsOnUniversalAll = !holdsUniversal &&
+                                currentFiltered.any { (patch, isEnabled) -> patch.isUniversal && !isEnabled }
                         BundlePatchControls(
                             enabledCount = currentFiltered.count { it.second },
                             totalCount = currentFiltered.size,
                             holdsUniversalPatches = holdsUniversal,
+                            warnOnUniversalAll = warnsOnUniversalAll,
                             onSelectAll = {
                                 // This tap enables the universal patches, so it has to show what it turned on
                                 if (!holdsUniversal) setUniversalExpanded(currentBundle.uid, true)

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -11,7 +11,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -44,7 +47,9 @@ internal fun BundlePatchControls(
     hasSavedSelection: Boolean,
     modifier: Modifier = Modifier,
     onReportIssue: (() -> Unit)? = null,
-    reportIssueLabel: String? = null
+    reportIssueLabel: String? = null,
+    /** True when this "Enable all" tap would also enable the universal patches. */
+    warnOnUniversalAll: Boolean = false
 ) {
     val context = LocalContext.current
 
@@ -60,6 +65,10 @@ internal fun BundlePatchControls(
     val copyLabel = stringResource(R.string.expert_mode_copy_from_bundle)
     val deselectAllLabel = stringResource(R.string.expert_mode_disable_all)
 
+    // The second "Enable all" tap applies every universal patch at once, which is a common
+    // cause of conflicts and failed patching. Confirmation makes that risk explicit.
+    var showUniversalAllWarning by remember { mutableStateOf(false) }
+
     // Universal patches stay off until a second tap, so the first one must not claim otherwise
     val enabledDone = if (holdsUniversalPatches) {
         stringResource(R.string.expert_mode_enable_all_universal_pending)
@@ -72,7 +81,13 @@ internal fun BundlePatchControls(
 
     ActionPillRow(modifier = modifier) {
         ActionPillButton(
-            onClick = withToast(enabledDone, onSelectAll),
+            onClick = {
+                if (warnOnUniversalAll) {
+                    showUniversalAllWarning = true
+                } else {
+                    withToast(enabledDone, onSelectAll)()
+                }
+            },
             icon = Icons.Outlined.DoneAll,
             contentDescription = selectAllLabel,
             tooltip = selectAllLabel,
@@ -150,6 +165,20 @@ internal fun BundlePatchControls(
                 )
             )
         }
+    }
+
+    if (showUniversalAllWarning) {
+        ConfirmDialog(
+            title = stringResource(R.string.expert_mode_universal_all_warning_title),
+            message = stringResource(R.string.expert_mode_universal_all_warning_message),
+            primaryText = stringResource(R.string.expert_mode_universal_all_enable),
+            isPrimaryDestructive = false,
+            onDismiss = { showUniversalAllWarning = false },
+            onConfirm = {
+                showUniversalAllWarning = false
+                withToast(enabledDone, onSelectAll)()
+            }
+        )
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -42,7 +42,9 @@ internal fun BundlePatchControls(
     onRestoreSaved: () -> Unit,
     onCopyFromBundle: () -> Unit,
     hasSavedSelection: Boolean,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onReportIssue: (() -> Unit)? = null,
+    reportIssueLabel: String? = null
 ) {
     val context = LocalContext.current
 
@@ -132,6 +134,22 @@ internal fun BundlePatchControls(
                 disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
             )
         )
+
+        // Report an issue on this bundle's repository
+        if (onReportIssue != null && reportIssueLabel != null) {
+            ActionPillButton(
+                onClick = onReportIssue,
+                icon = Icons.Outlined.BugReport,
+                contentDescription = reportIssueLabel,
+                tooltip = reportIssueLabel,
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                    disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                )
+            )
+        }
     }
 }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -153,7 +153,7 @@ internal fun BundlePatchControls(
         ConfirmDialog(
             title = stringResource(R.string.expert_mode_universal_all_warning_title),
             message = stringResource(R.string.expert_mode_universal_all_warning_message),
-            primaryText = stringResource(R.string.expert_mode_universal_all_enable),
+            primaryText = stringResource(R.string.enable),
             isPrimaryDestructive = false,
             onDismiss = { showUniversalAllWarning = false },
             onConfirm = {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertPatchCard.kt
@@ -46,8 +46,6 @@ internal fun BundlePatchControls(
     onCopyFromBundle: () -> Unit,
     hasSavedSelection: Boolean,
     modifier: Modifier = Modifier,
-    onReportIssue: (() -> Unit)? = null,
-    reportIssueLabel: String? = null,
     /** True when this "Enable all" tap would also enable the universal patches. */
     warnOnUniversalAll: Boolean = false
 ) {
@@ -149,22 +147,6 @@ internal fun BundlePatchControls(
                 disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
             )
         )
-
-        // Report an issue on this bundle's repository
-        if (onReportIssue != null && reportIssueLabel != null) {
-            ActionPillButton(
-                onClick = onReportIssue,
-                icon = Icons.Outlined.BugReport,
-                contentDescription = reportIssueLabel,
-                tooltip = reportIssueLabel,
-                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                    disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-                )
-            )
-        }
     }
 
     if (showUniversalAllWarning) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
@@ -87,19 +87,16 @@ internal fun HomeAppListOptionsDialog(
             ) { tab ->
                 Column(verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)) {
                     when (tab) {
-                        0 -> {
-                            val options = sortModeOptions<HomeAppSortMode>()
-                                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
-                            options.forEach { option ->
-                                RadioSelectionCard(
-                                    selected = sortMode == option.value,
-                                    onSelect = { onSortModeChange(option.value) },
-                                    title = option.title,
-                                    description = option.description
-                                )
-                            }
+                        0 -> sortModeOptions<HomeAppSortMode>().forEach { option ->
+                            RadioSelectionCard(
+                                selected = sortMode == option.value,
+                                onSelect = { onSortModeChange(option.value) },
+                                title = option.title,
+                                description = option.description
+                            )
                         }
 
+                        // Filters are not SortModeSpec, so they get the same ordering here
                         else -> {
                             val filters = HomeAppFilterMode.entries.map { mode ->
                                 Triple(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
@@ -87,9 +87,10 @@ internal fun HomeAppListOptionsDialog(
             ) { tab ->
                 Column(verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)) {
                     when (tab) {
-                        0 -> sortModeOptions<HomeAppSortMode>()
-                            .sortedBy { it.title.lowercase() }
-                            .forEach { option ->
+                        0 -> {
+                            val options = sortModeOptions<HomeAppSortMode>()
+                                .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
+                            options.forEach { option ->
                                 RadioSelectionCard(
                                     selected = sortMode == option.value,
                                     onSelect = { onSortModeChange(option.value) },
@@ -97,17 +98,24 @@ internal fun HomeAppListOptionsDialog(
                                     description = option.description
                                 )
                             }
+                        }
 
                         else -> {
-                            val sortedFilters = HomeAppFilterMode.entries
-                                .map { it to stringResource(it.labelRes) }
-                                .sortedBy { (_, label) -> label.lowercase() }
-                            sortedFilters.forEach { (mode, _) ->
+                            val filters = HomeAppFilterMode.entries.map { mode ->
+                                Triple(
+                                    mode,
+                                    stringResource(mode.labelRes),
+                                    stringResource(mode.descriptionRes)
+                                )
+                            }.sortedWith(
+                                compareBy(String.CASE_INSENSITIVE_ORDER) { (_, label, _) -> label }
+                            )
+                            filters.forEach { (mode, label, description) ->
                                 RadioSelectionCard(
                                     selected = filterMode == mode,
                                     onSelect = { onFilterModeChange(mode) },
-                                    title = stringResource(mode.labelRes),
-                                    description = stringResource(mode.descriptionRes)
+                                    title = label,
+                                    description = description
                                 )
                             }
                         }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppListOptionsDialog.kt
@@ -87,22 +87,29 @@ internal fun HomeAppListOptionsDialog(
             ) { tab ->
                 Column(verticalArrangement = Arrangement.spacedBy(Defaults.ItemSpacing)) {
                     when (tab) {
-                        0 -> sortModeOptions<HomeAppSortMode>().forEach { option ->
-                            RadioSelectionCard(
-                                selected = sortMode == option.value,
-                                onSelect = { onSortModeChange(option.value) },
-                                title = option.title,
-                                description = option.description
-                            )
-                        }
+                        0 -> sortModeOptions<HomeAppSortMode>()
+                            .sortedBy { it.title.lowercase() }
+                            .forEach { option ->
+                                RadioSelectionCard(
+                                    selected = sortMode == option.value,
+                                    onSelect = { onSortModeChange(option.value) },
+                                    title = option.title,
+                                    description = option.description
+                                )
+                            }
 
-                        else -> HomeAppFilterMode.entries.forEach { mode ->
-                            RadioSelectionCard(
-                                selected = filterMode == mode,
-                                onSelect = { onFilterModeChange(mode) },
-                                title = stringResource(mode.labelRes),
-                                description = stringResource(mode.descriptionRes)
-                            )
+                        else -> {
+                            val sortedFilters = HomeAppFilterMode.entries
+                                .map { it to stringResource(it.labelRes) }
+                                .sortedBy { (_, label) -> label.lowercase() }
+                            sortedFilters.forEach { (mode, _) ->
+                                RadioSelectionCard(
+                                    selected = filterMode == mode,
+                                    onSelect = { onFilterModeChange(mode) },
+                                    title = stringResource(mode.labelRes),
+                                    description = stringResource(mode.descriptionRes)
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -435,6 +435,11 @@ fun HomeDialogs(
             savedPatches = homeViewModel.expertModeInitialPatches,
             lockStateOf = homeViewModel::expertModeLockState,
             holdsUniversalPatches = homeViewModel::expertModeSelectAllHoldsUniversal,
+            bundleIssueUrls = remember(homeViewModel.expertModeAllPatchesInfo) {
+                homeViewModel.expertModeAllPatchesInfo.mapNotNull { (bundle, _) ->
+                    homeViewModel.getBundleIssuesUrl(bundle.uid)?.let { bundle.uid to it }
+                }.toMap()
+            },
             onDismiss = {
                 homeViewModel.cleanupExpertModeData()
             },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -41,6 +41,7 @@ import app.morphe.manager.domain.apk.InstalledApkInfo
 import app.morphe.manager.domain.apk.SavedApkInfo
 import app.morphe.manager.domain.bundles.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.sourceType
+import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.usesPrerelease
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.ui.model.HomeAppItem
@@ -399,12 +400,14 @@ fun HomeDialogs(
 
     // Expert Mode Dialog
     if (homeViewModel.showExpertModeDialog) {
+        // Reading the property re-walks and re-sorts every bundle's patches, so it is taken once
+        val allPatchesInfo = homeViewModel.expertModeAllPatchesInfo
         ExpertModeDialog(
             newPatches = homeViewModel.expertModeNewPatches,
             options = homeViewModel.expertModeOptions,
-            allPatchesInfo = homeViewModel.expertModeAllPatchesInfo,
+            allPatchesInfo = allPatchesInfo,
             totalSelectedCount = homeViewModel.expertModeTotalSelectedCount,
-            totalPatchesCount = homeViewModel.expertModeTotalPatchesCount,
+            totalPatchesCount = allPatchesInfo.sumOf { (_, patches) -> patches.size },
             hasMultipleBundles = homeViewModel.expertModeHasMultipleBundles,
             patchActions = ExpertPatchActions(
                 onPatchToggle = { bundleUid, patchName ->
@@ -435,19 +438,13 @@ fun HomeDialogs(
             savedPatches = homeViewModel.expertModeInitialPatches,
             lockStateOf = homeViewModel::expertModeLockState,
             holdsUniversalPatches = homeViewModel::expertModeSelectAllHoldsUniversal,
-            bundleIssueUrls = remember(homeViewModel.expertModeAllPatchesInfo) {
-                homeViewModel.expertModeAllPatchesInfo.mapNotNull { (bundle, _) ->
-                    homeViewModel.getBundleIssuesUrl(bundle.uid)?.let { bundle.uid to it }
-                }.toMap()
-            },
-            prereleaseBundleUids = remember(homeViewModel.expertModeAllPatchesInfo) {
-                homeViewModel.expertModeAllPatchesInfo.mapNotNull { (bundle, _) ->
-                    val source = homeViewModel.getPatchSource(bundle.uid)
-                    val isPrerelease = (source as? APIPatchBundle)?.usePrerelease == true ||
-                            (source as? JsonPatchBundle)?.usePrerelease == true
-                    if (isPrerelease) bundle.uid else null
-                }.toSet()
-            },
+            bundleIssueUrls = allPatchesInfo.mapNotNull { (bundle, _) ->
+                (homeViewModel.getPatchSource(bundle.uid) as? RemotePatchBundle)
+                    ?.issuesPageUrl?.let { bundle.uid to it }
+            }.toMap(),
+            prereleaseBundleUids = allPatchesInfo.mapNotNull { (bundle, _) ->
+                bundle.uid.takeIf { homeViewModel.getPatchSource(it)?.usesPrerelease == true }
+            }.toSet(),
             onDismiss = {
                 homeViewModel.cleanupExpertModeData()
             },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -438,10 +438,6 @@ fun HomeDialogs(
             savedPatches = homeViewModel.expertModeInitialPatches,
             lockStateOf = homeViewModel::expertModeLockState,
             holdsUniversalPatches = homeViewModel::expertModeSelectAllHoldsUniversal,
-            bundleIssueUrls = allPatchesInfo.mapNotNull { (bundle, _) ->
-                (homeViewModel.getPatchSource(bundle.uid) as? RemotePatchBundle)
-                    ?.issuesPageUrl?.let { bundle.uid to it }
-            }.toMap(),
             prereleaseBundleUids = allPatchesInfo.mapNotNull { (bundle, _) ->
                 bundle.uid.takeIf { homeViewModel.getPatchSource(it)?.usesPrerelease == true }
             }.toSet(),

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeDialogs.kt
@@ -440,6 +440,14 @@ fun HomeDialogs(
                     homeViewModel.getBundleIssuesUrl(bundle.uid)?.let { bundle.uid to it }
                 }.toMap()
             },
+            prereleaseBundleUids = remember(homeViewModel.expertModeAllPatchesInfo) {
+                homeViewModel.expertModeAllPatchesInfo.mapNotNull { (bundle, _) ->
+                    val source = homeViewModel.getPatchSource(bundle.uid)
+                    val isPrerelease = (source as? APIPatchBundle)?.usePrerelease == true ||
+                            (source as? JsonPatchBundle)?.usePrerelease == true
+                    if (isPrerelease) bundle.uid else null
+                }.toSet()
+            },
             onDismiss = {
                 homeViewModel.cleanupExpertModeData()
             },

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -46,8 +46,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.morphe.manager.R
 import app.morphe.manager.domain.bundles.APIPatchBundle
-import app.morphe.manager.domain.bundles.JsonPatchBundle
 import app.morphe.manager.domain.bundles.PatchBundleSource
+import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.usesPrerelease
 import app.morphe.manager.domain.bundles.RemotePatchBundle
 import app.morphe.manager.domain.repository.PatchBundleRepository
 import app.morphe.manager.patcher.patch.PatchInfo
@@ -943,8 +943,7 @@ fun BundleChangelogDialog(
         state = BundleChangelogState.Loading
         state = withContext(Dispatchers.Default) {
             try {
-                val usePrerelease = (src as? APIPatchBundle)?.usePrerelease == true
-                        || (src as? JsonPatchBundle)?.usePrerelease == true
+                val usePrerelease = src.usesPrerelease
 
                 val allEntries = src.fetchChangelogEntries(sinceVersion = null)
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -411,6 +411,15 @@ fun BundleManagementSheet(
                                             context.toast(failedToOpenUrlText)
                                         }
                                     },
+                                    onReportIssue = {
+                                        val issuesUrl = (bundle as? RemotePatchBundle)?.issuesPageUrl
+                                            ?: SOURCE_REPO_URL
+                                        try {
+                                            uriHandler.openUri(issuesUrl)
+                                        } catch (_: Exception) {
+                                            context.toast(failedToOpenUrlText)
+                                        }
+                                    },
                                     forceExpanded = isSingleDefaultBundle,
                                     isDragging = itemIsDragging,
                                     // Reorder maps list positions onto the full order, so a
@@ -576,6 +585,7 @@ private fun BundleManagementCard(
     onPatchesClick: () -> Unit,
     onVersionClick: () -> Unit,
     onOpenInBrowser: () -> Unit,
+    onReportIssue: () -> Unit,
     onOutdatedManagerClick: () -> Unit,
     forceExpanded: Boolean = false
 ) {
@@ -585,6 +595,7 @@ private fun BundleManagementCard(
     val enabledState = stringResource(R.string.enabled)
     val disabledState = stringResource(R.string.disabled)
     val openInBrowser = stringResource(R.string.sources_management_open_in_browser)
+    val reportIssue = stringResource(R.string.sources_management_report_issue)
 
     val context = LocalContext.current
     fun withToast(doneMessage: String, action: () -> Unit): () -> Unit = {
@@ -896,6 +907,21 @@ private fun BundleManagementCard(
                                     contentDescription = updateDesc,
                                     tooltip = updateVerb,
                                     enabled = !isBlocked
+                                )
+                            }
+
+                            // Report an issue button, next to the delete action
+                            if (bundle is RemotePatchBundle) {
+                                val issueDesc = reportIssue + " " + bundle.displayTitle
+                                ActionPillButton(
+                                    onClick = onReportIssue,
+                                    icon = Icons.Outlined.BugReport,
+                                    contentDescription = issueDesc,
+                                    tooltip = reportIssue,
+                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 )
                             }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -109,6 +109,9 @@ fun BundleManagementSheet(
     val showSheetOnboarding = globalOnboardingState?.sheetOnboardingActive == true
 
     val bundleToDelete = remember { mutableStateOf<PatchBundleSource?>(null) }
+    // Set when the user flips pre-releases on: the toggle waits for confirmation first,
+    // so the meaning of unstable testing builds is explained before anything changes
+    val bundleToConfirmPrerelease = remember { mutableStateOf<PatchBundleSource?>(null) }
     var showSortDialog by remember { mutableStateOf(false) }
     // Search is offered from two sources up
     val isSearchable = sources.size >= 2
@@ -368,15 +371,16 @@ fun BundleManagementSheet(
                                     onPrereleasesToggle = when {
                                         bundle is JsonPatchBundle && bundle.supportsPrerelease ||
                                                 bundle is APIPatchBundle -> { usePrerelease ->
-                                            if (bundle.uid == bundleToShowChangelogUid) {
-                                                bundleToShowChangelogUid = null
-                                            }
-                                            bundle.clearChangelogCache()
-                                            scope.launch {
-                                                patchBundleRepository.setUsePrerelease(
-                                                    bundle.uid,
-                                                    usePrerelease
-                                                )
+                                            if (usePrerelease) {
+                                                // Explain what pre-release means before flipping it on
+                                                bundleToConfirmPrerelease.value = bundle
+                                            } else {
+                                                scope.launch {
+                                                    patchBundleRepository.setUsePrerelease(
+                                                        bundle.uid,
+                                                        usePrerelease
+                                                    )
+                                                }
                                             }
                                         }
 
@@ -486,6 +490,27 @@ fun BundleManagementSheet(
             onConfirm = {
                 onDelete(bundleToDelete.value!!)
                 bundleToDelete.value = null
+            }
+        )
+    }
+
+    // Pre-release enable confirmation dialog
+    bundleToConfirmPrerelease.value?.let { bundle ->
+        ConfirmDialog(
+            title = stringResource(R.string.sources_prerelease_warning_title),
+            message = stringResource(R.string.sources_prerelease_warning_message),
+            primaryText = stringResource(R.string.sources_prerelease_enable),
+            isPrimaryDestructive = false,
+            onDismiss = { bundleToConfirmPrerelease.value = null },
+            onConfirm = {
+                bundleToConfirmPrerelease.value = null
+                if (bundle.uid == bundleToShowChangelogUid) {
+                    bundleToShowChangelogUid = null
+                }
+                (bundle as? RemotePatchBundle)?.clearChangelogCache()
+                scope.launch {
+                    patchBundleRepository.setUsePrerelease(bundle.uid, true)
+                }
             }
         )
     }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -505,7 +505,7 @@ fun BundleManagementSheet(
         ConfirmDialog(
             title = stringResource(R.string.sources_prerelease_warning_title),
             message = stringResource(R.string.sources_prerelease_warning_message),
-            primaryText = stringResource(R.string.sources_prerelease_enable),
+            primaryText = stringResource(R.string.enable),
             isPrimaryDestructive = false,
             onDismiss = { bundleToConfirmPrerelease.value = null },
             onConfirm = {
@@ -583,6 +583,7 @@ private fun PatchBundleSource.sourceSortTitle(): String =
 /**
  * Card for individual bundle management.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BundleManagementCard(
     bundle: PatchBundleSource,
@@ -820,24 +821,54 @@ private fun BundleManagementCard(
                             enabled = !isUpdating
                         )
 
-                        // Open in browser button
+                        // Both actions leave for the same repository, so they share a row.
+                        // Only the primary one carries a label, keeping it clear of the
+                        // width its own translation happens to need
                         if (bundle is RemotePatchBundle) {
-                            FilledTonalButton(
-                                onClick = onOpenInBrowser,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(48.dp)
-                                    .semantics {
-                                        contentDescription = openInBrowser
-                                    },
-                                shape = RoundedCornerShape(Defaults.CompactCornerRadius)
+                            val issueDesc = reportIssue + " " + bundle.displayTitle
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(Defaults.ContentPaddingSmall)
                             ) {
-                                Icon(
-                                    Icons.AutoMirrored.Outlined.OpenInNew,
-                                    contentDescription = null
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(openInBrowser)
+                                FilledTonalButton(
+                                    onClick = onOpenInBrowser,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .height(48.dp)
+                                        .semantics {
+                                            contentDescription = openInBrowser
+                                        },
+                                    shape = RoundedCornerShape(Defaults.CompactCornerRadius)
+                                ) {
+                                    Icon(
+                                        Icons.AutoMirrored.Outlined.OpenInNew,
+                                        contentDescription = null
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(openInBrowser)
+                                }
+
+                                TooltipBox(
+                                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                                        TooltipAnchorPosition.Above
+                                    ),
+                                    tooltip = { PlainTooltip { Text(reportIssue) } },
+                                    state = rememberTooltipState()
+                                ) {
+                                    FilledTonalIconButton(
+                                        onClick = onReportIssue,
+                                        modifier = Modifier
+                                            .size(48.dp)
+                                            .semantics {
+                                                contentDescription = issueDesc
+                                            },
+                                        shape = RoundedCornerShape(Defaults.CompactCornerRadius)
+                                    ) {
+                                        Icon(
+                                            Icons.Outlined.BugReport,
+                                            contentDescription = null
+                                        )
+                                    }
+                                }
                             }
                         }
 
@@ -928,21 +959,6 @@ private fun BundleManagementCard(
                                     contentDescription = updateDesc,
                                     tooltip = updateVerb,
                                     enabled = !isBlocked
-                                )
-                            }
-
-                            // Report an issue button, next to the delete action
-                            if (bundle is RemotePatchBundle) {
-                                val issueDesc = reportIssue + " " + bundle.displayTitle
-                                ActionPillButton(
-                                    onClick = onReportIssue,
-                                    icon = Icons.Outlined.BugReport,
-                                    contentDescription = issueDesc,
-                                    tooltip = reportIssue,
-                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
                                 )
                             }
 

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementSheet.kt
@@ -56,6 +56,7 @@ import app.morphe.manager.domain.bundles.*
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.avatarUrls
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.isDefault
 import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.sourceType
+import app.morphe.manager.domain.bundles.PatchBundleSource.Extensions.usesPrerelease
 import app.morphe.manager.domain.manager.PreferencesManager
 import app.morphe.manager.domain.manager.SourceBundleSortMode
 import app.morphe.manager.domain.repository.BlocklistRepository
@@ -180,9 +181,19 @@ fun BundleManagementSheet(
     val bundleToShowChangelog = bundleToShowChangelogUid
         ?.let { uid -> sources.filterIsInstance<RemotePatchBundle>().find { it.uid == uid } }
     val bundleToShowChangelogKey = bundleToShowChangelog?.let {
-        val usePrerelease = (it as? APIPatchBundle)?.usePrerelease == true
-                || (it as? JsonPatchBundle)?.usePrerelease == true
-        "${it.installedVersionSignature}|$usePrerelease"
+        "${it.installedVersionSignature}|${it.usesPrerelease}"
+    }
+
+    // Switching branches invalidates whatever the changelog dialog is holding, so the cache goes
+    // and an open dialog closes rather than keeping entries from the branch that was just left
+    fun applyPrerelease(bundle: PatchBundleSource, usePrerelease: Boolean) {
+        if (bundle.uid == bundleToShowChangelogUid) {
+            bundleToShowChangelogUid = null
+        }
+        (bundle as? RemotePatchBundle)?.clearChangelogCache()
+        scope.launch {
+            patchBundleRepository.setUsePrerelease(bundle.uid, usePrerelease)
+        }
     }
 
     // Check if only default bundle exists
@@ -375,12 +386,7 @@ fun BundleManagementSheet(
                                                 // Explain what pre-release means before flipping it on
                                                 bundleToConfirmPrerelease.value = bundle
                                             } else {
-                                                scope.launch {
-                                                    patchBundleRepository.setUsePrerelease(
-                                                        bundle.uid,
-                                                        usePrerelease
-                                                    )
-                                                }
+                                                applyPrerelease(bundle, false)
                                             }
                                         }
 
@@ -504,13 +510,7 @@ fun BundleManagementSheet(
             onDismiss = { bundleToConfirmPrerelease.value = null },
             onConfirm = {
                 bundleToConfirmPrerelease.value = null
-                if (bundle.uid == bundleToShowChangelogUid) {
-                    bundleToShowChangelogUid = null
-                }
-                (bundle as? RemotePatchBundle)?.clearChangelogCache()
-                scope.launch {
-                    patchBundleRepository.setUsePrerelease(bundle.uid, true)
-                }
+                applyPrerelease(bundle, true)
             }
         )
     }
@@ -844,11 +844,7 @@ private fun BundleManagementCard(
                         SettingsDivider(fullWidth = true)
 
                         // Resolve prerelease state once
-                        val currentUsePrerelease = when (bundle) {
-                            is JsonPatchBundle -> bundle.usePrerelease
-                            is APIPatchBundle -> bundle.usePrerelease
-                            else -> false
-                        }
+                        val currentUsePrerelease = bundle.usesPrerelease
 
                         // Prerelease toggle (for JsonPatchBundle with GitHub endpoint or APIPatchBundle)
                         if (onPrereleasesToggle != null) {

--- a/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/shared/SortModeSelectionDialog.kt
@@ -21,6 +21,11 @@ data class SortModeOption<T>(
     val description: String
 )
 
+/**
+ * Options of [T] in the order they are offered to the user, which is alphabetical rather than
+ * the declaration order: the lists are read as a menu, and every sort dialog has to agree on
+ * where an entry sits, including the ones the enums share.
+ */
 @Composable
 inline fun <reified T> sortModeOptions(): List<SortModeOption<T>>
     where T : Enum<T>, T : SortModeSpec =
@@ -30,7 +35,7 @@ inline fun <reified T> sortModeOptions(): List<SortModeOption<T>>
             title = stringResource(mode.labelRes),
             description = stringResource(mode.descriptionRes)
         )
-    }
+    }.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
 
 @Composable
 fun <T> SortModeSelectionDialog(

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
@@ -96,8 +96,6 @@ class BatchPatchEdit(
 
     val totalSelectedCount get() = selection.values.sumOf { it.size }
 
-    val totalPatchesCount get() = allPatchesInfo.sumOf { it.second.size }
-
     val hasMultipleBundles get() = selection.spansMultipleBundles()
 
     private val patchesByName = bundles.associate { it.uid to it.patches.associateBy { patch -> patch.name } }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1724,6 +1724,13 @@ class HomeViewModel(
     fun getBundleDisplayName(uid: Int): String? =
         allBundlesInfoState.value[uid]?.name
 
+    /**
+     * Returns the issues page URL of the bundle with [uid], or null when the bundle
+     * is not a remote source with a known GitHub/GitLab repository.
+     */
+    fun getBundleIssuesUrl(uid: Int): String? =
+        (patchSourcesState.value[uid] as? RemotePatchBundle)?.issuesPageUrl
+
     fun saveAppOrder(packageNames: List<String>) {
         homeAppButtonPrefs.saveOrder(packageNames)
     }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1729,13 +1729,6 @@ class HomeViewModel(
     fun getBundleDisplayName(uid: Int): String? =
         allBundlesInfoState.value[uid]?.name
 
-    /**
-     * Returns the issues page URL of the bundle with [uid], or null when the bundle
-     * is not a remote source with a known GitHub/GitLab repository.
-     */
-    fun getBundleIssuesUrl(uid: Int): String? =
-        (patchSourcesState.value[uid] as? RemotePatchBundle)?.issuesPageUrl
-
     fun saveAppOrder(packageNames: List<String>) {
         homeAppButtonPrefs.saveOrder(packageNames)
     }
@@ -2990,10 +2983,6 @@ class HomeViewModel(
     /** Total number of currently selected patches across all bundles. */
     val expertModeTotalSelectedCount: Int
         get() = expertModePatches.values.sumOf { it.size }
-
-    /** Total number of available patches across all bundles. */
-    val expertModeTotalPatchesCount: Int
-        get() = expertModeAllPatchesInfo.sumOf { it.second.size }
 
     /** True when patches from more than one bundle are selected (triggers warning on proceed). */
     val expertModeHasMultipleBundles: Boolean

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -1642,6 +1642,11 @@ class HomeViewModel(
                 compareByDescending<HomeAppItem> { it.showsUpdateBadge }
                     .then(morpheComparator)
             )
+            HomeAppSortMode.RECENTLY_PATCHED -> items.sortedWith(
+                // Newest patch first; apps never patched sort last, in recommended order
+                compareByDescending<HomeAppItem> { it.installedApp?.patchedAt ?: Long.MIN_VALUE }
+                    .then(morpheComparator)
+            )
         }
     }
 

--- a/app/src/main/java/app/morphe/manager/util/PatchSelectionExtensions.kt
+++ b/app/src/main/java/app/morphe/manager/util/PatchSelectionExtensions.kt
@@ -113,6 +113,14 @@ object PatchSelectionUtils {
         return hasUnselectedUniversal && !(universalArmed && selectable.allRegularSelected())
     }
 
+    /**
+     * True when a bulk enable of [this] would turn on at least one universal patch, i.e. the
+     * locked off ones do not count because [bulkEnablePatches] leaves them alone.
+     */
+    fun List<Pair<PatchInfo, Boolean>>.hasEnablableUniversal(
+        lockStateOf: (PatchInfo) -> PatchLockState
+    ) = selectable(lockStateOf).any { (patch, enabled) -> patch.isUniversal && !enabled }
+
     /** Patches the user is allowed to turn on, i.e. everything except the locked off ones. */
     private fun List<Pair<PatchInfo, Boolean>>.selectable(lockStateOf: (PatchInfo) -> PatchLockState) =
         filterNot { (patch, _) -> lockStateOf(patch) == PatchLockState.LOCKED_OFF }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,9 @@
     <string name="expert_mode_enable_all">Enable all</string>
     <string name="expert_mode_enable_all_done">All patches enabled</string>
     <string name="expert_mode_enable_all_universal_pending">Tap again for universal patches</string>
+    <string name="expert_mode_universal_all_warning_title">Enable all universal patches?</string>
+    <string name="expert_mode_universal_all_warning_message">Enabling every universal patch at once can cause patch conflicts, patch failures, or app crashes due to factors such as incompatible patches or limited memory. Proceed only if you accept this risk.</string>
+    <string name="expert_mode_universal_all_enable">Enable all universal patches</string>
     <string name="expert_mode_reset_to_default">Enable recommended patches</string>
     <string name="expert_mode_reset_to_default_done">Recommended patches applied</string>
     <string name="expert_mode_restore_saved">Restore saved selection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,6 @@
     <string name="sources_management_prerelease_toggle_description">Receives early access to new experimental patch versions</string>
     <string name="sources_prerelease_warning_title">Enable pre-release patches?</string>
     <string name="sources_prerelease_warning_message">Pre-release builds are still in development. Patches may fail or break the app, and features can change without warning</string>
-    <string name="sources_prerelease_enable">Enable pre-release</string>
     <string name="expert_mode_prerelease_notice">This source is on pre-release patches. Patching may fail or behave unexpectedly</string>
     <string name="sources_management_experimental_versions_toggle">Experimental app versions</string>
     <string name="sources_management_experimental_versions_toggle_description">Patches experimental app targets if available</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="home_app_sort_name_desc_description">Reverse alphabetical, Z to A</string>
     <string name="home_app_sort_updates_first">Patch updates first</string>
     <string name="home_app_sort_updates_first_description">Apps with update badges first, then recommended order</string>
+    <string name="home_app_sort_recently_patched">Recently patched</string>
+    <string name="home_app_sort_recently_patched_description">Most recently patched apps first</string>
     <string name="home_no_apps_title">No apps available</string>
     <string name="home_no_apps_subtitle">Add a patch source or enable an existing one in %s</string>
     <string name="home_no_apps_search_subtitle">No apps match \"%s\"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -272,7 +272,6 @@
     <string name="expert_mode_enable_all_universal_pending">Tap again for universal patches</string>
     <string name="expert_mode_universal_all_warning_title">Enable all universal patches?</string>
     <string name="expert_mode_universal_all_warning_message">Universal patches are not tested together. Enabling all of them at once can cause conflicts, failed patching, or crashes</string>
-    <string name="expert_mode_universal_all_enable">Enable all universal patches</string>
     <string name="expert_mode_reset_to_default">Enable recommended patches</string>
     <string name="expert_mode_reset_to_default_done">Recommended patches applied</string>
     <string name="expert_mode_restore_saved">Restore saved selection</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,6 +135,10 @@
     <string name="sources_management_failed_to_open_url">Failed to open URL</string>
     <string name="sources_management_prerelease_toggle">Pre-release patches</string>
     <string name="sources_management_prerelease_toggle_description">Receives early access to new experimental patch versions</string>
+    <string name="sources_prerelease_warning_title">Enable pre-release patches?</string>
+    <string name="sources_prerelease_warning_message">Pre-release builds are under active development and are not subject to the same stability guarantees as stable releases. They may contain incomplete features, unresolved defects, or breaking changes that could affect patching behavior or installed applications. Proceed only if you accept this risk.</string>
+    <string name="sources_prerelease_enable">Enable pre-release</string>
+    <string name="expert_mode_prerelease_notice">This source is configured to receive pre-release patch versions. These builds are under active development and are not subject to the stability guarantees of stable releases; patches may fail or behave unexpectedly.</string>
     <string name="sources_management_experimental_versions_toggle">Experimental app versions</string>
     <string name="sources_management_experimental_versions_toggle_description">Patches experimental app targets if available</string>
     <string name="sources_management_already_exists">This source has already been added</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="sources_sort_enabled_first">Enabled first</string>
     <string name="sources_sort_enabled_first_description">Show active sources before disabled sources</string>
     <string name="sources_management_open_in_browser">Open in browser</string>
+    <string name="sources_management_report_issue">Report an issue</string>
     <string name="sources_management_failed_to_open_url">Failed to open URL</string>
     <string name="sources_management_prerelease_toggle">Pre-release patches</string>
     <string name="sources_management_prerelease_toggle_description">Receives early access to new experimental patch versions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,9 +138,9 @@
     <string name="sources_management_prerelease_toggle">Pre-release patches</string>
     <string name="sources_management_prerelease_toggle_description">Receives early access to new experimental patch versions</string>
     <string name="sources_prerelease_warning_title">Enable pre-release patches?</string>
-    <string name="sources_prerelease_warning_message">Pre-release builds are under active development and are not subject to the same stability guarantees as stable releases. They may contain incomplete features, unresolved defects, or breaking changes that could affect patching behavior or installed applications. Proceed only if you accept this risk.</string>
+    <string name="sources_prerelease_warning_message">Pre-release builds are still in development. Patches may fail or break the app, and features can change without warning</string>
     <string name="sources_prerelease_enable">Enable pre-release</string>
-    <string name="expert_mode_prerelease_notice">This source is configured to receive pre-release patch versions. These builds are under active development and are not subject to the stability guarantees of stable releases; patches may fail or behave unexpectedly.</string>
+    <string name="expert_mode_prerelease_notice">This source is on pre-release patches. Patching may fail or behave unexpectedly</string>
     <string name="sources_management_experimental_versions_toggle">Experimental app versions</string>
     <string name="sources_management_experimental_versions_toggle_description">Patches experimental app targets if available</string>
     <string name="sources_management_already_exists">This source has already been added</string>
@@ -272,7 +272,7 @@
     <string name="expert_mode_enable_all_done">All patches enabled</string>
     <string name="expert_mode_enable_all_universal_pending">Tap again for universal patches</string>
     <string name="expert_mode_universal_all_warning_title">Enable all universal patches?</string>
-    <string name="expert_mode_universal_all_warning_message">Enabling every universal patch at once can cause patch conflicts, patch failures, or app crashes due to factors such as incompatible patches or limited memory. Proceed only if you accept this risk.</string>
+    <string name="expert_mode_universal_all_warning_message">Universal patches are not tested together. Enabling all of them at once can cause conflicts, failed patching, or crashes</string>
     <string name="expert_mode_universal_all_enable">Enable all universal patches</string>
     <string name="expert_mode_reset_to_default">Enable recommended patches</string>
     <string name="expert_mode_reset_to_default_done">Recommended patches applied</string>

--- a/app/src/test/java/app/morphe/manager/domain/bundles/IssuesUrlInferenceTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/bundles/IssuesUrlInferenceTest.kt
@@ -6,6 +6,7 @@
 package app.morphe.manager.domain.bundles
 
 import app.morphe.manager.domain.bundles.RemotePatchBundle.Companion.inferIssuesUrlFromEndpoint
+import app.morphe.manager.domain.bundles.RemotePatchBundle.Companion.issuesUrlForRepoUrl
 import kotlin.test.*
 
 /**
@@ -52,5 +53,18 @@ class IssuesUrlInferenceTest {
     @Test
     fun `malformed endpoint has no issues page`() {
         assertNull(inferIssuesUrlFromEndpoint("not a url"))
+    }
+
+    @Test
+    fun `manifest declared repository gets the host issues path`() {
+        assertEquals(
+            "https://github.com/owner/repo/issues",
+            issuesUrlForRepoUrl("https://github.com/owner/repo")
+        )
+        assertEquals(
+            "https://gitlab.com/owner/repo/-/issues",
+            issuesUrlForRepoUrl("https://gitlab.com/owner/repo")
+        )
+        assertNull(issuesUrlForRepoUrl("https://patches.example.com/owner/repo"))
     }
 }

--- a/app/src/test/java/app/morphe/manager/domain/bundles/IssuesUrlInferenceTest.kt
+++ b/app/src/test/java/app/morphe/manager/domain/bundles/IssuesUrlInferenceTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.domain.bundles
+
+import app.morphe.manager.domain.bundles.RemotePatchBundle.Companion.inferIssuesUrlFromEndpoint
+import kotlin.test.*
+
+/**
+ * The "report an issue" button targets the repository's issues page, so the endpoint must map
+ * to the right host layout (GitHub /issues, GitLab /-/issues) and to nothing when unknown.
+ */
+class IssuesUrlInferenceTest {
+
+    @Test
+    fun `github raw endpoint maps to issues page`() {
+        assertEquals(
+            "https://github.com/jkennethcarino/adobo/issues",
+            inferIssuesUrlFromEndpoint(
+                "https://raw.githubusercontent.com/jkennethcarino/adobo/dev/patches-bundle.json"
+            )
+        )
+    }
+
+    @Test
+    fun `github release endpoint maps to issues page`() {
+        assertEquals(
+            "https://github.com/crimera/piko/issues",
+            inferIssuesUrlFromEndpoint(
+                "https://github.com/crimera/piko/releases/download/v3.9.0-dev.7/patches-3.9.0-dev.7.mpp"
+            )
+        )
+    }
+
+    @Test
+    fun `gitlab endpoint maps to issues page`() {
+        assertEquals(
+            "https://gitlab.com/owner/repo/-/issues",
+            inferIssuesUrlFromEndpoint("https://gitlab.com/owner/repo/-/raw/main/patches-bundle.json")
+        )
+    }
+
+    @Test
+    fun `unknown host has no issues page`() {
+        assertNull(
+            inferIssuesUrlFromEndpoint("https://example.com/patches/patches-bundle.json")
+        )
+    }
+
+    @Test
+    fun `malformed endpoint has no issues page`() {
+        assertNull(inferIssuesUrlFromEndpoint("not a url"))
+    }
+}


### PR DESCRIPTION
## Summary

1. **Report-an-issue shortcut** — a bug icon in the **Sources** sheet (next to the delete action) and in **Expert mode** (bundle action row) that opens the bundle's GitHub/GitLab issues page, derived from the MPP endpoint (GitHub `/issues`, GitLab `/-/issues`; official source → MorpheApp/morphe-patches/issues).

2. **Pre-release warnings** — enabling **Pre-release patches** on a source now requires confirmation explaining these are unstable testing builds. Expert mode also shows an amber warning header when a source is receiving pre-release versions (single + multi-bundle tabs, incl. batch patcher).

3. **Universal-patch warning** — the second "Enable all" tap in Expert mode (the one that actually applies every universal patch at once) now confirms first, since that can cause conflicts or failed patching.

4. **A–Z sort & filter options** — the home "Sort and filter" dialog lists both tabs alphabetically instead of in enum order.

5. **Recently patched sort mode** — new home sort option ordering apps by their stored `patched_at` timestamp, newest first (never-patched apps last).