### PR TITLE
feat: Group the patch list by category

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/PreferencesManager.kt
@@ -89,6 +89,9 @@ class PreferencesManager(
 
     val useExpertMode = booleanPreference("use_expert_mode", false)
 
+    /** Whether patch lists are sectioned by the categories their bundle declares. */
+    val groupPatchesByCategory = booleanPreference("group_patches_by_category", true)
+
     val stripUnusedNativeLibs = booleanPreference("strip_unused_native_libs", false)
 
     /** Bytecode processing mode for the patcher. Defaults to [BytecodeMode.STRIP_FAST]. */
@@ -108,7 +111,7 @@ class PreferencesManager(
     val useProcessRuntime = booleanPreference(
         "process_runtime", // Old key was 'use_process_runtime' and may have the wrong default for some devices.
         // Process runtime fails for Android 10 and lower.
-        // Armv7 silently fails and nobody has researched why.
+        // ARMv7 silently fails and nobody has researched why.
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !isArmV7()
     )
     val patcherProcessMemoryLimit = IntPreference(dataStore, "use_process_runtime_memory_limit", PROCESS_RUNTIME_MEMORY_NOT_SET)
@@ -249,6 +252,7 @@ class PreferencesManager(
         val randomBackgroundInterval: RandomInterval? = null,
         val matrixBackgroundUnlocked: Boolean? = null,
         val useExpertMode: Boolean? = null,
+        val groupPatchesByCategory: Boolean? = null,
         val updateCheckInterval: UpdateCheckInterval? = null,
         val externalBatchPatchEnabled: Boolean? = null,
         val externalBatchPatchAllowlist: Set<String>? = null,
@@ -302,6 +306,7 @@ class PreferencesManager(
         randomBackgroundInterval = randomBackgroundInterval.get(),
         matrixBackgroundUnlocked = matrixBackgroundUnlocked.get(),
         useExpertMode = useExpertMode.get(),
+        groupPatchesByCategory = groupPatchesByCategory.get(),
         updateCheckInterval = updateCheckInterval.get(),
         externalBatchPatchEnabled = externalBatchPatchEnabled.get(),
         externalBatchPatchAllowlist = externalBatchPatchAllowlist.get(),
@@ -372,6 +377,7 @@ class PreferencesManager(
         snapshot.randomBackgroundInterval?.let { randomBackgroundInterval.value = it }
         snapshot.matrixBackgroundUnlocked?.let { matrixBackgroundUnlocked.value = it }
         snapshot.useExpertMode?.let { useExpertMode.value = it }
+        snapshot.groupPatchesByCategory?.let { groupPatchesByCategory.value = it }
         snapshot.updateCheckInterval?.let { updateCheckInterval.value = it }
         snapshot.externalBatchPatchEnabled?.let { externalBatchPatchEnabled.value = it }
         snapshot.externalBatchPatchAllowlist?.let { externalBatchPatchAllowlist.value = it }

--- a/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
+++ b/app/src/main/java/app/morphe/manager/patcher/patch/PatchInfo.kt
@@ -25,6 +25,8 @@ data class PatchInfo(
     val availabilityResolver: AvailabilityResolver? = null,
     /** The name as declared by the bundle, for anything the user reads. */
     val displayName: String = name,
+    /** Group declared by the bundle, or null when the bundle does not categorize its patches. */
+    val category: String? = null
 ) {
     @Suppress("DEPRECATION")
     constructor(patch: Patch<*>) : this(
@@ -87,6 +89,7 @@ data class PatchInfo(
             }?.toImmutableList(),
         options = patch.options.map { (_, option) -> Option(option) }.ifEmpty { null }?.toImmutableList(),
         availabilityResolver = patch.availability,
+        category = patch.category?.takeIf { it.isNotBlank() }
     )
 
     /**

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/ExpertModeDialog.kt
@@ -84,7 +84,7 @@ fun ExpertModeDialog(
     proceedText: String = stringResource(R.string.expert_mode_proceed),
     /** Off where mixing sources is the norm rather than something the user just did. */
     warnOnMultipleBundles: Boolean = true,
-    /** Bundle uids currently receiving pre-release patch versions, shown as a warning header. */
+    /** Bundle UIDs currently receiving pre-release patch versions, shown as a warning header. */
     prereleaseBundleUids: Set<Int> = emptySet(),
     onDismiss: () -> Unit,
     onProceed: () -> Unit
@@ -108,7 +108,7 @@ fun ExpertModeDialog(
         }
     }
 
-    val expandedUniversal = rememberUniversalSectionState()
+    val patchSections = rememberPatchSectionState()
 
     // The pre-release warning is worth a glance, not a permanent strip on top of the list. It
     // retires per source, so a source the user has not opened yet still gets its turn, and the
@@ -286,7 +286,7 @@ fun ExpertModeDialog(
                     savedPatches = savedPatches,
                     lockStateOf = lockStateOf,
                     holdsUniversalPatches = holdsUniversalPatches,
-                    onExpandUniversal = { expandedUniversal.setExpanded(it, true) }
+                    onExpandUniversal = { patchSections.setExpanded(it, UNIVERSAL_GROUP_KEY, true) }
                 )
 
                 RetirePrereleaseNotice(
@@ -308,8 +308,7 @@ fun ExpertModeDialog(
                         listState = singleBundleList,
                         markers = markers,
                         isFiltering = isFiltering,
-                        isUniversalExpanded = bundle.uid in expandedUniversal,
-                        onUniversalExpandedChange = { expandedUniversal.setExpanded(bundle.uid, it) },
+                        sectionState = patchSections,
                         lockStateOf = lockStateOf,
                         patchActions = patchActions,
                         onConfigureOptions = { selectedPatchForOptions.value = bundle.uid to it }
@@ -414,7 +413,7 @@ fun ExpertModeDialog(
                     )
 
                     // Kept in place on a tab the filters emptied, so the pager height holds and
-                    // the bulk actions grey out instead of the whole row snapping away
+                    // the bulk actions gray out instead of the whole row snapping away
                     BundleControls(
                         bundle = currentBundle,
                         patches = currentFiltered.orEmpty(),
@@ -422,7 +421,7 @@ fun ExpertModeDialog(
                         savedPatches = savedPatches,
                         lockStateOf = lockStateOf,
                         holdsUniversalPatches = holdsUniversalPatches,
-                        onExpandUniversal = { expandedUniversal.setExpanded(it, true) },
+                        onExpandUniversal = { patchSections.setExpanded(it, UNIVERSAL_GROUP_KEY, true) },
                         modifier = Modifier.padding(vertical = Defaults.ContentPaddingSmall)
                     )
 
@@ -446,8 +445,7 @@ fun ExpertModeDialog(
                                     listState = pageListStates[pageIndex],
                                     markers = markers,
                                     isFiltering = isFiltering,
-                                    isUniversalExpanded = bundle.uid in expandedUniversal,
-                                    onUniversalExpandedChange = { expandedUniversal.setExpanded(bundle.uid, it) },
+                                    sectionState = patchSections,
                                     lockStateOf = lockStateOf,
                                     patchActions = patchActions,
                                     onConfigureOptions = { selectedPatchForOptions.value = bundle.uid to it }
@@ -548,16 +546,6 @@ private fun PatchesListEmptyOverlay(visible: Boolean) {
     }
 }
 
-/** One bundle's patches, split into the ones written for this app and the universal ones. */
-@Immutable
-private data class PatchSections(
-    val specific: List<Pair<PatchInfo, Boolean>>,
-    val universal: List<Pair<PatchInfo, Boolean>>
-) {
-    /** Enabled universal patches, the ones a folded section would otherwise hide. */
-    val selectedUniversalCount = universal.count { (_, isEnabled) -> isEnabled }
-}
-
 /** Everything the rows of a bundle badge or warn about, all keyed by bundle uid. */
 @Immutable
 private data class PatchMarkers(
@@ -566,26 +554,6 @@ private data class PatchMarkers(
     val customOptions: Map<Int, Set<String>>,
     val prereleaseNotices: Set<Int>
 )
-
-/**
- * Splits and orders one bundle's patches for display. New patches float to the top of each
- * group; within a group the order is alphabetical.
- */
-@Composable
-private fun rememberPatchSections(
-    patches: List<Pair<PatchInfo, Boolean>>,
-    newPatchNames: Set<String>
-): PatchSections = remember(patches, newPatchNames) {
-    val displayOrder = compareByDescending<Pair<PatchInfo, Boolean>> { (patch, _) ->
-        patch.name in newPatchNames
-    }.thenBy { (patch, _) -> patch.name }
-
-    val (universal, specific) = patches.partition { (patch, _) -> patch.isUniversal }
-    PatchSections(
-        specific = specific.sortedWith(displayOrder),
-        universal = universal.sortedWith(displayOrder)
-    )
-}
 
 /** How long a pre-release warning holds its place, long enough to read it once. */
 private val PrereleaseNoticeDuration = 8.seconds
@@ -675,9 +643,9 @@ private fun BundleControls(
 }
 
 /**
- * One bundle's scrolling list: its pre-release warning, the patches written for this app, then
- * the universal ones behind a collapsible header. Every row animates its own placement, so
- * search results and the fold settle instead of jumping.
+ * One bundle's scrolling list: its pre-release warning, then the patches block by block, each
+ * behind a collapsible header of its own. Every row animates its own placement, so search
+ * results and the fold settle instead of jumping.
  *
  * The scrollbar stays with the caller, since the tabbed layout draws a single overlay for the
  * whole pager rather than one per page.
@@ -689,8 +657,7 @@ private fun BundlePatchList(
     listState: LazyListState,
     markers: PatchMarkers,
     isFiltering: Boolean,
-    isUniversalExpanded: Boolean,
-    onUniversalExpandedChange: (Boolean) -> Unit,
+    sectionState: PatchSectionState,
     lockStateOf: (PatchInfo) -> PatchLockState,
     patchActions: ExpertPatchActions,
     onConfigureOptions: (PatchInfo) -> Unit,
@@ -699,7 +666,19 @@ private fun BundlePatchList(
     val newPatchNames = markers.newPatches[bundle.uid].orEmpty()
     val missingRequiredOptions = markers.missingRequiredOptions[bundle.uid].orEmpty()
     val customOptions = markers.customOptions[bundle.uid].orEmpty()
-    val sections = rememberPatchSections(patches = patches, newPatchNames = newPatchNames)
+    // New patches float to the top of each block; within a block the order is alphabetical
+    val ordered = remember(patches, newPatchNames) {
+        val displayOrder = compareByDescending<Pair<PatchInfo, Boolean>> { (patch, _) ->
+            patch.name in newPatchNames
+        }.thenBy { (patch, _) -> patch.name }
+        patches.sortedWith(displayOrder)
+    }
+    val groups = rememberPatchGroups(
+        patches = ordered,
+        infoOf = { (patch, _) -> patch },
+        isEnabled = { (_, isEnabled) -> isEnabled }
+    )
+    val folds = sectionState.folds
 
     LazyColumn(
         state = listState,
@@ -710,15 +689,13 @@ private fun BundlePatchList(
 
         // Availability is resolved per patch, so a universal patch the installer requires or
         // rules out carries the same lock as an app-specific one
-        patchSectionRows(
+        patchGroupRows(
             sectionKey = bundle.uid,
-            specific = sections.specific,
-            universal = sections.universal,
+            groups = groups,
             key = { (patch, _): Pair<PatchInfo, Boolean> -> "${bundle.uid}:${patch.name}" },
             isFiltering = isFiltering,
-            isUniversalExpanded = isUniversalExpanded,
-            onUniversalExpandedChange = onUniversalExpandedChange,
-            universalSelectedCount = sections.selectedUniversalCount
+            folds = folds,
+            onToggle = { group -> sectionState.toggle(bundle.uid, group) }
         ) { (patch, isEnabled) ->
             PatchCard(
                 patch = patch,

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/HomeAppDialogs.kt
@@ -87,7 +87,8 @@ fun AppPatchesDialog(
     val selectedBundle = remember { mutableStateOf<Int?>(null) }
     val showFilterSheet = remember { mutableStateOf(false) }
     val collapsedBundles = remember { mutableStateOf(emptySet<Int>()) }
-    val expandedUniversal = rememberUniversalSectionState()
+    val patchSections = rememberPatchSectionState()
+    val patchFolds = patchSections.folds
 
     val filteredPatches = remember(allPatches, searchQuery.value, selectedBundle.value) {
         allPatches.filter { (uid, patch) ->
@@ -116,6 +117,20 @@ fun AppPatchesDialog(
         }
         result.map { it.first to it.second.toList() }
     }
+
+    // Every bundle's rows are grouped up front, so the list builder below stays free of the
+    // preference read and the resource lookup that grouping needs
+    val groupingOptions = rememberPatchGroupingOptions()
+    val bundleGroups: List<Pair<Int, List<PatchGroup<PatchInfo>>>> =
+        remember(groupedFilteredPatches, groupingOptions) {
+            groupedFilteredPatches.map { (uid, bundlePatches) ->
+                uid to buildPatchGroups(
+                    patches = bundlePatches,
+                    options = groupingOptions,
+                    infoOf = { patch -> patch }
+                )
+            }
+        }
 
     AppDialog(
         onDismissRequest = onDismiss,
@@ -220,58 +235,39 @@ fun AppPatchesDialog(
                         }
 
                         // Patch cards grouped by bundle
-                        groupedFilteredPatches.forEach { (uid, bundlePatches) ->
+                        bundleGroups.forEach { (uid, groups) ->
                             // Bundle section header (collapsible) - only for multi-bundle
                             if (isMultiBundle) {
                                 item(key = "header_$uid") {
                                     val isCollapsed = uid in collapsedBundles.value
-                                    val expandLabel = stringResource(R.string.expand)
-                                    val collapseLabel = stringResource(R.string.collapse)
-                                    HomeGlassCategoryRow(
+                                    PatchGroupHeader(
                                         title = bundleNames[uid] ?: uid.toString(),
-                                        leading = {
-                                            Icon(
-                                                imageVector = Icons.Outlined.Layers,
-                                                contentDescription = null,
-                                                modifier = Modifier.size(24.dp),
-                                                tint = MaterialTheme.colorScheme.primary
-                                            )
-                                        },
-                                        color = rememberAccentCardColor(bundleAccentColors[uid]),
-                                        trailing = {
-                                            Icon(
-                                                imageVector = if (isCollapsed) Icons.Outlined.ExpandMore else Icons.Outlined.ExpandLess,
-                                                contentDescription = if (isCollapsed) expandLabel else collapseLabel,
-                                                modifier = Modifier.size(24.dp),
-                                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        },
-                                        onClick = {
+                                        count = groups.sumOf { it.items.size },
+                                        isExpanded = !isCollapsed,
+                                        onToggle = {
                                             collapsedBundles.value = if (isCollapsed) {
                                                 collapsedBundles.value - uid
                                             } else {
                                                 collapsedBundles.value + uid
                                             }
                                         },
-                                        cornerRadius = Defaults.SettingsCornerRadius,
+                                        icon = Icons.Outlined.Layers,
+                                        accentColor = bundleAccentColors[uid],
                                         modifier = Modifier.animatedListItem(this)
                                     )
                                 }
                             }
 
                             if (uid !in collapsedBundles.value) {
-                                val (specificPatches, universalPatches) = bundlePatches.partition { !it.isUniversal }
-
-                                patchSectionRows(
+                                patchGroupRows(
                                     sectionKey = uid,
-                                    specific = specificPatches,
-                                    universal = universalPatches,
+                                    groups = groups,
                                     key = { patch: PatchInfo ->
                                         "$uid:${patch.name}:${patch.compatiblePackages?.joinToString { it.packageName.orEmpty() }.orEmpty()}"
                                     },
                                     isFiltering = isFiltering,
-                                    isUniversalExpanded = uid in expandedUniversal,
-                                    onUniversalExpandedChange = { expandedUniversal.setExpanded(uid, it) },
+                                    folds = patchFolds,
+                                    onToggle = { group -> patchSections.toggle(uid, group) },
                                     accentColor = bundleAccentColors[uid]
                                 ) { patch ->
                                     PatchItemCard(

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/PatchesListShared.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/PatchesListShared.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -35,6 +36,8 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import app.morphe.manager.R
+import app.morphe.manager.domain.manager.PreferencesManager
+import app.morphe.manager.patcher.patch.PatchInfo
 import app.morphe.manager.ui.screen.shared.Animations
 import app.morphe.manager.ui.screen.shared.AppDialogTextField
 import app.morphe.manager.ui.screen.shared.Defaults
@@ -44,6 +47,7 @@ import app.morphe.manager.ui.screen.shared.SemanticTone
 import app.morphe.manager.ui.screen.shared.StatusBadge
 import app.morphe.manager.ui.screen.shared.animatedListItem
 import app.morphe.manager.util.toHsv
+import org.koin.compose.koinInject
 
 /**
  * Header card shown at the top of patches-list dialogs.
@@ -110,23 +114,148 @@ internal fun rememberAccentCardColor(accentColor: Color?): Color? =
     }
 
 /**
- * Collapsible section header for the universal patches of one bundle.
+ * One collapsible block of a patch list.
  *
- * A null [onToggle] drops the chevron and the click, for the cases where the section has
- * nothing left to fold away.
+ * A null [title] is the ungrouped remainder: it carries no header and is always drawn, which is
+ * how a bundle that declares no categories keeps the plain list it has today. [key] is what the
+ * fold state is stored under, so a block holds its fold while a search reorders the list around it.
+ */
+@Immutable
+internal data class PatchGroup<T>(
+    val key: String,
+    val title: String?,
+    val items: List<T>,
+    val icon: ImageVector = Icons.Outlined.Category,
+    /** Enabled patches, the ones a folded block would otherwise hide. */
+    val selectedCount: Int = 0,
+    val defaultExpanded: Boolean = true
+)
+
+/** Fold key of the universal block, for the callers that have to open it from the outside. */
+internal const val UNIVERSAL_GROUP_KEY = "universal"
+
+private const val UNGROUPED_GROUP_KEY = "ungrouped"
+
+/**
+ * Splits [patches] into the blocks a list is drawn as: whatever the bundle left uncategorized,
+ * then one block per declared category, then the universal patches it did not categorize.
  *
- * [accentColor] is the color the bundle marks its own patches with, so the header stays part of
- * the block it opens when several bundles each contribute a universal section.
+ * A category is what the bundle asked for, so it wins over the universal split: a universal patch
+ * that declares one joins that block rather than the tail. Bundles written entirely against
+ * universal targets are the ones with the most patches to sort through, and folding all of them
+ * into a single tail would leave them exactly as unsorted as before.
  *
- * [selectedCount] is badged on the header itself, since a folded section is the one place a
- * patch can be enabled without being visible.
+ * The tail keeps the universal patches with no category of their own. Those apply to every app and
+ * would otherwise bury the handful written for this one, so they stay last and folded. Categories
+ * start out open instead, since folding a block that hides an enabled patch is only worth it for
+ * the one the user is least likely to have picked from. With grouping off the categories are
+ * ignored and only that tail is split off, which is also what a bundle that declares no categories
+ * at all comes out as.
+ *
+ * Order within a block is the order [patches] came in, so callers keep the sorting they want.
+ */
+internal fun <T> buildPatchGroups(
+    patches: List<T>,
+    options: PatchGroupingOptions,
+    infoOf: (T) -> PatchInfo,
+    isEnabled: (T) -> Boolean = { false }
+): List<PatchGroup<T>> {
+    val byCategory = patches.groupBy { if (options.groupByCategory) infoOf(it).category else null }
+    val (universal, ungrouped) = byCategory[null].orEmpty().partition { infoOf(it).isUniversal }
+
+    return buildList {
+        if (ungrouped.isNotEmpty()) {
+            add(PatchGroup(key = UNGROUPED_GROUP_KEY, title = null, items = ungrouped))
+        }
+
+        byCategory.keys.filterNotNull().sortedBy { it.lowercase() }.forEach { category ->
+            val items = byCategory.getValue(category)
+            add(
+                PatchGroup(
+                    key = "category:$category",
+                    title = category,
+                    items = items,
+                    selectedCount = items.count(isEnabled)
+                )
+            )
+        }
+
+        if (universal.isNotEmpty()) {
+            add(
+                PatchGroup(
+                    key = UNIVERSAL_GROUP_KEY,
+                    title = options.universalTitle,
+                    items = universal,
+                    icon = Icons.Outlined.Public,
+                    selectedCount = universal.count(isEnabled),
+                    defaultExpanded = false
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Everything [buildPatchGroups] needs beyond the patches themselves, read once per list rather
+ * than per bundle, so a screen that groups several lists does not call into composition per item.
+ */
+@Immutable
+internal data class PatchGroupingOptions(
+    val universalTitle: String,
+    val groupByCategory: Boolean
+)
+
+@Composable
+internal fun rememberPatchGroupingOptions(
+    prefs: PreferencesManager = koinInject()
+): PatchGroupingOptions {
+    val universalTitle = stringResource(R.string.expert_mode_universal_patches)
+    val groupByCategory by prefs.groupPatchesByCategory.getAsState()
+
+    return remember(universalTitle, groupByCategory) {
+        PatchGroupingOptions(universalTitle, groupByCategory)
+    }
+}
+
+/**
+ * The blocks [patches] is drawn as, following the user's grouping preference.
+ *
+ * Categories are whatever the bundle declares, so a bundle that declares none, and a user who
+ * turned grouping off, both end up with the plain list plus its universal tail.
  */
 @Composable
-internal fun UniversalPatchesHeader(
+internal fun <T> rememberPatchGroups(
+    patches: List<T>,
+    infoOf: (T) -> PatchInfo,
+    isEnabled: (T) -> Boolean = { false }
+): List<PatchGroup<T>> {
+    val options = rememberPatchGroupingOptions()
+
+    return remember(patches, options) {
+        buildPatchGroups(patches, options, infoOf, isEnabled)
+    }
+}
+
+/**
+ * Collapsible header of one block of a patch list.
+ *
+ * A null [onToggle] drops the chevron and the click, for the cases where the block has nothing
+ * left to fold away.
+ *
+ * [accentColor] is the color the bundle marks its own patches with, so the header stays part of
+ * the block it opens when several bundles each contribute one.
+ *
+ * [selectedCount] is badged on the header itself, since a folded block is the one place a patch
+ * can be enabled without being visible.
+ */
+@Composable
+internal fun PatchGroupHeader(
+    title: String,
     count: Int,
     isExpanded: Boolean,
     onToggle: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    icon: ImageVector = Icons.Outlined.Category,
     accentColor: Color? = null,
     selectedCount: Int = 0
 ) {
@@ -134,7 +263,7 @@ internal fun UniversalPatchesHeader(
     val chevronRotation by animateFloatAsState(
         targetValue = if (isExpanded) 180f else 0f,
         animationSpec = tween(Defaults.ANIMATION_DURATION),
-        label = "universal_patches_chevron"
+        label = "patch_group_chevron"
     )
 
     // Held while the badge fades out, so the count does not blink to zero on its way off
@@ -143,12 +272,12 @@ internal fun UniversalPatchesHeader(
     val shownSelectedCount = lastSelectedCount.intValue
 
     HomeGlassCategoryRow(
-        title = stringResource(R.string.expert_mode_universal_patches),
+        title = title,
         count = pluralStringResource(R.plurals.patch_count, count, count.toString()),
         onClick = onToggle,
         leading = {
             Icon(
-                imageVector = Icons.Outlined.Public,
+                imageVector = icon,
                 contentDescription = null,
                 modifier = Modifier.size(24.dp),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
@@ -202,49 +331,52 @@ internal fun UniversalPatchesHeader(
 }
 
 /**
- * Rows of one bundle: the patches written for the app at hand first, then the universal ones
- * behind a collapsible header.
+ * Rows of one patch list, block by block, each behind a collapsible header of its own.
  *
- * Universal patches apply to every app and would otherwise bury the handful written for this one.
- * There is nothing worth folding away when they are the whole list, or when a filter already
- * narrows it, so [isFiltering] and an empty [specific] both keep the section open.
+ * There is nothing worth folding away when the list is a single block, and a filter already
+ * narrows it far enough that a fold would only hide results, so both keep every block open.
  *
  * [row] draws one patch and stays with the caller, since the lists differ in what a row carries
  * and in what it can be toggled into.
+ *
+ * [folds] is a plain snapshot rather than the state holder itself: this builder runs while the
+ * lazy list assembles its items, so a fold has to reach it as a value the screen already read.
  */
-internal fun <T> LazyListScope.patchSectionRows(
+internal fun <T> LazyListScope.patchGroupRows(
     sectionKey: Any,
-    specific: List<T>,
-    universal: List<T>,
+    groups: List<PatchGroup<T>>,
     key: (T) -> Any,
     isFiltering: Boolean,
-    isUniversalExpanded: Boolean,
-    onUniversalExpandedChange: (Boolean) -> Unit,
+    folds: PatchFolds,
+    onToggle: (PatchGroup<T>) -> Unit,
     accentColor: Color? = null,
-    universalSelectedCount: Int = 0,
     row: @Composable LazyItemScope.(T) -> Unit
 ) {
-    items(specific, key = key, itemContent = row)
+    val alwaysOpen = isFiltering || groups.size == 1
 
-    if (universal.isEmpty()) return
+    groups.forEach { group ->
+        if (group.title == null) {
+            items(group.items, key = key, itemContent = row)
+            return@forEach
+        }
 
-    val alwaysOpen = isFiltering || specific.isEmpty()
-    val isExpanded = alwaysOpen || isUniversalExpanded
+        val isExpanded = alwaysOpen || folds.isExpanded(sectionKey, group)
 
-    item(key = "universal_header_$sectionKey") {
-        UniversalPatchesHeader(
-            count = universal.size,
-            isExpanded = isExpanded,
-            onToggle = if (alwaysOpen) null else { { onUniversalExpandedChange(!isUniversalExpanded) } },
-            accentColor = accentColor,
-            selectedCount = universalSelectedCount,
-            modifier = Modifier.animatedListItem(this)
-        )
+        item(key = "group_${sectionKey}_${group.key}") {
+            PatchGroupHeader(
+                title = group.title,
+                count = group.items.size,
+                isExpanded = isExpanded,
+                onToggle = if (alwaysOpen) null else ({ onToggle(group) }),
+                icon = group.icon,
+                accentColor = accentColor,
+                selectedCount = group.selectedCount,
+                modifier = Modifier.animatedListItem(this)
+            )
+        }
+
+        if (isExpanded) items(group.items, key = key, itemContent = row)
     }
-
-    if (!isExpanded) return
-
-    items(universal, key = key, itemContent = row)
 }
 
 /**
@@ -321,21 +453,42 @@ internal fun PatchesListEmptyState(modifier: Modifier = Modifier) {
 }
 
 /**
- * Which bundles have their universal section unfolded.
+ * The folds of a patch list, as a value a screen can read and hand to the list builder.
  *
- * The state belongs to the screen rather than to the section, since "enable all" has to open a
- * section on the tap that finally reaches its universal patches.
+ * Only explicit toggles are stored, so a block the user never touched follows its own default.
+ */
+@Immutable
+internal data class PatchFolds(private val overrides: Map<String, Boolean>) {
+    fun isExpanded(sectionKey: Any, group: PatchGroup<*>) =
+        overrides[foldKey(sectionKey, group.key)] ?: group.defaultExpanded
+
+    internal fun with(sectionKey: Any, groupKey: String, expanded: Boolean) =
+        PatchFolds(overrides + (foldKey(sectionKey, groupKey) to expanded))
+}
+
+private fun foldKey(sectionKey: Any, groupKey: String) = "$sectionKey:$groupKey"
+
+/**
+ * Which blocks of a patch list the user has folded open or shut.
+ *
+ * The state belongs to the screen rather than to the block, since "enable all" has to open a
+ * block on the tap that finally reaches its universal patches. Screens read [folds] in
+ * composition, so a toggle rebuilds the list the ordinary way instead of relying on the lazy
+ * list to observe a read made while it was assembling its items.
  */
 @Stable
-internal class UniversalSectionState {
-    private var expandedUids by mutableStateOf(emptySet<Int>())
+internal class PatchSectionState {
+    var folds by mutableStateOf(PatchFolds(emptyMap()))
+        private set
 
-    operator fun contains(bundleUid: Int) = bundleUid in expandedUids
+    fun toggle(sectionKey: Any, group: PatchGroup<*>) {
+        setExpanded(sectionKey, group.key, !folds.isExpanded(sectionKey, group))
+    }
 
-    fun setExpanded(bundleUid: Int, expanded: Boolean) {
-        expandedUids = if (expanded) expandedUids + bundleUid else expandedUids - bundleUid
+    fun setExpanded(sectionKey: Any, groupKey: String, expanded: Boolean) {
+        folds = folds.with(sectionKey, groupKey, expanded)
     }
 }
 
 @Composable
-internal fun rememberUniversalSectionState() = remember { UniversalSectionState() }
+internal fun rememberPatchSectionState() = remember { PatchSectionState() }

--- a/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/home/SourceManagementDialogs.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -543,6 +542,13 @@ fun BundlePatchesDialog(
 
     val isFiltering = searchQuery.isNotBlank() || selectedPackages.isNotEmpty()
 
+    val patchSections = rememberPatchSectionState()
+    val patchFolds = patchSections.folds
+    val patchGroups = rememberPatchGroups(
+        patches = filteredPatches,
+        infoOf = { (_, patch) -> patch }
+    )
+
     AppDialog(
         onDismissRequest = {
             when {
@@ -649,9 +655,13 @@ fun BundlePatchesDialog(
                         }
 
                         // Filtered patches list
-                        items(
-                            filteredPatches,
-                            key = { (index, _) -> index }
+                        patchGroupRows(
+                            sectionKey = src.uid,
+                            groups = patchGroups,
+                            key = { (index, _): IndexedValue<PatchInfo> -> index },
+                            isFiltering = isFiltering,
+                            folds = patchFolds,
+                            onToggle = { group -> patchSections.toggle(src.uid, group) }
                         ) { (_, patch) ->
                             val context = LocalContext.current
                             val expertBadgeTooltip = stringResource(R.string.sources_patch_expert_badge_tooltip)

--- a/app/src/main/java/app/morphe/manager/ui/screen/settings/AppearanceTabContent.kt
+++ b/app/src/main/java/app/morphe/manager/ui/screen/settings/AppearanceTabContent.kt
@@ -74,6 +74,7 @@ fun AppearanceTabContent(
     val customAppCardColors by themeViewModel.prefs.customAppCardColors.getAsState()
     val showAppGroupingSwitcher by homeAppButtonPrefs.showCategoryViewSwitcher.collectAsStateWithLifecycle()
     val showSortButton by homeAppButtonPrefs.showSortButton.collectAsStateWithLifecycle()
+    val groupPatchesByCategory by themeViewModel.prefs.groupPatchesByCategory.getAsState()
     val backgroundType by themeViewModel.prefs.backgroundType.getAsState()
     val enableParallax by themeViewModel.prefs.enableBackgroundParallax.getAsState()
     val randomInterval by themeViewModel.prefs.randomBackgroundInterval.getAsState()
@@ -147,6 +148,13 @@ fun AppearanceTabContent(
             onRepatchNoticeToggle = { themeViewModel.toggleShowRepatchNotice(showRepatchNotice) },
             onSortButtonToggle = { homeAppButtonPrefs.setShowSortButton(!showSortButton) },
             onAppGroupingToggle = { homeAppButtonPrefs.setShowCategoryViewSwitcher(!showAppGroupingSwitcher) }
+        )
+
+        PatchListSection(
+            groupByCategory = groupPatchesByCategory,
+            onGroupByCategoryToggle = {
+                themeViewModel.toggleGroupPatchesByCategory(groupPatchesByCategory)
+            }
         )
 
         BackgroundSection(
@@ -461,6 +469,30 @@ private fun HomeScreenSection(
             icon = Icons.Outlined.ViewAgenda,
             checked = showAppGrouping,
             onToggle = onAppGroupingToggle
+        )
+    }
+}
+
+/**
+ * Toggles for how patch lists are laid out.
+ */
+@Composable
+private fun PatchListSection(
+    groupByCategory: Boolean,
+    onGroupByCategoryToggle: () -> Unit
+) {
+    SectionHeader(
+        text = stringResource(R.string.settings_appearance_patch_list),
+        icon = Icons.Outlined.Extension
+    )
+
+    SettingsGroup(modifier = Modifier.padding(bottom = Defaults.ContentPadding)) {
+        SettingsSwitchItem(
+            title = stringResource(R.string.settings_appearance_patch_categories),
+            subtitle = stringResource(R.string.settings_appearance_patch_categories_description),
+            icon = Icons.Outlined.Category,
+            checked = groupByCategory,
+            onToggle = onGroupByCategoryToggle
         )
     }
 }

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/ThemeSettingsViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/ThemeSettingsViewModel.kt
@@ -114,6 +114,10 @@ class ThemeSettingsViewModel(
         prefs.showRepatchNotice.update(!current)
     }
 
+    fun toggleGroupPatchesByCategory(current: Boolean) = viewModelScope.launch {
+        prefs.groupPatchesByCategory.update(!current)
+    }
+
     fun setPureBlackTheme(enabled: Boolean) = viewModelScope.launch {
         prefs.pureBlackTheme.update(enabled)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,6 +731,9 @@ Uninstalling will permanently erase all app data"</string>
     <string name="settings_appearance_greeting_phrases_subtitle">Show a greeting message on the home screen</string>
     <string name="settings_appearance_app_grouping">App grouping</string>
     <string name="settings_appearance_app_grouping_description">Show a home screen switcher to group apps by source or your own categories, keeping the selection when off</string>
+    <string name="settings_appearance_patch_list">Patch list</string>
+    <string name="settings_appearance_patch_categories">Group by category</string>
+    <string name="settings_appearance_patch_categories_description">Section patch lists by the categories a source declares, leaving sources that declare none as a plain list</string>
     <string name="settings_appearance_repatch_notice">Re-patch notice</string>
     <string name="settings_appearance_repatch_notice_description">Show a banner on the home screen when patched apps can be re-patched</string>
     <string name="settings_appearance_sort_button">Sort and filter button</string>

--- a/app/src/test/java/app/morphe/manager/ui/screen/home/PatchGroupingTest.kt
+++ b/app/src/test/java/app/morphe/manager/ui/screen/home/PatchGroupingTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Morphe.
+ * https://github.com/MorpheApp/morphe-manager
+ */
+
+package app.morphe.manager.ui.screen.home
+
+import app.morphe.manager.patcher.patch.CompatiblePackage
+import app.morphe.manager.patcher.patch.PatchInfo
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * How a patch list is cut into blocks. A bundle that declares no categories has to come out as the
+ * plain list it was before categories existed, since that is what every already published bundle is.
+ */
+class PatchGroupingTest {
+    private val options = PatchGroupingOptions(universalTitle = "Universal", groupByCategory = true)
+
+    private fun patch(name: String, category: String? = null, universal: Boolean = false) = PatchInfo(
+        name = name,
+        description = null,
+        include = false,
+        compatiblePackages = if (universal) {
+            null
+        } else {
+            persistentListOf(CompatiblePackage(packageName = "com.example", versions = null))
+        },
+        options = null,
+        category = category
+    )
+
+    private fun group(patches: List<PatchInfo>, options: PatchGroupingOptions = this.options) =
+        buildPatchGroups(patches, options, infoOf = { it }, isEnabled = { it.include })
+
+    @Test
+    fun `a bundle without categories keeps the plain list it had before`() {
+        val groups = group(listOf(patch("A"), patch("B"), patch("U", universal = true)))
+
+        assertEquals(2, groups.size)
+        assertNull(groups[0].title, "the ungrouped block carries no header")
+        assertEquals(listOf("A", "B"), groups[0].items.map { it.name })
+        assertEquals("Universal", groups[1].title)
+        assertFalse(groups[1].defaultExpanded, "the universal block stays folded")
+    }
+
+    @Test
+    fun `categories become blocks of their own, ordered after the ungrouped ones`() {
+        val groups = group(
+            listOf(
+                patch("Ungrouped"),
+                patch("Zoom", category = "Video"),
+                patch("Hide ads", category = "Ads"),
+                patch("U", universal = true)
+            )
+        )
+
+        assertEquals(listOf(null, "Ads", "Video", "Universal"), groups.map { it.title })
+        assertTrue(groups[1].defaultExpanded, "categories start out open")
+    }
+
+    @Test
+    fun `a list that is all one category is still a block, so it can be folded`() {
+        val groups = group(listOf(patch("A", category = "Ads"), patch("B", category = "Ads")))
+
+        assertEquals(listOf("Ads"), groups.map { it.title })
+        assertEquals(2, groups[0].items.size)
+    }
+
+    @Test
+    fun `grouping switched off leaves the same blocks as a bundle without categories`() {
+        val patches = listOf(
+            patch("A", category = "Ads"),
+            patch("B", category = "Video"),
+            patch("U", universal = true)
+        )
+
+        val groups = group(patches, options.copy(groupByCategory = false))
+
+        assertEquals(listOf(null, "Universal"), groups.map { it.title })
+        assertEquals(listOf("A", "B"), groups[0].items.map { it.name })
+    }
+
+    @Test
+    fun `the selected count is per block, since a folded block hides what it holds`() {
+        val enabled = patch("On", category = "Ads").copy(include = true)
+        val groups = group(listOf(enabled, patch("Off", category = "Ads"), patch("Other", category = "Video")))
+
+        assertEquals(1, groups.first { it.title == "Ads" }.selectedCount)
+        assertEquals(0, groups.first { it.title == "Video" }.selectedCount)
+    }
+
+    @Test
+    fun `a universal patch that declares a category joins it instead of the tail`() {
+        val groups = group(
+            listOf(
+                patch("Specific", category = "Ads"),
+                patch("Universal ad block", category = "Ads", universal = true),
+                patch("Plain universal", universal = true)
+            )
+        )
+
+        assertEquals(listOf("Ads", "Universal"), groups.map { it.title })
+        assertEquals(listOf("Specific", "Universal ad block"), groups[0].items.map { it.name })
+        assertEquals(listOf("Plain universal"), groups[1].items.map { it.name })
+    }
+
+    @Test
+    fun `a bundle that categorizes every universal patch is left with no tail at all`() {
+        val groups = group(
+            listOf(
+                patch("Block ads", category = "Ads", universal = true),
+                patch("Spoof model", category = "Spoofs", universal = true)
+            )
+        )
+
+        assertEquals(listOf("Ads", "Spoofs"), groups.map { it.title })
+    }
+
+    @Test
+    fun `grouping switched off puts categorized universal patches back in the tail`() {
+        val groups = group(
+            listOf(patch("Block ads", category = "Ads", universal = true)),
+            options.copy(groupByCategory = false)
+        )
+
+        assertEquals(listOf("Universal"), groups.map { it.title })
+    }
+
+    @Test
+    fun `blocks are keyed by category, so a fold survives the list being filtered around it`() {
+        val first = group(listOf(patch("A", category = "Ads"), patch("B", category = "Video")))
+        val filtered = group(listOf(patch("B", category = "Video")))
+
+        assertEquals(first.first { it.title == "Video" }.key, filtered.single().key)
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional, bundle-declared **category** to patches and uses it to section the universal patches in the manager's patch lists. A bundle picks its own taxonomy; the manager groups by whatever it finds and leaves everything else exactly as it is today.

Addresses MorpheApp/morphe-manager#929 and MorpheApp/morphe-manager#933

Large bundles are hard to navigate, and universal ones are the worst of it: a bundle written entirely against universal targets can carry several hundred patches with nothing to sort them by. Both issues ask for the same thing: collapsible sections by patch type, with search reaching inside them.

## Scope: universal patches only, for now

The field is free-form and available to every patch, but the manager currently acts on it **only for universal patches**. A category declared on an app specific patch is read and ignored, and those rows keep exactly the list they have today.

That is deliberate. Universal patches are the ones a list drowns in, while patches written for a single app are already narrowed down by that app. Limiting the first step this way means there is almost nothing to walk back if a taxonomy turns out to be wrong: one condition in `buildPatchGroups`, rather than a layout change across every patch list in the app.

## What changes

**`morphe-patcher`**
- `Patch.category: String?`, added as a trailing field with a default, exactly the way `availability` was added.
- `PatchBuilder.category(name)` for the DSL.
- `api/morphe-patcher.api` regenerated.

**`morphe-patches-library`**
- `PatchListGenerator` writes `category` into `patches-list.json`. Purely additive: existing consumers ignore the new field, and it stays `null` for bundles that declare nothing.

**`morphe-patches-template`**
- The template carries its own copy of `PatchListGenerator`, so it gets the same change. Kept identical to the library copy apart from its package, which is how the two have been kept so far.

**`morphe-manager`**
- `PatchInfo.category`, read straight off the loaded patch.
- `PatchesListShared.kt` is generalized from the fixed pair "app specific + universal" into a list of blocks: `PatchGroup`, `buildPatchGroups()`, `patchGroupRows()`. The universal block is now simply the last group, still folded by default, and holds whatever the bundle did not categorize.
- Settings → Appearance → **Patch list → Group by category** (on by default).

## Backwards compatibility

- **Existing bundles keep working untouched.** Bundles call the `bytecodePatch { }` DSL, never the `Patch` constructor, so a bundle compiled before this change simply never calls `category(...)` and the field stays `null`.
- **A bundle that declares no categories renders exactly the list it renders today**: one headerless block plus the universal tail. This is not a special case in the code, it is what `buildPatchGroups` produces when every category is `null`.
- **App specific rows are untouched either way**, since categories are not acted on for them yet.
- **No data migration.** Selections, options, `SeenPatch` and exported configurations are keyed by patch name via `uniqueNames()`. `category` is deliberately not part of that key, so every stored selection stays valid.
- **Users who do not want it** switch the setting off, which collapses the categories back into the plain list.

## Declaring a category

One line in the patch builder. Patches that do not call it stay ungrouped.

```kotlin
val overrideCertificatePinningPatch = resourcePatch(
    name = "Override certificate pinning",
    description = "Overrides certificate pinning, allowing to inspect traffic via a proxy.",
    default = false
) {
    category("Privacy and network")

    execute {
        // ...
    }
}
```

The name is free-form, matched by the manager as an opaque key, so a bundle can ship any taxonomy it likes without agreeing on one with us. Nothing has to be registered anywhere: an unknown category is simply a new section header.

## How it looks in the manager

- Each category is a collapsible header carrying its patch count, and a badge with the number of enabled patches so a folded block never hides a selection silently.
- Categories start expanded; the universal block keeps its current folded default.
- Searching or filtering forces every block open and drops the empty ones, so a match is never hidden behind a fold.
- Ordering: the patches written for the app at hand first (no header, as today), then the declared categories alphabetically, then the universal patches the bundle did not categorize.
- All three patch lists share the same code: the expert mode selection dialog, the per app patch list, and the bundle browser in Patch sources.

<details>
 <summary>Screenshot</summary>

<img width="1080" height="1986" alt="Screenshot_2026-09-05-00-14-55-060_app morphe manager debug-edit" src="https://github.com/user-attachments/assets/7aab821f-4046-4dae-b6d4-9f75bcd6773e" />

</details>

## Merge order

The repositories depend on each other, so merge and release in this order:

1. https://github.com/MorpheApp/morphe-patcher/pull/198
2. https://github.com/MorpheApp/morphe-patches-library/pull/54
3. https://github.com/MorpheApp/morphe-manager/pull/941
4. https://github.com/MorpheApp/morphe-patches-template/pull/60