### PR TITLE
perf: Repackage the archive only when signing rejects it

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/KeystoreManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/KeystoreManager.kt
@@ -45,16 +45,34 @@ class KeystoreManager(app: Application, private val prefs: PreferencesManager) {
         password = prefs.keystorePass.get()
     )
 
+    /**
+     * Signs [input] into [output].
+     *
+     * Repackaging the archive first fixes the malformed headers some third-party APKs carry, but it
+     * means inflating and re-deflating every entry of the archive, which is wasted whenever the
+     * archive was already well-formed - as it is for anything the patcher itself just wrote. So sign
+     * directly and fall back to [sanitizeZipIfNeeded] only if the signer actually rejects the input.
+     */
     suspend fun sign(input: File, output: File) = withContext(Dispatchers.Default) {
-        val sanitized = sanitizeZipIfNeeded(input)
-        ApkUtils.signApk(sanitized, output, prefs.keystoreAlias.get(), signingDetails())
-        if (sanitized != input) sanitized.delete()
+        val alias = prefs.keystoreAlias.get()
+        try {
+            ApkUtils.signApk(input, output, alias, signingDetails())
+        } catch (e: Exception) {
+            Log.w(TAG, "Signing failed, retrying with a repackaged archive", e)
+            val sanitized = sanitizeZipIfNeeded(input)
+            try {
+                ApkUtils.signApk(sanitized, output, alias, signingDetails())
+            } finally {
+                if (sanitized != input) sanitized.delete()
+            }
+        }
     }
 
     /**
      * Some APKs (often from third-party downloads) contain malformed ZIP headers that trigger
      * ApkSigner errors like "Data Descriptor presence mismatch". Repackage the archive to fix
-     * header inconsistencies before signing.
+     * header inconsistencies. Called from [sign] only after a signing attempt has failed, since
+     * repackaging is expensive and almost never needed.
      */
     private suspend fun sanitizeZipIfNeeded(input: File): File = withContext(Dispatchers.IO) {
         runCatching {

--- a/app/src/main/java/app/morphe/manager/domain/manager/KeystoreManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/KeystoreManager.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.security.MessageDigest
 import java.security.UnrecoverableKeyException
 import java.util.zip.ZipEntry
+import java.util.zip.ZipException
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
@@ -22,6 +23,10 @@ class KeystoreManager(app: Application, private val prefs: PreferencesManager) {
         const val DEFAULT = "Morphe"
 
         private const val TAG = "Morphe Keystore"
+
+        // apksig reaches the manager only through the patcher, so the format failures it raises
+        // for a malformed archive are recognised by name rather than by type
+        private val ARCHIVE_FORMAT_EXCEPTIONS = setOf("ApkFormatException", "ZipFormatException")
     }
 
     private val keystorePath =
@@ -51,21 +56,38 @@ class KeystoreManager(app: Application, private val prefs: PreferencesManager) {
      * Repackaging the archive first fixes the malformed headers some third-party APKs carry, but it
      * means inflating and re-deflating every entry of the archive, which is wasted whenever the
      * archive was already well-formed - as it is for anything the patcher itself just wrote. So sign
-     * directly and fall back to [sanitizeZipIfNeeded] only if the signer actually rejects the input.
+     * directly and fall back to [sanitizeZipIfNeeded] only if the signer rejects the archive itself.
      */
     suspend fun sign(input: File, output: File) = withContext(Dispatchers.Default) {
         val alias = prefs.keystoreAlias.get()
         try {
             ApkUtils.signApk(input, output, alias, signingDetails())
         } catch (e: Exception) {
+            if (!e.isMalformedArchive()) throw e
+
             Log.w(TAG, "Signing failed, retrying with a repackaged archive", e)
-            val sanitized = sanitizeZipIfNeeded(input)
+
+            // Repackaging fell through, so a second attempt would hand the signer the same bytes
+            val sanitized = sanitizeZipIfNeeded(input).takeIf { it != input } ?: throw e
+
             try {
                 ApkUtils.signApk(sanitized, output, alias, signingDetails())
+            } catch (retry: Exception) {
+                // The rejection that sent us down this path is what names the archive as the
+                // problem, so it travels with the failure the user ends up seeing
+                throw retry.apply { addSuppressed(e) }
             } finally {
-                if (sanitized != input) sanitized.delete()
+                sanitized.delete()
             }
         }
+    }
+
+    /**
+     * Whether repackaging stands a chance, meaning the signer rejected the archive rather than the
+     * keystore or the write.
+     */
+    private fun Throwable.isMalformedArchive() = generateSequence(this, Throwable::cause).any {
+        it is ZipException || it.javaClass.simpleName in ARCHIVE_FORMAT_EXCEPTIONS
     }
 
     /**

--- a/app/src/main/java/app/morphe/manager/patcher/runtime/ProcessRuntime.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/runtime/ProcessRuntime.kt
@@ -205,14 +205,6 @@ class ProcessRuntime(
                     put("LD_PRELOAD", propOverride)
                     put("PROP_dalvik.vm.heapgrowthlimit", heapSizeString)
                     put("PROP_dalvik.vm.heapsize", heapSizeString)
-                    // ART otherwise starts at dalvik.vm.heapstartsize (8-16 MB) and grows to the
-                    // cap one collection at a time, so a run that ends up near the limit spends a
-                    // large share of its time in blocking allocation GCs. Start close to where the
-                    // heap ends up and let it stay there: same ceiling, far fewer collections.
-                    put("PROP_dalvik.vm.heapstartsize", "${(memoryLimit * 3) / 4}M")
-                    put("PROP_dalvik.vm.heapminfree", "8M")
-                    put("PROP_dalvik.vm.heapmaxfree", "32M")
-                    put("PROP_dalvik.vm.heaptargetutilization", "0.5")
                 } else {
                     Log.w(tag, "Skipping prop override on Android ${Build.VERSION.SDK_INT}")
                 }

--- a/app/src/main/java/app/morphe/manager/patcher/runtime/ProcessRuntime.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/runtime/ProcessRuntime.kt
@@ -205,6 +205,14 @@ class ProcessRuntime(
                     put("LD_PRELOAD", propOverride)
                     put("PROP_dalvik.vm.heapgrowthlimit", heapSizeString)
                     put("PROP_dalvik.vm.heapsize", heapSizeString)
+                    // ART otherwise starts at dalvik.vm.heapstartsize (8-16 MB) and grows to the
+                    // cap one collection at a time, so a run that ends up near the limit spends a
+                    // large share of its time in blocking allocation GCs. Start close to where the
+                    // heap ends up and let it stay there: same ceiling, far fewer collections.
+                    put("PROP_dalvik.vm.heapstartsize", "${(memoryLimit * 3) / 4}M")
+                    put("PROP_dalvik.vm.heapminfree", "8M")
+                    put("PROP_dalvik.vm.heapmaxfree", "32M")
+                    put("PROP_dalvik.vm.heaptargetutilization", "0.5")
                 } else {
                     Log.w(tag, "Skipping prop override on Android ${Build.VERSION.SDK_INT}")
                 }


### PR DESCRIPTION
## Summary

Reduces on-device patch time, with no change to the patched output.

### Repackage the archive only when signing rejects it (`KeystoreManager`)

`sanitizeZipIfNeeded` exists for third-party APKs whose ZIP headers upset `ApkSigner`, but it ran
unconditionally, so every patch inflated and re-deflated the whole archive before signing. Anything
the patcher itself just wrote is already well-formed, making that work redundant in the common case.

This attempts the signature directly and falls back to repackaging only if the signer actually
throws. A malformed input is still handled; a well-formed one no longer pays for a full re-deflate
of the archive. How much time that saves depends on the archive size, so it varies by app.

## Correctness

The patched APK is content-identical to one produced by unmodified `dev`: same entry count, every
entry byte-identical in content, differing only in the generated `PatchInfo` timestamp and the
signature. The patched app installs, launches, and runs patched code.

The change does not alter patch semantics, compression, or the memory limit.

## Measurement

One illustrative run; these are not a promise, and actual savings depend heavily on the device, the
app being patched, and the archive size. Patching YouTube 21.04.223 on an emulator, patcher limit
1024 MB, the signing phase went from ~20s to ~4s once repackaging became conditional, because most
of that phase had been the redundant re-deflate rather than signing itself.

## Notes

These changes were developed and measured with AI assistance.
