### PR TITLE
fix: Add "Pre-release updates" confirmation dialog

### DIFF
--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/advanced/UpdatesSection.kt
@@ -47,6 +47,16 @@ fun UpdatesSettingsItem(
     val useManagerPrereleases by prefs.useManagerPrereleases.getAsState()
     val usePatchesPrereleases by prefs.bundlePrereleasesEnabled.getAsState()
     val showIntervalDialog = remember { mutableStateOf(false) }
+    val showPrereleaseWarning = remember { mutableStateOf(false) }
+
+    fun applyManagerPrereleases() {
+        settingsViewModel.toggleManagerPrereleases(
+            currentValue = useManagerPrereleases,
+            backgroundNotificationsEnabled = backgroundUpdateNotifications,
+            patchesPrereleaseIds = usePatchesPrereleases,
+            onCheckUpdate = onManagerPrereleasesToggle
+        )
+    }
 
     if (showIntervalDialog.value) {
         UpdateCheckIntervalDialog(
@@ -59,21 +69,35 @@ fun UpdatesSettingsItem(
         )
     }
 
+    if (showPrereleaseWarning.value) {
+        ConfirmDialog(
+            title = stringResource(R.string.settings_advanced_updates_prerelease_warning_title),
+            message = stringResource(R.string.settings_advanced_updates_prerelease_warning_message),
+            primaryText = stringResource(R.string.enable),
+            isPrimaryDestructive = false,
+            onDismiss = { showPrereleaseWarning.value = false },
+            onConfirm = {
+                showPrereleaseWarning.value = false
+                applyManagerPrereleases()
+            }
+        )
+    }
+
     SettingsGroup {
         // Use manager prereleases toggle
         SettingsSwitchItem(
             checked = useManagerPrereleases,
             onToggle = {
-                settingsViewModel.toggleManagerPrereleases(
-                    currentValue = useManagerPrereleases,
-                    backgroundNotificationsEnabled = backgroundUpdateNotifications,
-                    patchesPrereleaseIds = usePatchesPrereleases,
-                    onCheckUpdate = onManagerPrereleasesToggle
-                )
+                if (useManagerPrereleases) {
+                    applyManagerPrereleases()
+                } else {
+                    // Explain what pre-release means, and that patches are separate, before flipping it on
+                    showPrereleaseWarning.value = true
+                }
             },
             icon = Icons.Outlined.Science,
-            title = stringResource(R.string.settings_advanced_updates_use_prereleases),
-            subtitle = stringResource(R.string.settings_advanced_updates_use_prereleases_description)
+            title = stringResource(R.string.settings_advanced_updates_manager_prereleases),
+            subtitle = stringResource(R.string.settings_advanced_updates_manager_prereleases_description)
         )
 
         // Check frequency interval selector (non-GMS only), shown when background notifications

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,7 +719,7 @@ Uninstalling will permanently erase all app data"</string>
     <string name="settings_advanced_updates">Updates</string>
     <string name="settings_advanced_patcher">Patcher</string>
     <string name="settings_advanced_updates_use_prereleases">Pre-release updates</string>
-    <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe app versions. Enable pre-release per source in patch sources</string>
+    <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe Manager versions. Note: To enable pre-release patches, enable them in the patch sources list</string>
     <string name="settings_advanced_updates_allow_metered">Mobile data updates</string>
     <string name="settings_advanced_updates_allow_metered_description">Allows Morphe and patch updates to download over mobile data</string>
     <string name="settings_advanced_updates_background_notifications">Background update notifications</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -718,8 +718,14 @@ Uninstalling will permanently erase all app data"</string>
     <!-- Settings - Advanced Tab - Updates Section -->
     <string name="settings_advanced_updates">Updates</string>
     <string name="settings_advanced_patcher">Patcher</string>
-    <string name="settings_advanced_updates_use_prereleases">Pre-release updates</string>
-    <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe app versions. Note: To enable pre-release patches, enable them in the patch sources list</string>
+    <string name="settings_advanced_updates_manager_prereleases">Pre-release updates</string>
+    <!-- "Morphe" here is the app itself, not the patches. Do not translate this as pre-release patches -->
+    <string name="settings_advanced_updates_manager_prereleases_description">Early access to new Morphe versions</string>
+    <string name="settings_advanced_updates_prerelease_warning_title">Enable pre-release updates?</string>
+    <!-- Shown before pre-release updates are turned on for the app itself. Patches have their own toggle in each patch source -->
+    <string name="settings_advanced_updates_prerelease_warning_message">"Pre-release versions of Morphe are still in development and can be unstable.
+
+Patches are not affected: enable pre-release patches for each source in the patch sources list"</string>
     <string name="settings_advanced_updates_allow_metered">Mobile data updates</string>
     <string name="settings_advanced_updates_allow_metered_description">Allows Morphe and patch updates to download over mobile data</string>
     <string name="settings_advanced_updates_background_notifications">Background update notifications</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -719,7 +719,7 @@ Uninstalling will permanently erase all app data"</string>
     <string name="settings_advanced_updates">Updates</string>
     <string name="settings_advanced_patcher">Patcher</string>
     <string name="settings_advanced_updates_use_prereleases">Pre-release updates</string>
-    <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe Manager versions. Note: To enable pre-release patches, enable them in the patch sources list</string>
+    <string name="settings_advanced_updates_use_prereleases_description">Early access to new Morphe app versions. Note: To enable pre-release patches, enable them in the patch sources list</string>
     <string name="settings_advanced_updates_allow_metered">Mobile data updates</string>
     <string name="settings_advanced_updates_allow_metered_description">Allows Morphe and patch updates to download over mobile data</string>
     <string name="settings_advanced_updates_background_notifications">Background update notifications</string>


### PR DESCRIPTION
The current description makes it difficult to understand that the "Pre-release updates" setting applies only to the Manager.
It can be misinterpret as "This option enables pre-release for each source in patch sources"
In fact, even the person who translated this string at Crowdin was confused and translated it as if this setting also enabled pre-releases of patches in my language.
This PR reduces confusion for users when enabling patches pre-releases.

Additionally, to make it even clearer, in addition to this change, I think we can also change the setting title to "Pre-release updates for Manager".