### PR TITLE
feat: fall back to the bundle website for unresolved downloads

### DIFF
--- a/app/src/main/java/app/morphe/manager/domain/bundles/PatchBundleSource.kt
+++ b/app/src/main/java/app/morphe/manager/domain/bundles/PatchBundleSource.kt
@@ -48,6 +48,10 @@ sealed class PatchBundleSource(
     }
 
     val version get() = manifestAttributes?.version
+
+    /** Official site the bundle publishes its app from, declared in the bundle manifest. */
+    val website get() = manifestAttributes?.website
+
     val isNameOutOfDate get() = manifestAttributes?.name?.let { it != name } == true
     val error get() = (state as? State.Failed)?.throwable
     val displayTitle get() = displayName?.takeUnless { it.isBlank() } ?: name

--- a/app/src/main/java/app/morphe/manager/domain/manager/DownloadUrlResolver.kt
+++ b/app/src/main/java/app/morphe/manager/domain/manager/DownloadUrlResolver.kt
@@ -23,38 +23,42 @@ import kotlin.time.Duration.Companion.seconds
 class DownloadUrlResolver(private val morpheAPI: MorpheAPI) {
 
     /**
-     * Resolves the download page for [packageName] at [version], falling back to a plain web
-     * search when the API cannot point anywhere useful.
+     * Resolves the download page for [packageName] at [version], falling back to the bundle's own
+     * website when it declared one, or to a plain web search otherwise, whenever the API cannot
+     * point anywhere useful.
+     *
+     * @param officialUrl The app's official site from the covering patch bundle, or null when the
+     *   bundle does not declare one.
      *
      * Every redirect along the way is followed: the API sometimes points at itself once more,
      * and the download sites redirect for reasons of their own, so only the end of the chain
      * says what the user will actually get.
      */
-    suspend fun resolve(packageName: String, version: String?): String =
+    suspend fun resolve(packageName: String, version: String?, officialUrl: String? = null): String =
         // The instructions wait on this, so a host that never answers has to end the wait itself
-        withTimeoutOrNull(RESOLVE_TIMEOUT) { follow(packageName, version) } ?: run {
+        withTimeoutOrNull(RESOLVE_TIMEOUT) { follow(packageName, version, officialUrl) } ?: run {
             Log.w(tag, "Timed out resolving the download page")
-            webSearchUrl(packageName, version)
+            fallback(packageName, version, officialUrl)
         }
 
-    private suspend fun follow(packageName: String, version: String?): String {
+    private suspend fun follow(packageName: String, version: String?, officialUrl: String?): String {
         val searchUrl = apiSearchUrl(packageName, version)
         Log.d(tag, "Using search url: $searchUrl")
 
         var resolved = morpheAPI.resolveRedirect(searchUrl) ?: run {
             Log.w(tag, "No redirect location for: $searchUrl")
-            return webSearchUrl(packageName, version)
+            return fallback(packageName, version, officialUrl)
         }
 
         repeat(MAX_REDIRECTS) {
             // A URL that redirects nowhere is the end of the chain
-            val next = morpheAPI.resolveRedirect(resolved) ?: return finalUrl(resolved, packageName, version)
+            val next = morpheAPI.resolveRedirect(resolved) ?: return finalUrl(resolved, packageName, version, officialUrl)
             Log.i(tag, "Following redirect to: $next")
             resolved = next
         }
 
         Log.w(tag, "Gave up after $MAX_REDIRECTS redirects")
-        return webSearchUrl(packageName, version)
+        return fallback(packageName, version, officialUrl)
     }
 
     /** The unfollowed API URL, standing in for the destination until [resolve] has one. */
@@ -76,18 +80,34 @@ class DownloadUrlResolver(private val morpheAPI: MorpheAPI) {
         return "https://google.com/search?q=${URLEncoder.encode(query, "UTF-8")}"
     }
 
-    /** Hands back [url], or a web search when it cannot lead to the version that was asked for. */
-    private fun finalUrl(url: String, packageName: String, version: String?): String {
+    /** Hands back [url], or the best fallback when it cannot lead to the version that was asked for. */
+    private fun finalUrl(
+        url: String,
+        packageName: String,
+        version: String?,
+        officialUrl: String?
+    ): String {
         // Uptodown answers a retired download id with its "latest version" page, which is not
         // the build the patches need. Only its per-build pages end in "-x"
         val uri = runCatching { URI(url) }.getOrNull() ?: return url
-        val onUptodown = uri.host?.lowercase()?.endsWith("uptodown.com") == true
+        val host = uri.host?.lowercase()
+        val onUptodown = host?.endsWith("uptodown.com") == true
         if (onUptodown && !uri.path.orEmpty().trimEnd('/').endsWith("-x")) {
             Log.w(tag, "Uptodown link lost its build, searching instead: $url")
-            return webSearchUrl(packageName, version)
+            return fallback(packageName, version, officialUrl)
+        }
+        // The API points at a plain search page when it knows nothing of the app. A bundle that
+        // declared its own site beats that, so the user lands on the one place that really has it
+        if (host?.endsWith("google.com") == true) {
+            Log.i(tag, "Resolution ended in a search page, preferring the bundle's website: $url")
+            return fallback(packageName, version, officialUrl)
         }
         return url
     }
+
+    /** The bundle's own site when one was declared, or a plain web search query at the mirrors. */
+    private fun fallback(packageName: String, version: String?, officialUrl: String?): String =
+        officialUrl ?: webSearchUrl(packageName, version)
 
     private companion object {
         // Enough for the API pointing at itself and a site or two moving the page, while still

--- a/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
+++ b/app/src/main/java/app/morphe/manager/domain/repository/PatchBundleRepository.kt
@@ -78,6 +78,16 @@ class PatchBundleRepository(
     val allBundlesInfoFlow = store.state.map { (it as? BundleState.Ready)?.info ?: persistentMapOf() }
 
     /**
+     * Official site declared by the first bundle in [uids] that declares one, in the order given.
+     * Null when none of the sources are loaded yet or no bundle declares a website, in which case
+     * the caller keeps its usual web-search fallback.
+     */
+    suspend fun websiteFor(uids: Collection<Int>): String? {
+        val byUid = sources.first().associateBy { it.uid }
+        return uids.asSequence().mapNotNull { byUid[it]?.website }.firstOrNull()
+    }
+
+    /**
      * Sources that appear on the remote blocklist, keyed by source uid.
      * Combines the current source list with [BlocklistRepository.entries] so the map stays in
      * sync as either side changes. Blocked sources are removed from [enabledBundlesInfoFlow] and

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/BatchPatcherViewModel.kt
@@ -310,6 +310,11 @@ class BatchPatcherViewModel : ViewModel(), KoinComponent, ApkDownloadHelperHost 
         val version: String?,
         val url: String,
         /**
+         * Official site declared by one of the covering bundles, used instead of a plain search
+         * when the API knows nothing of the app. Null when no bundle declares one.
+         */
+        val officialUrl: String? = null,
+        /**
          * Versions the sources cover, carried so a download helper can be told what else is
          * acceptable when the requested version is no longer offered anywhere.
          */
@@ -331,10 +336,14 @@ class BatchPatcherViewModel : ViewModel(), KoinComponent, ApkDownloadHelperHost 
             compatible = compatible
         )
         viewModelScope.launch {
-            val resolved = withContext(Dispatchers.IO) {
-                downloadUrlResolver.resolve(item.packageName, version)
+            val officialUrl = withContext(Dispatchers.IO) {
+                patchBundleRepository.websiteFor(item.bundles.map { it.uid })
             }
-            apkSearch = apkSearch?.takeIf { it.item.packageName == item.packageName }?.copy(url = resolved)
+            val resolved = withContext(Dispatchers.IO) {
+                downloadUrlResolver.resolve(item.packageName, version, officialUrl)
+            }
+            apkSearch = apkSearch?.takeIf { it.item.packageName == item.packageName }
+                ?.copy(url = resolved, officialUrl = officialUrl)
         }
     }
 
@@ -408,7 +417,8 @@ class BatchPatcherViewModel : ViewModel(), KoinComponent, ApkDownloadHelperHost 
             allowSplitArchive = !(apkFileType?.isApk == true && apkFileType.isRequired),
             stockInstallRequired = state.value?.useMount == true &&
                     search.item.source !is BatchApkSource.Installed,
-            fallbackWebUrl = downloadUrlResolver.webSearchUrl(packageName, search.version)
+            fallbackWebUrl = search.officialUrl
+                ?: downloadUrlResolver.webSearchUrl(packageName, search.version)
         )
     }
 

--- a/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/app/morphe/manager/ui/viewmodel/HomeViewModel.kt
@@ -355,6 +355,9 @@ class HomeViewModel(
     var pendingSelectedDownloadVersion by mutableStateOf<AppTarget?>(null)
     var pendingSelectedApp by mutableStateOf<SelectedApp?>(null)
     var resolvedDownloadUrl by mutableStateOf<String?>(null)
+    // Official site of the pending app, from the carried bundle. Surfaces instead of a plain
+    // web search when the API does not know of a download page for the app
+    var pendingWebsiteUrl by mutableStateOf<String?>(null)
     var pendingSavedApkInfo by mutableStateOf<SavedApkInfo?>(null)
     var pendingInstalledApkInfo by mutableStateOf<InstalledApkInfo?>(null)
     // null = not yet loaded, true/false = loaded result
@@ -1701,6 +1704,20 @@ class HomeViewModel(
                     if (patches.isNotEmpty()) put(uid, patches)
                 }
         }
+    }
+
+    /**
+     * Official site the bundle(s) covering [packageName] declare, or null when none does.
+     * With several covering bundles the one the user picked previously is tried first.
+     */
+    private suspend fun websiteUrlFor(packageName: String): String? {
+        val coveringUids = getPatchesForPackage(packageName).keys
+        if (coveringUids.isEmpty()) return null
+        val ordered = pendingSelectedBundleUid
+            ?.takeIf { it in coveringUids }
+            ?.let { listOf(it) + (coveringUids - it) }
+            ?: coveringUids
+        return patchBundleRepository.websiteFor(ordered)
     }
 
     /**
@@ -3225,8 +3242,10 @@ class HomeViewModel(
         resolvedDownloadUrl = downloadUrlResolver.apiSearchUrl(packageName, version)
 
         viewModelScope.launch {
+            val officialUrl = withContext(Dispatchers.IO) { websiteUrlFor(packageName) }
+            pendingWebsiteUrl = officialUrl
             val resolved = withContext(Dispatchers.IO) {
-                downloadUrlResolver.resolve(packageName, version)
+                downloadUrlResolver.resolve(packageName, version, officialUrl)
             }
             resolvedDownloadUrl = resolved
         }
@@ -3273,7 +3292,8 @@ class HomeViewModel(
             // Mirrors processSelectedApp - only a required plain APK rules split archives out
             allowSplitArchive = !(apkFileType?.isApk == true && apkFileType.isRequired),
             stockInstallRequired = usingMountInstall && pendingTargetAppInstalled != true,
-            fallbackWebUrl = downloadUrlResolver.webSearchUrl(packageName, requestedVersion?.version)
+            fallbackWebUrl = pendingWebsiteUrl
+                ?: downloadUrlResolver.webSearchUrl(packageName, requestedVersion?.version)
         )
     }
 
@@ -3321,6 +3341,7 @@ class HomeViewModel(
         pendingSelectedDownloadVersion = null
         if (!keepBundleUid) pendingSelectedBundleUid = null
         resolvedDownloadUrl = null
+        pendingWebsiteUrl = null
         pendingSavedApkInfo = null
         pendingInstalledApkInfo = null
         pendingTargetAppInstalled = null


### PR DESCRIPTION
## Problem

The API answers a download search with a redirect chain, and apps it knows nothing about (for example Anime Witcher) dead-end on a plain Google search page. The download instructions dialog then tells the user to search the web instead of pointing at anywhere useful.

Patch bundles can already declare their own official site via the \Website\ manifest attribute, but nothing reads it.

## Change

When the redirect chain cannot land on a download page, fall back to the bundle's officially declared website before giving up to a web search.

- \PatchBundleSource\: expose \website\ from the bundle manifest attributes
- \PatchBundleRepository.websiteFor(uids)\: site of the first covering bundle that declares one, in preference order
- \DownloadUrlResolver.resolve(packageName, version, officialUrl)\: prefer the official site in every dead-end path (timeout, no redirect location, gave up on the redirect loop, a plain \google.com\ search page, and a Uptodown link that lost its build)
- \HomeViewModel\ / \BatchPatcherViewModel\: look up the covering bundle's website per pending app and pass it through, also using it as the download-helper \allbackWebUrl\

For apps whose bundle declares no website the behavior is unchanged (the site-restricted web search is still the fallback).

Verified with \:app:compileDebugKotlin\.